### PR TITLE
Fix health_monitor cannot read correct args

### DIFF
--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -127,8 +127,8 @@
   <!-- Guidance Stack -->
   <group ns="$(env CARMA_GUIDE_NS)">
     <!-- Health Monitor -->
-
-    <include file="$(find health_monitor)/launch/health_monitor.launch" />
+    
+    <include file="$(find health_monitor)/launch/health_monitor.launch"/>
     
     <include file="$(find carma)/launch/guidance.launch">
       <arg name="route_file_folder" value="$(arg route_file_folder)"/>

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -128,11 +128,8 @@
   <group ns="$(env CARMA_GUIDE_NS)">
     <!-- Health Monitor -->
 
-    <include file="$(find health_monitor)/launch/health_monitor.launch">
-      <remap from="system_alert" to="/system_alert"/>
-      <remap from="~required_drivers" to="/required_drivers"/>
-      <remap from="~lidar_gps_drivers" to="/lidar_gps_drivers"/>
-    </include>
+    <include file="$(find health_monitor)/launch/health_monitor.launch" />
+    
     <include file="$(find carma)/launch/guidance.launch">
       <arg name="route_file_folder" value="$(arg route_file_folder)"/>
     </include>

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -128,11 +128,11 @@
   <group ns="$(env CARMA_GUIDE_NS)">
     <!-- Health Monitor -->
 
-    <node pkg="health_monitor" type="health_monitor" name="health_monitor" required="true">
+    <include file="$(find health_monitor)/launch/health_monitor.launch">
       <remap from="system_alert" to="/system_alert"/>
       <remap from="~required_drivers" to="/required_drivers"/>
-      <rosparam command="load" file="$(find health_monitor)/config/params.yaml"/>
-    </node>
+      <remap from="~lidar_gps_drivers" to="/lidar_gps_drivers"/>
+    </include>
     <include file="$(find carma)/launch/guidance.launch">
       <arg name="route_file_folder" value="$(arg route_file_folder)"/>
     </include>

--- a/health_monitor/config/params.yaml
+++ b/health_monitor/config/params.yaml
@@ -38,3 +38,10 @@ strategic_plugin_service_suffix: /plan_maneuvers
 tactical_plugin_service_suffix: /plan_trajectory
 
 car: true # to bypass the fact that health_monitor cannot read parameters from VehicelConfigParam.yaml loaded file through carma_src.launch
+
+# Required drivers for the vehicle to be functional
+required_drivers:
+  - /hardware_interface/mock_controller
+lidar_gps_drivers:
+  - /hardware_interface/mock_lidar
+  - /hardware_interface/mock_gnss

--- a/health_monitor/config/params.yaml
+++ b/health_monitor/config/params.yaml
@@ -18,7 +18,7 @@ spin_rate_hz: 10.0
 
 # Double: The timeout threshold for essential drivers
 # Units: ms
-required_driver_timeout: 1500.0
+required_driver_timeout: 50000.0
 
 # Double: The time allocated for system startup
 # Units: s
@@ -36,12 +36,3 @@ strategic_plugin_service_suffix: /plan_maneuvers
 
 # String: Tactical plugin service suffix
 tactical_plugin_service_suffix: /plan_trajectory
-
-car: true # to bypass the fact that health_monitor cannot read parameters from VehicelConfigParam.yaml loaded file through carma_src.launch
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/mock_controller
-lidar_gps_drivers:
-  - /hardware_interface/mock_lidar
-  - /hardware_interface/mock_gnss

--- a/health_monitor/config/params.yaml
+++ b/health_monitor/config/params.yaml
@@ -36,3 +36,5 @@ strategic_plugin_service_suffix: /plan_maneuvers
 
 # String: Tactical plugin service suffix
 tactical_plugin_service_suffix: /plan_trajectory
+
+car: true # to bypass the fact that health_monitor cannot read parameters from VehicelConfigParam.yaml loaded file through carma_src.launch

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -32,7 +32,7 @@ Loads parameters and configures logging for the node
     <remap from="~car" to="/car"/> 
     
     <!-- Health Monitor Node -->
-    <node pkg="health_monitor" type="health_monitor" name="health_monitor" output="screen" required="true">
+    <node pkg="health_monitor" type="health_monitor" name="health_monitor" required="true">
         <rosparam command="load" file="$(find health_monitor)/config/params.yaml" />
     </node>
 </launch>

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -21,8 +21,11 @@ Loads parameters and configures logging for the node
  -->
 <launch>
     <!-- Health Monitor Node -->
