### PR TITLE
Add usage of the motion prediction library to the object_detection_tr…

### DIFF
--- a/object_detection_tracking/CMakeLists.txt
+++ b/object_detection_tracking/CMakeLists.txt
@@ -12,8 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   cav_msgs
   roscpp
   carma_utils
+  motion_predict
 )
-
 
 ###################################
 ## catkin specific configuration ##
@@ -27,7 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
    INCLUDE_DIRS include
 #  LIBRARIES object_detection_tracking
- CATKIN_DEPENDS autoware_msgs cav_msgs roscpp carma_utils
+ CATKIN_DEPENDS autoware_msgs cav_msgs roscpp carma_utils motion_predict
 #  DEPENDS system_lib
 )
 
@@ -73,7 +73,7 @@ install(DIRECTORY include/
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 install(DIRECTORY
         launch
-      ##config
+        config
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/object_detection_tracking/config/parameters.yaml
+++ b/object_detection_tracking/config/parameters.yaml
@@ -1,0 +1,17 @@
+# Time between predicted states in seconds
+prediction_time_step: 0.1
+
+# Period of prediction in seconds
+prediction_period: 2.0
+
+# CV Model X-Axis Acceleration Noise
+cv_x_accel_noise: 9.0
+
+# CV Model Y-Axis Acceleration Noise
+cv_y_accel_noise: 9.0
+
+# Maximum expected process noise. Used for mapping noise to confidence in [0,1] range
+prediction_process_noise_max: 1000.0
+
+# Percentage of initial confidence to propagate to next time step
+prediction_confidence_drop_rate: 0.95

--- a/object_detection_tracking/include/object_detection_tracking_node.h
+++ b/object_detection_tracking/include/object_detection_tracking_node.h
@@ -32,6 +32,7 @@ class ObjectDetectionTrackingNode
   
   //node handle
   ros::CARMANodeHandle nh_;
+  ros::CARMANodeHandle pnh_;
    
   //subscriber
   ros::Subscriber autoware_obj_sub_;
@@ -41,7 +42,7 @@ class ObjectDetectionTrackingNode
   
   //ObjectDetectionTrackingWorker class object
   ObjectDetectionTrackingWorker object_worker_;
-
+  
     /*!fn initialize()
   \brief initialize this node before running
   */

--- a/object_detection_tracking/include/object_detection_tracking_worker.h
+++ b/object_detection_tracking/include/object_detection_tracking_worker.h
@@ -45,12 +45,28 @@ class ObjectDetectionTrackingWorker
     */
 
   void detectedObjectCallback(const autoware_msgs::DetectedObjectArray &msg);
+
+  // Setters for the prediction parameters
+  void setPredictionTimeStep(double time_step);
+  void setPredictionPeriod(double period);
+  void setXAccelerationNoise(double noise);
+  void setYAccelerationNoise(double noise);
+  void setProcessNoiseMax(double noise_max);
+  void setConfidenceDropRate(double drop_rate);
  
  private:
 
-    // local copy of external object publihsers
+  // local copy of external object publihsers
 
-    PublishObjectCallback obj_pub_;
+  PublishObjectCallback obj_pub_;
+
+  // Prediction parameters
+  double prediction_time_step_ = 0.1;
+  double prediction_period_ = 2.0;
+  double cv_x_accel_noise_ = 9.0;
+  double cv_y_accel_noise_ = 9.0;
+  double prediction_process_noise_max_ = 1000.0;
+  double prediction_confidence_drop_rate_ = 0.9;
   
 };
 

--- a/object_detection_tracking/launch/external_object.launch
+++ b/object_detection_tracking/launch/external_object.launch
@@ -15,5 +15,7 @@
 -->
 
 <launch>
-   <node name="external_object" pkg="object_detection_tracking" type="object_detection_tracking_node" output="screen" />
+  <node name="external_object" pkg="object_detection_tracking" type="object_detection_tracking_node">
+    <rosparam command="load" file="$(find object_detection_tracking)/config/parameters.yaml"/>
+  </node>
 </launch>

--- a/object_detection_tracking/package.xml
+++ b/object_detection_tracking/package.xml
@@ -27,7 +27,7 @@
   <depend>cav_msgs</depend>
   <depend>roscpp</depend>
   <depend>carma_utils</depend>
-
+  <depend>motion_predict</depend>
   <export>
   
 

--- a/object_detection_tracking/src/object_detection_tracking_worker.cpp
+++ b/object_detection_tracking/src/object_detection_tracking_worker.cpp
@@ -14,68 +14,144 @@
  * the License.
  */
 #include "object_detection_tracking_worker.h"
+#include <motion_predict/motion_predict.h>
+#include <motion_predict/predict_ctrv.h>
 
-namespace object{
+namespace object
+{
+ObjectDetectionTrackingWorker::ObjectDetectionTrackingWorker(PublishObjectCallback obj_pub) : obj_pub_(obj_pub){};
 
-ObjectDetectionTrackingWorker::ObjectDetectionTrackingWorker(PublishObjectCallback obj_pub):obj_pub_(obj_pub) { };
+void ObjectDetectionTrackingWorker::detectedObjectCallback(const autoware_msgs::DetectedObjectArray& obj_array)
+{
+  cav_msgs::ExternalObjectList msg;
+  msg.header = obj_array.header;
 
-void ObjectDetectionTrackingWorker::detectedObjectCallback(const autoware_msgs::DetectedObjectArray &obj_array)
-{	
-	
-	cav_msgs::ExternalObjectList msg;
-	msg.header=obj_array.header;
+  for (int i = 0; i < obj_array.objects.size(); i++)
+  {
+    cav_msgs::ExternalObject obj;
 
-	for(int i=0;i<obj_array.objects.size();i++)
-	{
-		cav_msgs::ExternalObject obj;
+    // Header contains the frame rest of the fields will use
+    obj.header = obj_array.objects[i].header;
 
-		//Header contains the frame rest of the fields will use
-		 obj.header=obj_array.objects[i].header;
+    // Presence vector message is used to describe objects coming from potentially
+    // different sources. The presence vector is used to determine what items are set
+    // by the producer
+    obj.presence_vector = obj.presence_vector | obj.ID_PRESENCE_VECTOR;
+    obj.presence_vector = obj.presence_vector | obj.POSE_PRESENCE_VECTOR;
+    obj.presence_vector = obj.presence_vector | obj.VELOCITY_PRESENCE_VECTOR;
+    obj.presence_vector = obj.presence_vector | obj.SIZE_PRESENCE_VECTOR;
+    obj.presence_vector = obj.presence_vector | obj.OBJECT_TYPE_PRESENCE_VECTOR;
+    obj.presence_vector = obj.presence_vector | obj.DYNAMIC_OBJ_PRESENCE;
 
-		//Presence vector message is used to describe objects coming from potentially
-		//different sources. The presence vector is used to determine what items are set
-		//by the producer
-		obj.presence_vector=obj.presence_vector | obj.ID_PRESENCE_VECTOR;
-		obj.presence_vector=obj.presence_vector | obj.POSE_PRESENCE_VECTOR;
-		obj.presence_vector=obj.presence_vector | obj.VELOCITY_PRESENCE_VECTOR;
-		obj.presence_vector=obj.presence_vector | obj.SIZE_PRESENCE_VECTOR;
-		obj.presence_vector=obj.presence_vector | obj.OBJECT_TYPE_PRESENCE_VECTOR;
-		obj.presence_vector=obj.presence_vector | obj.DYNAMIC_OBJ_PRESENCE;
-		
-		//Object id. Matching ids on a topic should refer to the same object within some time period, expanded
-		obj.id=obj_array.objects[i].id;
+    // Object id. Matching ids on a topic should refer to the same object within some time period, expanded
+    obj.id = obj_array.objects[i].id;
 
-		//Pose of the object within the frame specified in header
-		obj.pose.pose=obj_array.objects[i].pose;
-		obj.pose.covariance[0]=obj_array.objects[i].variance.x;
-		obj.pose.covariance[7]=obj_array.objects[i].variance.y;
-		obj.pose.covariance[17]=obj_array.objects[i].variance.z;
+    // Pose of the object within the frame specified in header
+    obj.pose.pose = obj_array.objects[i].pose;
+    obj.pose.covariance[0] = obj_array.objects[i].variance.x;
+    obj.pose.covariance[7] = obj_array.objects[i].variance.y;
+    obj.pose.covariance[17] = obj_array.objects[i].variance.z;
 
-		//Average velocity of the object within the frame specified in header
-		obj.velocity.twist=obj_array.objects[i].velocity;
+    // Average velocity of the object within the frame specified in header
+    obj.velocity.twist = obj_array.objects[i].velocity;
 
-		//The size of the object aligned along the axis of the object described by the orientation in pose
-		//Dimensions are specified in meters
-		obj.size=obj_array.objects[i].dimensions;
-	    
-		//describes a general object type as defined in this message
-        obj.object_type=obj.UNKNOWN;
+    // The size of the object aligned along the axis of the object described by the orientation in pose
+    // Dimensions are specified in meters
+    obj.size = obj_array.objects[i].dimensions;
 
-		// Binary value to show if the object is static or dynamic (1: dynamic, 0: static)
-		
-        if( (abs(obj.velocity.twist.linear.x || obj.velocity.twist.linear.y || obj.velocity.twist.linear.z)) > 0.75 )
-        {
-		  obj.dynamic_obj=1;
-		}
-		else
-		{
-		  obj.dynamic_obj=0;
-		}
-		
-		msg.objects.emplace_back(obj);
-	}
+    // Update the object type and generate predictions using CV or CTRV vehicle models.
+		// If the object is a bicycle or motor vehicle use CTRV otherwise use CV.
+    bool use_ctrv_model = true;
 
-		obj_pub_(msg);
+    if (obj_array.objects[i].label.compare("bicycle") == 0)
+    {
+      obj.object_type = obj.UNKNOWN;
+    }
+    else if (obj_array.objects[i].label.compare("motorbike") == 0)
+    {
+      obj.object_type = obj.MOTORCYCLE;
+    }
+    else if (obj_array.objects[i].label.compare("car") == 0)
+    {
+      obj.object_type = obj.SMALL_VEHICLE;
+    }
+    else if (obj_array.objects[i].label.compare("bus") == 0)
+    {
+      obj.object_type = obj.LARGE_VEHICLE;
+    }
+    else if (obj_array.objects[i].label.compare("truck") == 0)
+    {
+      obj.object_type = obj.LARGE_VEHICLE;
+    }
+    else if (obj_array.objects[i].label.compare("person"))
+    {
+      obj.object_type = obj.PEDESTRIAN;
+      use_ctrv_model = false;
+    }
+    else
+    {
+      obj.object_type = obj.UNKNOWN;
+      use_ctrv_model = false;
+    }
+
+    if (use_ctrv_model)
+    {
+      obj.predictions =
+          motion_predict::ctrv::predictPeriod(obj, prediction_time_step_, prediction_period_,
+                                              prediction_process_noise_max_, prediction_confidence_drop_rate_);
+    }
+    else
+    {
+      obj.predictions = motion_predict::cv::predictPeriod(
+          obj, prediction_time_step_, prediction_period_, cv_x_accel_noise_, cv_y_accel_noise_,
+          prediction_process_noise_max_, prediction_confidence_drop_rate_);
+    }
+
+    // Binary value to show if the object is static or dynamic (1: dynamic, 0: static)
+
+    if ((abs(obj.velocity.twist.linear.x || obj.velocity.twist.linear.y || obj.velocity.twist.linear.z)) > 0.75)
+    {
+      obj.dynamic_obj = 1;
+    }
+    else
+    {
+      obj.dynamic_obj = 0;
+    }
+
+    msg.objects.emplace_back(obj);
+  }
+
+  obj_pub_(msg);
 }
 
-}//object
+void ObjectDetectionTrackingWorker::setPredictionTimeStep(double time_step)
+{
+  prediction_time_step_ = time_step;
+}
+
+void ObjectDetectionTrackingWorker::setPredictionPeriod(double period)
+{
+  prediction_period_ = period;
+}
+
+void ObjectDetectionTrackingWorker::setXAccelerationNoise(double noise)
+{
+  cv_x_accel_noise_ = noise;
+}
+
+void ObjectDetectionTrackingWorker::setYAccelerationNoise(double noise)
+{
+  cv_y_accel_noise_ = noise;
+}
+
+void ObjectDetectionTrackingWorker::setProcessNoiseMax(double noise_max)
+{
+  prediction_process_noise_max_ = noise_max;
+}
+
+void ObjectDetectionTrackingWorker::setConfidenceDropRate(double drop_rate)
+{
+  prediction_confidence_drop_rate_ = drop_rate;
+}
+
+}  // namespace object


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds support for motion prediction to the object_detection_tracking node.
<!--- Describe your changes in detail -->
Not sure why but the whole file is showing as modified. I actually only changed these lines
62 -108
And added the include/cmake changes needed to add motion_predict library. 
## Related Issue
#697 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Populate sensed object motion predictions
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
