### PR TITLE
Added script to setup an ssh key for git

### DIFF
--- a/engineering_tools/ssh_key_gen.bash
+++ b/engineering_tools/ssh_key_gen.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2020 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# Script generates an SSH Key using the provided email.
+
+ssh-keygen -t rsa -b 4096 -C "$1"
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_rsa
+sudo apt-get install xclip
+xclip -sel clip < ~/.ssh/id_rsa.pub
+gnome-terminal & firefox https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account

--- a/engineering_tools/ssh_key_gen.bash
+++ b/engineering_tools/ssh_key_gen.bash
@@ -16,6 +16,11 @@
 
 # Script generates an SSH Key using the provided email.
 
+if [ -z "$1" ]; then
+    echo "An email address must be provided."
+    exit -1
+fi
+
 ssh-keygen -t rsa -b 4096 -C "$1"
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_rsa


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds a script ssh_key_gen.bash that will help the user setup an ssh key. It will prompt the user for a passphrase then open a browser with instructions for setting the key on github. 

This is meant to make user setup documentation a bit easier to write. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