-    <node pkg="health_monitor" type="health_monitor" name="health_monitor">
+    <node pkg="health_monitor" type="health_monitor" name="health_monitor" output="screen">
         <rosparam command="load" file="$(find health_monitor)/config/params.yaml" />
         <remap from="driver_discovery" to="/hardware_interface/driver_discovery"/>
+        <remap from="system_alert" to="/system_alert"/>
+        <remap from="~required_drivers" to="/required_drivers"/>
+        <remap from="~lidar_gps_drivers" to="/lidar_gps_drivers"/>
     </node>
 </launch>

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -18,8 +18,6 @@
 <!-- 
 Primary launch file for health monitor node
 Loads parameters and configures logging for the node
-EYYYYYYYY
-    My name is Misheel
  -->
 <launch>
 

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -18,14 +18,23 @@
 <!-- 
 Primary launch file for health monitor node
 Loads parameters and configures logging for the node
+EYYYYYYYY
+    My name is Misheel
  -->
 <launch>
+
+    <!-- Handle global parameters for topics -->
+    <remap from="driver_discovery" to="$(optenv CARMA_INTR_NS)/driver_discovery"/>
+    <remap from="system_alert" to="/system_alert"/>
+
+    <!-- Handle global parameters for variables-->
+    <remap from="~required_drivers" to="/required_drivers"/> 
+    <remap from="~lidar_gps_drivers" to="/lidar_gps_drivers"/>
+    <remap from="~truck" to="/truck"/>
+    <remap from="~car" to="/car"/> 
+    
     <!-- Health Monitor Node -->
     <node pkg="health_monitor" type="health_monitor" name="health_monitor" output="screen" required="true">
         <rosparam command="load" file="$(find health_monitor)/config/params.yaml" />
-        <remap from="driver_discovery" to="/hardware_interface/driver_discovery"/>
-        <remap from="system_alert" to="/system_alert"/>
-        <remap from="~required_drivers" to="/required_drivers"/>
-        <remap from="~lidar_gps_drivers" to="/lidar_gps_drivers"/>
     </node>
 </launch>

--- a/health_monitor/launch/health_monitor.launch
+++ b/health_monitor/launch/health_monitor.launch
@@ -21,7 +21,7 @@ Loads parameters and configures logging for the node
  -->
 <launch>
     <!-- Health Monitor Node -->
-    <node pkg="health_monitor" type="health_monitor" name="health_monitor" output="screen">
+    <node pkg="health_monitor" type="health_monitor" name="health_monitor" output="screen" required="true">
         <rosparam command="load" file="$(find health_monitor)/config/params.yaml" />
         <remap from="driver_discovery" to="/hardware_interface/driver_discovery"/>
         <remap from="system_alert" to="/system_alert"/>

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -27,8 +27,8 @@ namespace health_monitor
     void DriverManager::update_driver_status(const cav_msgs::DriverStatusConstPtr& msg, long current_time)
     {
         // Params: bool available, bool active, std::string name, long timestamp, uint8_t type
-        ROS_WARN_STREAM("=======================ROS Msg name received: " << msg->name << ": End=========================\n");
-        ROS_WARN_STREAM("=======================ROS Msg status received: " << msg->status << ": End=========================\n");
+        //ROS_WARN_STREAM("=======================ROS Msg name received: " << msg->name << ": End=========================\n");
+        //ROS_WARN_STREAM("=======================ROS Msg status received: " << msg->status << ": End=========================\n");
         Entry driver_status(msg->status == cav_msgs::DriverStatus::OPERATIONAL || msg->status == cav_msgs::DriverStatus::DEGRADED,true, msg->name, current_time, 0, "");
         em_.update_entry(driver_status);
     }

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -170,7 +170,7 @@ namespace health_monitor
         {
             if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_1_g_1")
             {
-                alert.description = "All enssential drivers are ready";
+                alert.description = "All essential drivers are ready";
                 alert.type = cav_msgs::SystemAlert::DRIVERS_READY;
                 return alert;
             } 

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "driver_manager.h"
-#include <ros/ros.h>
+
 namespace health_monitor
 {
 

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -73,44 +73,47 @@ namespace health_monitor
             }
         }
 
