### PR TITLE
Update carma exec command to use more robust command resoltion

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -270,7 +270,7 @@ carma__exec() {
         shift
 
     # If the image was not specified use what was in the carma config
-    elif [ docker container inspect carma-config > /dev/null 2>&1 ]; then
+    elif docker container inspect carma-config > /dev/null 2>&1; then
 
         local IMAGE_BACKUP=$TARGET_IMAGE
         local SUPPORTED_ORANIZATIONS="usdotfhwastol\|usdotfhwastoldev"
@@ -279,13 +279,15 @@ carma__exec() {
         # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
         # then returns the name of the image.  
         local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-            "sed -n -e '/image:\s*\($SUPPORTED_ORANIZATIONS\)\/\($SUPPORTED_IMAGES\)/ s/.*\image: *//p' docker-compose.yml | grep -m 1 '.*'")
+            "sed -n -e '/image:\s*\($SUPPORTED_ORANIZATIONS\)\/\($SUPPORTED_IMAGES\)/ s/.*\image: *//p' /opt/carma/vehicle/config/docker-compose.yml | grep -m 1 '.*'")
             
 
         # If the sed resulted in an empty string then reset the tag
         if [ -z "$TARGET_IMAGE" ]; then
             local TARGET_IMAGE=$IMAGE_BACKUP
         fi
+    else
+        echo "No config detected or target image specified so using default: $TARGET_IMAGE"
     
     fi
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -254,7 +254,6 @@ carma-config__status() {
 
 carma__exec() {
     local TARGET_IMAGE="usdotfhwastol/carma-platform:latest"
-    local COMMAND="bash"
 
     # Check if the -i argument was provided
     # If the image was specified then use that
@@ -297,11 +296,6 @@ carma__exec() {
         exit -1
     fi
 
-    # If a command was specified then assign it
-    if [ -n "$1" ]; then
-        local COMMAND="$@"
-    fi
-
     # Docker setup here is based on Pierre Killy's docker-ros-box https://github.com/pierrekilly/docker-ros-box located here.
     # Docker ROS Box is licensed under the MIT licesne a copy of which can be found in the carma-platform repository here https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/docs/License.md
 
@@ -312,15 +306,36 @@ carma__exec() {
 
     echo "Trying to open shell inside image: $TARGET_IMAGE"
 
-    docker run \
-        -e DISPLAY=$DISPLAY \
-        --group-add video \
-        --volume=$XSOCK:$XSOCK:rw \
-        --volume=$XAUTH:$XAUTH:rw \
-        --env="XAUTHORITY=${XAUTH}" \
-        --device=/dev/dri:/dev/dri \
-        --network=host \
-        -it $TARGET_IMAGE "$COMMAND"
+    # If a command was specified then assign it otherwise use bash
+    local entrypoint="/bin/bash"
+    local INIT_FILE="/home/carma/.base-image/init-env.sh"
+
+    if [ -n "$1" ]; then
+
+        local COMMAND="source $INIT_FILE && ${@}"
+
+        docker run \
+            -e DISPLAY=$DISPLAY \
+            --group-add video \
+            --volume=$XSOCK:$XSOCK:rw \
+            --volume=$XAUTH:$XAUTH:rw \
+            --env="XAUTHORITY=${XAUTH}" \
+            --device=/dev/dri:/dev/dri \
+            --network=host \
+            --entrypoint="$entrypoint" \
+            -it $TARGET_IMAGE -c "$COMMAND"
+    else
+        docker run \
+            -e DISPLAY=$DISPLAY \
+            --group-add video \
+            --volume=$XSOCK:$XSOCK:rw \
+            --volume=$XAUTH:$XAUTH:rw \
+            --env="XAUTHORITY=${XAUTH}" \
+            --device=/dev/dri:/dev/dri \
+            --network=host \
+            --entrypoint="$entrypoint" \
+            -it $TARGET_IMAGE --init-file "$INIT_FILE"
+    fi
 }
 
 carma__help() {

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -321,6 +321,12 @@ carma__exec() {
             --group-add video \
             --volume=$XSOCK:$XSOCK:rw \
             --volume=$XAUTH:$XAUTH:rw \
+            --volume=/opt/carma/logs:/opt/carma/logs \
+            --volume=/opt/carma/.ros:/opt/carma/.ros \
+            --volume=/opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration \
+            --volume=/opt/carma/yolo:/opt/carma/yolo \
+            --volume=/opt/carma/maps:/opt/carma/maps \
+            --volume=/opt/carma/routes:/opt/carma/routes \
             --env="XAUTHORITY=${XAUTH}" \
             --device=/dev/dri:/dev/dri \
             --network=host \
@@ -332,6 +338,12 @@ carma__exec() {
             --group-add video \
             --volume=$XSOCK:$XSOCK:rw \
             --volume=$XAUTH:$XAUTH:rw \
+            --volume=/opt/carma/logs:/opt/carma/logs \
+            --volume=/opt/carma/.ros:/opt/carma/.ros \
+            --volume=/opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration \
+            --volume=/opt/carma/yolo:/opt/carma/yolo \
+            --volume=/opt/carma/maps:/opt/carma/maps \
+            --volume=/opt/carma/routes:/opt/carma/routes \
             --env="XAUTHORITY=${XAUTH}" \
             --device=/dev/dri:/dev/dri \
             --network=host \


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This change improves the robustness of the carma exec command by using a custom entrypoint and separating the behavior of the version with and without user input. 
## Related Issue
support #658 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Allow a larger variety of commands to be run 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with the following commands
```
carma exec rviz
carma exec
carma roscd cav_msgs && ls
carma exec -i usdotfhwastoldev/carma-platform:develop ls /usr/bin
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
