### PR TITLE
CAR-2350: update guidance state topic, add system_alert topic, and ads_health_s…

### DIFF
--- a/truck_inspection_client/config/parameters.yaml
+++ b/truck_inspection_client/config/parameters.yaml
@@ -4,6 +4,9 @@ vin_number: 1FUJGHDV0CLBP8896
 # License plate number - 9 alphanumeric char
 license_plate: DOT-10003
 
+# State short name - 2 alphabet char
+state_short_name: VA
+
 # Carrier Name - 25 alphanumeric char
 carrier_name: FMCSA Tech Division
 

--- a/truck_inspection_client/include/truck_inspection_client.h
+++ b/truck_inspection_client/include/truck_inspection_client.h
@@ -49,6 +49,7 @@ namespace truck_inspection_client
         // subscriber for Mobility Request messages
         ros::Subscriber request_sub_;
         ros::Subscriber ads_state_sub_;
+        ros::Subscriber ads_system_alert_sub_;
         ros::Subscriber version_sub_;
         ros::Subscriber bsm_sub_;
 
@@ -58,12 +59,14 @@ namespace truck_inspection_client
         // callbacks for the subscriber
         void requestCallback(const cav_msgs::MobilityRequestConstPtr& msg);
         void guidanceStatesCallback(const cav_msgs::GuidanceStateConstPtr& msg);
+        void systemAlertsCallback(const cav_msgs::SystemAlertConstPtr& msg);
         void versionCallback(const std_msgs::StringConstPtr& msg);
         void bsmCallback(const cav_msgs::BSMConstPtr& msg);
 
         // truck info
         std::string vin_number_;
         std::string license_plate_;
+        std::string state_short_name_;
         std::string carrier_name_;
         std::string carrier_id_;
         std::string ads_software_version_;
@@ -74,7 +77,8 @@ namespace truck_inspection_client
         int weight_;
         int iss_score_;
         bool permit_required_;
-        bool ads_engaged_;        
+        bool ads_engaged_;  
+        std::string ads_system_alert_type_;  
     };
 
 }

--- a/truck_inspection_client/src/truck_inspection_client.cpp
+++ b/truck_inspection_client/src/truck_inspection_client.cpp
@@ -26,6 +26,7 @@ namespace truck_inspection_client
         pnh_.reset(new ros::CARMANodeHandle("~"));
         pnh_->getParam("vin_number", vin_number_);
         pnh_->getParam("license_plate", license_plate_);
+        pnh_->getParam("state_short_name", state_short_name_);
         pnh_->getParam("carrier_name", carrier_name_);
         pnh_->getParam("carrier_id", carrier_id_);
         pnh_->getParam("weight", weight_);
@@ -36,16 +37,18 @@ namespace truck_inspection_client
         pnh_->getParam("pre_trip_ads_health_check", pre_trip_ads_health_check_);
         mo_pub_ = nh_->advertise<cav_msgs::MobilityOperation>("mobility_operation_outbound", 5);
         request_sub_ = nh_->subscribe("mobility_request_inbound", 1, &TruckInspectionClient::requestCallback, this);
-        ads_state_sub_ = nh_->subscribe("guidance_state", 1, &TruckInspectionClient::guidanceStatesCallback, this);
+        ads_state_sub_ = nh_->subscribe("/guidance/state", 1, &TruckInspectionClient::guidanceStatesCallback, this);
+        ads_system_alert_sub_ = nh_->subscribe("system_alert", 1, &TruckInspectionClient::systemAlertsCallback, this);
         version_sub_ = nh_->subscribe("/carma_system_version", 1, &TruckInspectionClient::versionCallback, this);
         bsm_sub_ = nh_->subscribe("bsm_outbound", 1, &TruckInspectionClient::bsmCallback, this);
         this->ads_engaged_ = false;
+        this->ads_system_alert_type_ = std::to_string(cav_msgs::SystemAlert::NOT_READY);
         this->ads_software_version_ = "System Version Unknown";
         // set vin publisher
         ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
             cav_msgs::MobilityOperation msg_out;
             msg_out.strategy = this->INSPECTION_STRATEGY;
-            msg_out.strategy_params = "VIN:" + vin_number_;
+            msg_out.strategy_params = "vin_number:" + vin_number_ + ",license_plate:" + license_plate_ +",state_short_name:"+ state_short_name_;
             mo_pub_.publish(msg_out);
             return true;
         });
@@ -70,16 +73,19 @@ namespace truck_inspection_client
     {
         this->ads_engaged_ = (msg->state == cav_msgs::GuidanceState::ENGAGED);
     }
-
+    void TruckInspectionClient::systemAlertsCallback(const cav_msgs::SystemAlertConstPtr& msg){
+        this->ads_system_alert_type_ = std::to_string(msg->type);
+    }
     void TruckInspectionClient::requestCallback(const cav_msgs::MobilityRequestConstPtr& msg)
     {
         if(msg->strategy == this->INSPECTION_STRATEGY) {
             cav_msgs::MobilityOperation mo_msg;
             mo_msg.header.sender_bsm_id = bsm_id_;
             mo_msg.strategy = this->INSPECTION_STRATEGY;
-            std::string ads_status = this->ads_engaged_ ? "Green" : "Red";
-            std::string params = boost::str(boost::format("vin_number:%s,license_plate:%s,carrier_name:%s,carrier_id:%s,weight:%d,ads_software_version:%s,date_of_last_state_inspection:%s,date_of_last_ads_calibration:%s,pre_trip_ads_health_check:%s,ads_status:%s,iss_score:%d,permit_required:%s")
-                                                         % vin_number_ % license_plate_ % carrier_name_ % carrier_id_ % weight_ % ads_software_version_ % date_of_last_state_inspection_ % date_of_last_ads_calibration_ % pre_trip_ads_health_check_ % ads_status %  iss_score_ % permit_required_);
+            std::string ads_auto_status = this->ads_engaged_ ? "Engaged" : "Not Engaged";
+            std::string ads_health_status = this->ads_engaged_ ?  ads_system_alert_type_ : std::to_string(cav_msgs::SystemAlert::SHUTDOWN);  
+            std::string params = boost::str(boost::format("vin_number:%s,license_plate:%s,carrier_name:%s,carrier_id:%s,weight:%d,ads_software_version:%s,date_of_last_state_inspection:%s,date_of_last_ads_calibration:%s,pre_trip_ads_health_check:%s,ads_health_status:%s,ads_auto_status:%s,iss_score:%d,permit_required:%s")
+                                                         % vin_number_ % license_plate_ % carrier_name_ % carrier_id_ % weight_ % ads_software_version_ % date_of_last_state_inspection_ % date_of_last_ads_calibration_ % pre_trip_ads_health_check_ % ads_health_status % ads_auto_status % iss_score_ % permit_required_);
             long time = (long)(ros::Time::now().toNSec() / pow(10, 6));
             mo_msg.header.timestamp = time;
             mo_msg.strategy_params = params;


### PR DESCRIPTION
…tatus, state_short_name and ads_auto_status

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## CAR-2350 CARMA Platform - Truck Inspection Plugin Client - Update

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CAR-2350

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
update guidance state topic, add system_alert topic, and update ads_health_status, ads_auto_status and state_short_name

## How Has This Been Tested?
Tested by running ROS environment in local VM
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