-       //Decision making 
-        if(ssc==0)
+        //Decision making 
+        if (ssc == 1)
+        {
+            if((lidar1==0) && (lidar2==0) && (gps==0))
+            {
+                return "s_1_l1_0_l2_0_g_0";
+            }
+            else if((lidar1==0) && (lidar2==0) && (gps==1))
+            {
+                return "s_1_l1_0_l2_0_g_1";
+            }
+            else if((lidar1==0) && (lidar2==1) && (gps==0))
+            {
+                return "s_1_l1_0_l2_1_g_0";
+            }
+            else if((lidar1==0) && (lidar2==1) && (gps==1))
+            {
+                return "s_1_l1_0_l2_1_g_1";
+            }
+            else if((lidar1==1) && (lidar2==0) && (gps==0))
+            {
+                return "s_1_l1_1_l2_0_g_0";
+            }
+            else if((lidar1==1) && (lidar2==0) && (gps==1))
+            {
+                return "s_1_l1_1_l2_0_g_1";
+            }
+            else if((lidar1==1) && (lidar2==1) && (gps==0))
+            {
+                return "s_1_l1_1_l2_1_g_0";
+            }
+            else if((lidar1==1) && (lidar2==1) && (gps==1))
+            {
+                return "s_1_l1_1_l2_1_g_1";
+            }
+        }
+        else 
         {
             return "s_0";
         }
-        // if ssc = 1
-        if((lidar1==0) && (lidar2==0) && (gps==0))
-        {
-            return "s_1_l1_0_l2_0_g_0";
-        }
-        else if((lidar1==0) && (lidar2==0) && (gps==1))
-        {
-            return "s_1_l1_0_l2_0_g_1";
-        }
-        else if((lidar1==0) && (lidar2==1) && (gps==0))
-        {
-            return "s_1_l1_0_l2_1_g_0";
-        }
-        else if((lidar1==0) && (lidar2==1) && (gps==1))
-        {
-            return "s_1_l1_0_l2_1_g_1";
-        }
-        else if((lidar1==1) && (lidar2==0) && (gps==0))
-        {
-            return "s_1_l1_1_l2_0_g_0";
-        }
-        else if((lidar1==1) && (lidar2==0) && (gps==1))
-        {
-            return "s_1_l1_1_l2_0_g_1";
-        }
-        else if((lidar1==1) && (lidar2==1) && (gps==0))
-        {
-            return "s_1_l1_1_l2_1_g_0";
-        }
-        else if((lidar1==1) && (lidar2==1) && (gps==1))
-        {
-            return "s_1_l1_1_l2_1_g_1";
-        }
+       
     }
 
 
@@ -126,7 +129,6 @@ namespace health_monitor
             {
                 evaluate_sensor(ssc,i->available_,current_time,i->timestamp_,driver_timeout_);
             }
-
             if(em_.is_lidar_gps_entry_required(i->name_)==0) //Lidar
             {
                 evaluate_sensor(lidar,i->available_,current_time,i->timestamp_,driver_timeout_);

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -26,23 +26,22 @@ namespace health_monitor
 
     void DriverManager::update_driver_status(const cav_msgs::DriverStatusConstPtr& msg, long current_time)
     {
-        // Params: bool available, bool active, std::string name, long timestamp, uint8_t type
-        //ROS_WARN_STREAM("=======================ROS Msg name received: " << msg->name << ": End=========================\n");
-        //ROS_WARN_STREAM("=======================ROS Msg status received: " << msg->status << ": End=========================\n");
         Entry driver_status(msg->status == cav_msgs::DriverStatus::OPERATIONAL || msg->status == cav_msgs::DriverStatus::DEGRADED,true, msg->name, current_time, 0, "");
         em_.update_entry(driver_status);
     }
 
     void DriverManager::evaluate_sensor(int &sensor_input,bool available,long current_time,long timestamp,long driver_timeout)
     {
+        
         if((!available) || (current_time-timestamp > driver_timeout))
-           {
+        {
             sensor_input=0;
-           }
-           else
-           {
+
+        }
+        else
+        {
             sensor_input=1;
-           }
+        }
     }
 
     std::string DriverManager::are_critical_drivers_operational_truck(long current_time)
@@ -74,46 +73,43 @@ namespace health_monitor
         }
 
         //Decision making 
