### PR TITLE
gps_failure

### DIFF
--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -190,6 +190,12 @@ namespace health_monitor
                 alert.description = "One Lidar and GPS Failed";
                 alert.type = cav_msgs::SystemAlert::CAUTION;
                 return alert;
+            } 
+            else if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_1_g_0")
+            {
+                alert.description = "GPS Failed";
+                alert.type = cav_msgs::SystemAlert::CAUTION;
+                return alert;
             }
             else if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_0_l2_0_g_1")
             {

--- a/health_monitor/test/test_driver_manager.cpp
+++ b/health_monitor/test/test_driver_manager.cpp
@@ -611,6 +611,7 @@ namespace health_monitor
         EXPECT_EQ("s_0", dm.are_critical_drivers_operational_truck(1500));
     }
 
+
     TEST(DriverManagerTest, testTruckSsc_1_Lidar1_0_Lidar2_0_Gps_0)
     {
         std::vector<std::string> required_drivers{"controller"};
@@ -992,6 +993,50 @@ namespace health_monitor
         msg4.gnss = true;
         msg4.name = "gps";
         msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinCautionLidar1WorkingGpsNotWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
         cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
         dm.update_driver_status(msg4_pointer, 1000);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The Health monitor in develop is missing the logic or not evaluating the "s_1_l1_1_l2_1_g_0" which denotes GPS failure only.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/675
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