-        if (ssc == 1)
-        {
-            if((lidar1==0) && (lidar2==0) && (gps==0))
-            {
-                return "s_1_l1_0_l2_0_g_0";
-            }
-            else if((lidar1==0) && (lidar2==0) && (gps==1))
-            {
-                return "s_1_l1_0_l2_0_g_1";
-            }
-            else if((lidar1==0) && (lidar2==1) && (gps==0))
-            {
-                return "s_1_l1_0_l2_1_g_0";
-            }
-            else if((lidar1==0) && (lidar2==1) && (gps==1))
-            {
-                return "s_1_l1_0_l2_1_g_1";
-            }
-            else if((lidar1==1) && (lidar2==0) && (gps==0))
-            {
-                return "s_1_l1_1_l2_0_g_0";
-            }
-            else if((lidar1==1) && (lidar2==0) && (gps==1))
-            {
-                return "s_1_l1_1_l2_0_g_1";
-            }
-            else if((lidar1==1) && (lidar2==1) && (gps==0))
-            {
-                return "s_1_l1_1_l2_1_g_0";
-            }
-            else if((lidar1==1) && (lidar2==1) && (gps==1))
-            {
-                return "s_1_l1_1_l2_1_g_1";
-            }
-        }
-        else 
+        if (ssc == 0)
         {
             return "s_0";
         }
-       
+        // if ssc= 1
+        if((lidar1==0) && (lidar2==0) && (gps==0))
+        {
+            return "s_1_l1_0_l2_0_g_0";
+        }
+        else if((lidar1==0) && (lidar2==0) && (gps==1))
+        {
+            return "s_1_l1_0_l2_0_g_1";
+        }
+        else if((lidar1==0) && (lidar2==1) && (gps==0))
+        {
+            return "s_1_l1_0_l2_1_g_0";
+        }
+        else if((lidar1==0) && (lidar2==1) && (gps==1))
+        {
+            return "s_1_l1_0_l2_1_g_1";
+        }
+        else if((lidar1==1) && (lidar2==0) && (gps==0))
+        {
+            return "s_1_l1_1_l2_0_g_0";
+        }
+        else if((lidar1==1) && (lidar2==0) && (gps==1))
+        {
+            return "s_1_l1_1_l2_0_g_1";
+        }
+        else if((lidar1==1) && (lidar2==1) && (gps==0))
+        {
+            return "s_1_l1_1_l2_1_g_0";
+        }
+        else if((lidar1==1) && (lidar2==1) && (gps==1))
+        {
+            return "s_1_l1_1_l2_1_g_1";
+        }
     }
 
 
@@ -140,7 +136,6 @@ namespace health_monitor
         }
 
         //Decision making 
-
         if(ssc==1)
         {
             if((lidar==0) && (gps==0))
@@ -171,7 +166,7 @@ namespace health_monitor
     {
          cav_msgs::SystemAlert alert;
 
-         if(truck==true)
+        if(truck==true)
         {
             if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_1_g_1")
             {

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "driver_manager.h"
-
+#include <ros/ros.h>
 namespace health_monitor
 {
 
@@ -27,6 +27,8 @@ namespace health_monitor
     void DriverManager::update_driver_status(const cav_msgs::DriverStatusConstPtr& msg, long current_time)
     {
         // Params: bool available, bool active, std::string name, long timestamp, uint8_t type
+        ROS_WARN_STREAM("=======================ROS Msg name received: " << msg->name << ": End=========================\n");
+        ROS_WARN_STREAM("=======================ROS Msg status received: " << msg->status << ": End=========================\n");
         Entry driver_status(msg->status == cav_msgs::DriverStatus::OPERATIONAL || msg->status == cav_msgs::DriverStatus::DEGRADED,true, msg->name, current_time, 0, "");
         em_.update_entry(driver_status);
     }

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -31,7 +31,6 @@ namespace health_monitor
     {
         for(auto i = entry_list_.begin(); i < entry_list_.end(); ++i)
         {
-            //ROS_WARN_STREAM("Entry name received: " << entry.name_ << ": End\n");
             if(i->name_.compare(entry.name_) == 0)
             {
                 // name and type of the entry wont change
@@ -43,6 +42,7 @@ namespace health_monitor
         }
         entry_list_.push_back(entry);
     }
+
 
     std::vector<Entry> EntryManager::get_entries() const
     {
@@ -79,8 +79,6 @@ namespace health_monitor
     {
         for(auto i = required_entries_.begin(); i < required_entries_.end(); ++i)
         {
-            ROS_WARN_STREAM("Entry name received: " << name << ": End\n");
-            ROS_WARN_STREAM("Entry name existing: " << *i << ": End\n");
             if(i->compare(name) == 0)
             {
                 return true;

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -16,7 +16,6 @@
 
 #include "entry_manager.h"
 #include <iostream>
-#include <ros/ros.h>
 
 namespace health_monitor
 {

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -16,6 +16,7 @@
 
 #include "entry_manager.h"
 #include <iostream>
+#include <ros/ros.h>
 
 namespace health_monitor
 {
@@ -30,6 +31,7 @@ namespace health_monitor
     {
         for(auto i = entry_list_.begin(); i < entry_list_.end(); ++i)
         {
+            ROS_WARN_STREAM("Entry name received: " << entry.name_ << ": End\n");
             if(i->name_.compare(entry.name_) == 0)
             {
                 // name and type of the entry wont change

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -31,7 +31,7 @@ namespace health_monitor
     {
         for(auto i = entry_list_.begin(); i < entry_list_.end(); ++i)
         {
-            ROS_WARN_STREAM("Entry name received: " << entry.name_ << ": End\n");
+            //ROS_WARN_STREAM("Entry name received: " << entry.name_ << ": End\n");
             if(i->name_.compare(entry.name_) == 0)
             {
                 // name and type of the entry wont change
@@ -79,6 +79,8 @@ namespace health_monitor
     {
         for(auto i = required_entries_.begin(); i < required_entries_.end(); ++i)
         {
+            ROS_WARN_STREAM("Entry name received: " << name << ": End\n");
+            ROS_WARN_STREAM("Entry name existing: " << *i << ": End\n");
             if(i->compare(name) == 0)
             {
                 return true;

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -42,13 +42,15 @@ namespace health_monitor
         plugin_service_prefix_ = pnh_.param<std::string>("plugin_service_prefix", "");
         strategic_plugin_service_suffix_ = pnh_.param<std::string>("strategic_plugin_service_suffix", "");
         tactical_plugin_service_suffix_ = pnh_.param<std::string>("tactical_plugin_service_suffix", "");
+        
         pnh_.getParam("required_plugins", required_plugins_);
         pnh_.getParam("required_drivers", required_drivers_);
         pnh_.getParam("lidar_gps_drivers", lidar_gps_drivers_); 
+
         truck_=false;
         car_=false;
-        pnh_.getParam("truck", truck_);
         pnh_.getParam("car", car_);
+        pnh_.getParam("truck", truck_); 
 
         // initialize worker class
         plugin_manager_ = PluginManager(required_plugins_, plugin_service_prefix_, strategic_plugin_service_suffix_, tactical_plugin_service_suffix_);
@@ -57,6 +59,7 @@ namespace health_monitor
         // record starup time
         start_up_timestamp_ = ros::Time::now().toNSec() / 1e6;
         start_time_flag_=ros::Time::now();
+        
     }
     
     void HealthMonitor::run()

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -49,8 +49,9 @@ namespace health_monitor
 
         truck_=false;
         car_=false;
+        pnh_.getParam("truck", truck_);
         pnh_.getParam("car", car_);
-        pnh_.getParam("truck", truck_); 
+         
 
         // initialize worker class
         plugin_manager_ = PluginManager(required_plugins_, plugin_service_prefix_, strategic_plugin_service_suffix_, tactical_plugin_service_suffix_);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR is to fix health_monitor publishing incorrect state to `/system_alert` due to the bug in `carma_src.launch` and `health_monitor.launch` files. The node was directly invoked from the `carma_src.launch` file, bypassing its own health_monitor.launch file, and needed remapping of its 4 global parameters loaded from `carma-config/<vehicle-type>/VehicleConfigParams.yaml`. 

Furthermore, upon this fix, driver_timeout_ value is found to be too short that carma was incorrectly detecting operational drivers to be faulty. System alert was frequently changing from one state to another (operational, fatal, degraded etc). Therefore, its value is increase to 50000 ms as of now. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/668

## Motivation and Context

This was a fix to recently added changes to health_monitor to handle sensor loss variations. The car and truck has different sets of sensors, so different expectations of operational drivers were set in health_monitor. However, due to the bug, it wasn't detecting either car or truck.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- All unit tests still pass for health_monitor
- Locally integration tested by checking correct topic mappings (with correct type of msg associated) for health_monitor node: `/system_alert`  `/hardware_interface/driver_discovery` `/guidance/plugin_discovery`
- `/system_alert` says `all essential drivers are ready` consistently. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
