### PR TITLE
Add Unobstructed Lane Change

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -51,7 +51,8 @@ sonar.modules= mock_drivers, \
   carma_wm, \
   carma_wm_ctrl, \
   mpc_follower_wrapper, \
-  roadway_objects
+  roadway_objects, \
+  unobstructed_lanechange
 
 mock_drivers.sonar.projectBaseDir              = /opt/carma/src/CARMAPlatform/carmajava/mock_drivers
 carma_transform_server.sonar.projectBaseDir    = /opt/carma/src/CARMAPlatform/carma_transform_server
@@ -72,6 +73,7 @@ carma_wm_ctrl.sonar.projectBaseDir             = /opt/carma/src/CARMAPlatform/ca
 mpc_follower_wrapper.sonar.projectBaseDir      = /opt/carma/src/CARMAPlatform/mpc_follower_wrapper
 truck_inspection_client.sonar.projectBaseDir   = /opt/carma/src/CARMAPlatform/truck_inspection_client
 roadway_objects.sonar.projectBaseDir           = /opt/carma/src/CARMAPlatform/roadway_objects
+unobstructed_lanechange.sonar.projectBaseDir   = /opt/carma/src/CARMAPlatform/unobstructed_lanechange
 
 # C++ Package differences
 # Sources
@@ -93,21 +95,23 @@ carma_wm_ctrl.sonar.sources             = src
 mpc_follower_wrapper.sonar.sources      = src
 truck_inspection_client.sonar.sources   = src
 roadway_objects.sonar.sources           = src
+unobstructed_lanechange.sonar.sources   = src
+
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
-autoware_plugin.sonar.tests         = test
-bsm_generator.sonar.tests           = test
-gnss_to_map_convertor.sonar.tests   = test
-guidance.sonar.tests                = test
-pure_pursuit_wrapper.sonar.tests    = test
-route_generator.sonar.tests         = test
-trajectory_executor.sonar.tests     = test
-gnss_ndt_selector.sonar.tests       = test
-health_monitor.sonar.tests          = test
-arbitrator.sonar.tests              = test
-carma_wm.sonar.tests                = test
-carma_wm_ctrl.sonar.tests           = test
-mpc_follower_wrapper.sonar.tests    = test
-truck_inspection_client.sonar.tests = test
-roadway_objects.sonar.tests         = test 
+autoware_plugin.sonar.tests       = test
+bsm_generator.sonar.tests         = test
+gnss_to_map_convertor.sonar.tests = test
+guidance.sonar.tests              = test
+pure_pursuit_wrapper.sonar.tests  = test
+route_generator.sonar.tests       = test
+trajectory_executor.sonar.tests   = test
+gnss_ndt_selector.sonar.tests     = test
+health_monitor.sonar.tests        = test
+arbitrator.sonar.tests            = test
+carma_wm.sonar.tests              = test
+carma_wm_ctrl.sonar.tests         = test
+mpc_follower_wrapper.sonar.tests  = test
+roadway_objects.sonar.tests       = test
+unobstructed_lanechange.sonar.tests = test

--- a/unobstructed_lanechange/CMakeLists.txt
+++ b/unobstructed_lanechange/CMakeLists.txt
@@ -1,0 +1,104 @@
+# Copyright (C) 2018-2020 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+cmake_minimum_required(VERSION 2.8.3)
+project(unobstructed_lanechange)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++14)
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  carma_utils
+  cav_msgs
+  roscpp
+  std_msgs
+  carma_wm
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+
+catkin_package(
+   INCLUDE_DIRS include
+   CATKIN_DEPENDS carma_utils cav_msgs roscpp std_msgs carma_wm
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+file(GLOB_RECURSE headers */*.hpp */*.h)
+
+add_executable( ${PROJECT_NAME}
+  ${headers}
+  src/unobstructed_lanechange.cpp
+  src/main.cpp)
+
+
+add_library(unobstructed_lanechange_plugin_lib src/unobstructed_lanechange.cpp)
+
+add_dependencies(unobstructed_lanechange_plugin_lib ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME} unobstructed_lanechange_plugin_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+
+#############
+## Install ##
+#############
+
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Install C++
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Mark other files for installation (e.g. launch and bag files, etc.)
+install(DIRECTORY
+  launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+
+#############
+## Testing ##
+#############
+catkin_add_gmock(${PROJECT_NAME}-test
+  test/test_unobstructed_lanechange_plugin.cpp
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
+target_link_libraries(${PROJECT_NAME}-test unobstructed_lanechange_plugin_lib ${catkin_LIBRARIES})
+

--- a/unobstructed_lanechange/Readme.md
+++ b/unobstructed_lanechange/Readme.md
@@ -1,0 +1,3 @@
+In this package, cubic spline interpolation is used for continious trajectory generation. The spline is implemented as a header file available in the "include/third_party_library/spline.h" directory. The links to the spline library information and its license are provided below:
+https://kluge.in-chemnitz.de/opensource/spline/
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/unobstructed_lanechange/config/parameters.yaml
+++ b/unobstructed_lanechange/config/parameters.yaml
@@ -1,0 +1,5 @@
+# The length of the trajectory in time domain, in seconds
+trajectory_time_length: 6.0
+
+# The default control plugin name
+control_plugin_name: "mpc_follower"

--- a/unobstructed_lanechange/include/spline.h
+++ b/unobstructed_lanechange/include/spline.h
@@ -1,0 +1,404 @@
+/*
+ * spline.h
+ *
+ * simple cubic spline interpolation library without external
+ * dependencies
+ *
+ * ---------------------------------------------------------------------
+ * Copyright (C) 2011, 2014 Tino Kluge (ttk448 at gmail.com)
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ *
+ */
+
+
+#ifndef TK_SPLINE_H
+#define TK_SPLINE_H
+
+#include <cstdio>
+#include <cassert>
+#include <vector>
+#include <algorithm>
+
+
+// unnamed namespace only because the implementation is in this
+// header file and we don't want to export symbols to the obj files
+namespace
+{
+
+namespace tk
+{
+
+// band matrix solver
+class band_matrix
+{
+private:
+    std::vector< std::vector<double> > m_upper;  // upper band
+    std::vector< std::vector<double> > m_lower;  // lower band
+public:
+    band_matrix() {};                             // constructor
+    band_matrix(int dim, int n_u, int n_l);       // constructor
+    ~band_matrix() {};                            // destructor
+    void resize(int dim, int n_u, int n_l);      // init with dim,n_u,n_l
+    int dim() const;                             // matrix dimension
+    int num_upper() const
+    {
+        return m_upper.size()-1;
+    }
+    int num_lower() const
+    {
+        return m_lower.size()-1;
+    }
+    // access operator
+    double & operator () (int i, int j);            // write
+    double   operator () (int i, int j) const;      // read
+    // we can store an additional diogonal (in m_lower)
+    double& saved_diag(int i);
+    double  saved_diag(int i) const;
+    void lu_decompose();
+    std::vector<double> r_solve(const std::vector<double>& b) const;
+    std::vector<double> l_solve(const std::vector<double>& b) const;
+    std::vector<double> lu_solve(const std::vector<double>& b,
+                                 bool is_lu_decomposed=false);
+
+};
+
+
+// spline interpolation
+class spline
+{
+public:
+    enum bd_type {
+        first_deriv = 1,
+        second_deriv = 2
+    };
+
+private:
+    std::vector<double> m_x,m_y;            // x,y coordinates of points
+    // interpolation parameters
+    // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
+    std::vector<double> m_a,m_b,m_c;        // spline coefficients
+    double  m_b0, m_c0;                     // for left extrapol
+    bd_type m_left, m_right;
+    double  m_left_value, m_right_value;
+    bool    m_force_linear_extrapolation;
+
+public:
+    // set default boundary condition to be zero curvature at both ends
+    spline(): m_left(second_deriv), m_right(second_deriv),
+        m_left_value(0.0), m_right_value(0.0),
+        m_force_linear_extrapolation(false)
+    {
+        ;
+    }
+
+    // optional, but if called it has to come be before set_points()
+    void set_boundary(bd_type left, double left_value,
+                      bd_type right, double right_value,
+                      bool force_linear_extrapolation=false);
+    void set_points(const std::vector<double>& x,
+                    const std::vector<double>& y, bool cubic_spline=true);
+    double operator() (double x) const;
+};
+
+
+
+// ---------------------------------------------------------------------
+// implementation part, which could be separated into a cpp file
+// ---------------------------------------------------------------------
+
+
+// band_matrix implementation
+// -------------------------
+
+band_matrix::band_matrix(int dim, int n_u, int n_l)
+{
+    resize(dim, n_u, n_l);
+}
+void band_matrix::resize(int dim, int n_u, int n_l)
+{
+    assert(dim>0);
+    assert(n_u>=0);
+    assert(n_l>=0);
+    m_upper.resize(n_u+1);
+    m_lower.resize(n_l+1);
+    for(size_t i=0; i<m_upper.size(); i++) {
+        m_upper[i].resize(dim);
+    }
+    for(size_t i=0; i<m_lower.size(); i++) {
+        m_lower[i].resize(dim);
+    }
+}
+int band_matrix::dim() const
+{
+    if(m_upper.size()>0) {
+        return m_upper[0].size();
+    } else {
+        return 0;
+    }
+}
+
+
+// defines the new operator (), so that we can access the elements
+// by A(i,j), index going from i=0,...,dim()-1
+double & band_matrix::operator () (int i, int j)
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+double band_matrix::operator () (int i, int j) const
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+// second diag (used in LU decomposition), saved in m_lower
+double band_matrix::saved_diag(int i) const
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+double & band_matrix::saved_diag(int i)
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+
+// LR-Decomposition of a band matrix
+void band_matrix::lu_decompose()
+{
+    int  i_max,j_max;
+    int  j_min;
+    double x;
+
+    // preconditioning
+    // normalize column i so that a_ii=1
+    for(int i=0; i<this->dim(); i++) {
+        assert(this->operator()(i,i)!=0.0);
+        this->saved_diag(i)=1.0/this->operator()(i,i);
+        j_min=std::max(0,i-this->num_lower());
+        j_max=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=j_min; j<=j_max; j++) {
+            this->operator()(i,j) *= this->saved_diag(i);
+        }
+        this->operator()(i,i)=1.0;          // prevents rounding errors
+    }
+
+    // Gauss LR-Decomposition
+    for(int k=0; k<this->dim(); k++) {
+        i_max=std::min(this->dim()-1,k+this->num_lower());  // num_lower not a mistake!
+        for(int i=k+1; i<=i_max; i++) {
+            assert(this->operator()(k,k)!=0.0);
+            x=-this->operator()(i,k)/this->operator()(k,k);
+            this->operator()(i,k)=-x;                         // assembly part of L
+            j_max=std::min(this->dim()-1,k+this->num_upper());
+            for(int j=k+1; j<=j_max; j++) {
+                // assembly part of R
+                this->operator()(i,j)=this->operator()(i,j)+x*this->operator()(k,j);
+            }
+        }
+    }
+}
+// solves Ly=b
+std::vector<double> band_matrix::l_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_start;
+    double sum;
+    for(int i=0; i<this->dim(); i++) {
+        sum=0;
+        j_start=std::max(0,i-this->num_lower());
+        for(int j=j_start; j<i; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=(b[i]*this->saved_diag(i)) - sum;
+    }
+    return x;
+}
+// solves Rx=y
+std::vector<double> band_matrix::r_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_stop;
+    double sum;
+    for(int i=this->dim()-1; i>=0; i--) {
+        sum=0;
+        j_stop=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=i+1; j<=j_stop; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=( b[i] - sum ) / this->operator()(i,i);
+    }
+    return x;
+}
+
+std::vector<double> band_matrix::lu_solve(const std::vector<double>& b,
+        bool is_lu_decomposed)
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double>  x,y;
+    if(is_lu_decomposed==false) {
+        this->lu_decompose();
+    }
+    y=this->l_solve(b);
+    x=this->r_solve(y);
+    return x;
+}
+
+
+
+
+// spline implementation
+// -----------------------
+
+void spline::set_boundary(spline::bd_type left, double left_value,
+                          spline::bd_type right, double right_value,
+                          bool force_linear_extrapolation)
+{
+    assert(m_x.size()==0);          // set_points() must not have happened yet
+    m_left=left;
+    m_right=right;
+    m_left_value=left_value;
+    m_right_value=right_value;
+    m_force_linear_extrapolation=force_linear_extrapolation;
+}
+
+
+void spline::set_points(const std::vector<double>& x,
+                        const std::vector<double>& y, bool cubic_spline)
+{
+    assert(x.size()==y.size());
+    assert(x.size()>2);
+    m_x=x;
+    m_y=y;
+    int   n=x.size();
+    // TODO: maybe sort x and y, rather than returning an error
+    for(int i=0; i<n-1; i++) {
+        assert(m_x[i]<m_x[i+1]);
+    }
+
+    if(cubic_spline==true) { // cubic spline interpolation
+        // setting up the matrix and right hand side of the equation system
+        // for the parameters b[]
+        band_matrix A(n,1,1);
+        std::vector<double>  rhs(n);
+        for(int i=1; i<n-1; i++) {
+            A(i,i-1)=1.0/3.0*(x[i]-x[i-1]);
+            A(i,i)=2.0/3.0*(x[i+1]-x[i-1]);
+            A(i,i+1)=1.0/3.0*(x[i+1]-x[i]);
+            rhs[i]=(y[i+1]-y[i])/(x[i+1]-x[i]) - (y[i]-y[i-1])/(x[i]-x[i-1]);
+        }
+        // boundary conditions
+        if(m_left == spline::second_deriv) {
+            // 2*b[0] = f''
+            A(0,0)=2.0;
+            A(0,1)=0.0;
+            rhs[0]=m_left_value;
+        } else if(m_left == spline::first_deriv) {
+            // c[0] = f', needs to be re-expressed in terms of b:
+            // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
+            A(0,0)=2.0*(x[1]-x[0]);
+            A(0,1)=1.0*(x[1]-x[0]);
+            rhs[0]=3.0*((y[1]-y[0])/(x[1]-x[0])-m_left_value);
+        } else {
+            assert(false);
+        }
+        if(m_right == spline::second_deriv) {
+            // 2*b[n-1] = f''
+            A(n-1,n-1)=2.0;
+            A(n-1,n-2)=0.0;
+            rhs[n-1]=m_right_value;
+        } else if(m_right == spline::first_deriv) {
+            // c[n-1] = f', needs to be re-expressed in terms of b:
+            // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
+            // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
+            A(n-1,n-1)=2.0*(x[n-1]-x[n-2]);
+            A(n-1,n-2)=1.0*(x[n-1]-x[n-2]);
+            rhs[n-1]=3.0*(m_right_value-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
+        } else {
+            assert(false);
+        }
+
+        // solve the equation system to obtain the parameters b[]
+        m_b=A.lu_solve(rhs);
+
+        // calculate parameters a[] and c[] based on b[]
+        m_a.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=1.0/3.0*(m_b[i+1]-m_b[i])/(x[i+1]-x[i]);
+            m_c[i]=(y[i+1]-y[i])/(x[i+1]-x[i])
+                   - 1.0/3.0*(2.0*m_b[i]+m_b[i+1])*(x[i+1]-x[i]);
+        }
+    } else { // linear interpolation
+        m_a.resize(n);
+        m_b.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=0.0;
+            m_b[i]=0.0;
+            m_c[i]=(m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
+        }
+    }
+
+    // for left extrapolation coefficients
+    m_b0 = (m_force_linear_extrapolation==false) ? m_b[0] : 0.0;
+    m_c0 = m_c[0];
+
+    // for the right extrapolation coefficients
+    // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
+    double h=x[n-1]-x[n-2];
+    // m_b[n-1] is determined by the boundary condition
+    m_a[n-1]=0.0;
+    m_c[n-1]=3.0*m_a[n-2]*h*h+2.0*m_b[n-2]*h+m_c[n-2];   // = f'_{n-2}(x_{n-1})
+    if(m_force_linear_extrapolation==true)
+        m_b[n-1]=0.0;
+}
+
+double spline::operator() (double x) const
+{
+    size_t n=m_x.size();
+    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+    std::vector<double>::const_iterator it;
+    it=std::lower_bound(m_x.begin(),m_x.end(),x);
+    int idx=std::max( int(it-m_x.begin())-1, 0);
+
+    double h=x-m_x[idx];
+    double interpol;
+    if(x<m_x[0]) {
+        // extrapolation to the left
+        interpol=(m_b0*h + m_c0)*h + m_y[0];
+    } else if(x>m_x[n-1]) {
+        // extrapolation to the right
+        interpol=(m_b[n-1]*h + m_c[n-1])*h + m_y[n-1];
+    } else {
+        // interpolation
+        interpol=((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+    }
+    return interpol;
+}
+
+
+} // namespace tk
+
+
+} // namespace
+
+#endif /* TK_SPLINE_H */

--- a/unobstructed_lanechange/include/third_party_library/GNU GENERAL PUBLIC LICENSE
+++ b/unobstructed_lanechange/include/third_party_library/GNU GENERAL PUBLIC LICENSE
@@ -1,0 +1,83 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+Preamble
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS

--- a/unobstructed_lanechange/include/third_party_library/spline.h
+++ b/unobstructed_lanechange/include/third_party_library/spline.h
@@ -1,0 +1,404 @@
+/*
+ * spline.h
+ *
+ * simple cubic spline interpolation library without external
+ * dependencies
+ *
+ * ---------------------------------------------------------------------
+ * Copyright (C) 2011, 2014 Tino Kluge (ttk448 at gmail.com)
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ *
+ */
+
+
+#ifndef TK_SPLINE_H
+#define TK_SPLINE_H
+
+#include <cstdio>
+#include <cassert>
+#include <vector>
+#include <algorithm>
+
+
+// unnamed namespace only because the implementation is in this
+// header file and we don't want to export symbols to the obj files
+namespace
+{
+
+namespace tk
+{
+
+// band matrix solver
+class band_matrix
+{
+private:
+    std::vector< std::vector<double> > m_upper;  // upper band
+    std::vector< std::vector<double> > m_lower;  // lower band
+public:
+    band_matrix() {};                             // constructor
+    band_matrix(int dim, int n_u, int n_l);       // constructor
+    ~band_matrix() {};                            // destructor
+    void resize(int dim, int n_u, int n_l);      // init with dim,n_u,n_l
+    int dim() const;                             // matrix dimension
+    int num_upper() const
+    {
+        return m_upper.size()-1;
+    }
+    int num_lower() const
+    {
+        return m_lower.size()-1;
+    }
+    // access operator
+    double & operator () (int i, int j);            // write
+    double   operator () (int i, int j) const;      // read
+    // we can store an additional diogonal (in m_lower)
+    double& saved_diag(int i);
+    double  saved_diag(int i) const;
+    void lu_decompose();
+    std::vector<double> r_solve(const std::vector<double>& b) const;
+    std::vector<double> l_solve(const std::vector<double>& b) const;
+    std::vector<double> lu_solve(const std::vector<double>& b,
+                                 bool is_lu_decomposed=false);
+
+};
+
+
+// spline interpolation
+class spline
+{
+public:
+    enum bd_type {
+        first_deriv = 1,
+        second_deriv = 2
+    };
+
+private:
+    std::vector<double> m_x,m_y;            // x,y coordinates of points
+    // interpolation parameters
+    // f(x) = a*(x-x_i)^3 + b*(x-x_i)^2 + c*(x-x_i) + y_i
+    std::vector<double> m_a,m_b,m_c;        // spline coefficients
+    double  m_b0, m_c0;                     // for left extrapol
+    bd_type m_left, m_right;
+    double  m_left_value, m_right_value;
+    bool    m_force_linear_extrapolation;
+
+public:
+    // set default boundary condition to be zero curvature at both ends
+    spline(): m_left(second_deriv), m_right(second_deriv),
+        m_left_value(0.0), m_right_value(0.0),
+        m_force_linear_extrapolation(false)
+    {
+        ;
+    }
+
+    // optional, but if called it has to come be before set_points()
+    void set_boundary(bd_type left, double left_value,
+                      bd_type right, double right_value,
+                      bool force_linear_extrapolation=false);
+    void set_points(const std::vector<double>& x,
+                    const std::vector<double>& y, bool cubic_spline=true);
+    double operator() (double x) const;
+};
+
+
+
+// ---------------------------------------------------------------------
+// implementation part, which could be separated into a cpp file
+// ---------------------------------------------------------------------
+
+
+// band_matrix implementation
+// -------------------------
+
+band_matrix::band_matrix(int dim, int n_u, int n_l)
+{
+    resize(dim, n_u, n_l);
+}
+void band_matrix::resize(int dim, int n_u, int n_l)
+{
+    assert(dim>0);
+    assert(n_u>=0);
+    assert(n_l>=0);
+    m_upper.resize(n_u+1);
+    m_lower.resize(n_l+1);
+    for(size_t i=0; i<m_upper.size(); i++) {
+        m_upper[i].resize(dim);
+    }
+    for(size_t i=0; i<m_lower.size(); i++) {
+        m_lower[i].resize(dim);
+    }
+}
+int band_matrix::dim() const
+{
+    if(m_upper.size()>0) {
+        return m_upper[0].size();
+    } else {
+        return 0;
+    }
+}
+
+
+// defines the new operator (), so that we can access the elements
+// by A(i,j), index going from i=0,...,dim()-1
+double & band_matrix::operator () (int i, int j)
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+double band_matrix::operator () (int i, int j) const
+{
+    int k=j-i;       // what band is the entry
+    assert( (i>=0) && (i<dim()) && (j>=0) && (j<dim()) );
+    assert( (-num_lower()<=k) && (k<=num_upper()) );
+    // k=0 -> diogonal, k<0 lower left part, k>0 upper right part
+    if(k>=0)   return m_upper[k][i];
+    else	    return m_lower[-k][i];
+}
+// second diag (used in LU decomposition), saved in m_lower
+double band_matrix::saved_diag(int i) const
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+double & band_matrix::saved_diag(int i)
+{
+    assert( (i>=0) && (i<dim()) );
+    return m_lower[0][i];
+}
+
+// LR-Decomposition of a band matrix
+void band_matrix::lu_decompose()
+{
+    int  i_max,j_max;
+    int  j_min;
+    double x;
+
+    // preconditioning
+    // normalize column i so that a_ii=1
+    for(int i=0; i<this->dim(); i++) {
+        assert(this->operator()(i,i)!=0.0);
+        this->saved_diag(i)=1.0/this->operator()(i,i);
+        j_min=std::max(0,i-this->num_lower());
+        j_max=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=j_min; j<=j_max; j++) {
+            this->operator()(i,j) *= this->saved_diag(i);
+        }
+        this->operator()(i,i)=1.0;          // prevents rounding errors
+    }
+
+    // Gauss LR-Decomposition
+    for(int k=0; k<this->dim(); k++) {
+        i_max=std::min(this->dim()-1,k+this->num_lower());  // num_lower not a mistake!
+        for(int i=k+1; i<=i_max; i++) {
+            assert(this->operator()(k,k)!=0.0);
+            x=-this->operator()(i,k)/this->operator()(k,k);
+            this->operator()(i,k)=-x;                         // assembly part of L
+            j_max=std::min(this->dim()-1,k+this->num_upper());
+            for(int j=k+1; j<=j_max; j++) {
+                // assembly part of R
+                this->operator()(i,j)=this->operator()(i,j)+x*this->operator()(k,j);
+            }
+        }
+    }
+}
+// solves Ly=b
+std::vector<double> band_matrix::l_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_start;
+    double sum;
+    for(int i=0; i<this->dim(); i++) {
+        sum=0;
+        j_start=std::max(0,i-this->num_lower());
+        for(int j=j_start; j<i; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=(b[i]*this->saved_diag(i)) - sum;
+    }
+    return x;
+}
+// solves Rx=y
+std::vector<double> band_matrix::r_solve(const std::vector<double>& b) const
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double> x(this->dim());
+    int j_stop;
+    double sum;
+    for(int i=this->dim()-1; i>=0; i--) {
+        sum=0;
+        j_stop=std::min(this->dim()-1,i+this->num_upper());
+        for(int j=i+1; j<=j_stop; j++) sum += this->operator()(i,j)*x[j];
+        x[i]=( b[i] - sum ) / this->operator()(i,i);
+    }
+    return x;
+}
+
+std::vector<double> band_matrix::lu_solve(const std::vector<double>& b,
+        bool is_lu_decomposed)
+{
+    assert( this->dim()==(int)b.size() );
+    std::vector<double>  x,y;
+    if(is_lu_decomposed==false) {
+        this->lu_decompose();
+    }
+    y=this->l_solve(b);
+    x=this->r_solve(y);
+    return x;
+}
+
+
+
+
+// spline implementation
+// -----------------------
+
+void spline::set_boundary(spline::bd_type left, double left_value,
+                          spline::bd_type right, double right_value,
+                          bool force_linear_extrapolation)
+{
+    assert(m_x.size()==0);          // set_points() must not have happened yet
+    m_left=left;
+    m_right=right;
+    m_left_value=left_value;
+    m_right_value=right_value;
+    m_force_linear_extrapolation=force_linear_extrapolation;
+}
+
+
+void spline::set_points(const std::vector<double>& x,
+                        const std::vector<double>& y, bool cubic_spline)
+{
+    assert(x.size()==y.size());
+    assert(x.size()>2);
+    m_x=x;
+    m_y=y;
+    int   n=x.size();
+    // TODO: maybe sort x and y, rather than returning an error
+    for(int i=0; i<n-1; i++) {
+        assert(m_x[i]<m_x[i+1]);
+    }
+
+    if(cubic_spline==true) { // cubic spline interpolation
+        // setting up the matrix and right hand side of the equation system
+        // for the parameters b[]
+        band_matrix A(n,1,1);
+        std::vector<double>  rhs(n);
+        for(int i=1; i<n-1; i++) {
+            A(i,i-1)=1.0/3.0*(x[i]-x[i-1]);
+            A(i,i)=2.0/3.0*(x[i+1]-x[i-1]);
+            A(i,i+1)=1.0/3.0*(x[i+1]-x[i]);
+            rhs[i]=(y[i+1]-y[i])/(x[i+1]-x[i]) - (y[i]-y[i-1])/(x[i]-x[i-1]);
+        }
+        // boundary conditions
+        if(m_left == spline::second_deriv) {
+            // 2*b[0] = f''
+            A(0,0)=2.0;
+            A(0,1)=0.0;
+            rhs[0]=m_left_value;
+        } else if(m_left == spline::first_deriv) {
+            // c[0] = f', needs to be re-expressed in terms of b:
+            // (2b[0]+b[1])(x[1]-x[0]) = 3 ((y[1]-y[0])/(x[1]-x[0]) - f')
+            A(0,0)=2.0*(x[1]-x[0]);
+            A(0,1)=1.0*(x[1]-x[0]);
+            rhs[0]=3.0*((y[1]-y[0])/(x[1]-x[0])-m_left_value);
+        } else {
+            assert(false);
+        }
+        if(m_right == spline::second_deriv) {
+            // 2*b[n-1] = f''
+            A(n-1,n-1)=2.0;
+            A(n-1,n-2)=0.0;
+            rhs[n-1]=m_right_value;
+        } else if(m_right == spline::first_deriv) {
+            // c[n-1] = f', needs to be re-expressed in terms of b:
+            // (b[n-2]+2b[n-1])(x[n-1]-x[n-2])
+            // = 3 (f' - (y[n-1]-y[n-2])/(x[n-1]-x[n-2]))
+            A(n-1,n-1)=2.0*(x[n-1]-x[n-2]);
+            A(n-1,n-2)=1.0*(x[n-1]-x[n-2]);
+            rhs[n-1]=3.0*(m_right_value-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
+        } else {
+            assert(false);
+        }
+
+        // solve the equation system to obtain the parameters b[]
+        m_b=A.lu_solve(rhs);
+
+        // calculate parameters a[] and c[] based on b[]
+        m_a.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=1.0/3.0*(m_b[i+1]-m_b[i])/(x[i+1]-x[i]);
+            m_c[i]=(y[i+1]-y[i])/(x[i+1]-x[i])
+                   - 1.0/3.0*(2.0*m_b[i]+m_b[i+1])*(x[i+1]-x[i]);
+        }
+    } else { // linear interpolation
+        m_a.resize(n);
+        m_b.resize(n);
+        m_c.resize(n);
+        for(int i=0; i<n-1; i++) {
+            m_a[i]=0.0;
+            m_b[i]=0.0;
+            m_c[i]=(m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
+        }
+    }
+
+    // for left extrapolation coefficients
+    m_b0 = (m_force_linear_extrapolation==false) ? m_b[0] : 0.0;
+    m_c0 = m_c[0];
+
+    // for the right extrapolation coefficients
+    // f_{n-1}(x) = b*(x-x_{n-1})^2 + c*(x-x_{n-1}) + y_{n-1}
+    double h=x[n-1]-x[n-2];
+    // m_b[n-1] is determined by the boundary condition
+    m_a[n-1]=0.0;
+    m_c[n-1]=3.0*m_a[n-2]*h*h+2.0*m_b[n-2]*h+m_c[n-2];   // = f'_{n-2}(x_{n-1})
+    if(m_force_linear_extrapolation==true)
+        m_b[n-1]=0.0;
+}
+
+double spline::operator() (double x) const
+{
+    size_t n=m_x.size();
+    // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
+    std::vector<double>::const_iterator it;
+    it=std::lower_bound(m_x.begin(),m_x.end(),x);
+    int idx=std::max( int(it-m_x.begin())-1, 0);
+
+    double h=x-m_x[idx];
+    double interpol;
+    if(x<m_x[0]) {
+        // extrapolation to the left
+        interpol=(m_b0*h + m_c0)*h + m_y[0];
+    } else if(x>m_x[n-1]) {
+        // extrapolation to the right
+        interpol=(m_b[n-1]*h + m_c[n-1])*h + m_y[n-1];
+    } else {
+        // interpolation
+        interpol=((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+    }
+    return interpol;
+}
+
+
+} // namespace tk
+
+
+} // namespace
+
+#endif /* TK_SPLINE_H */

--- a/unobstructed_lanechange/include/unobstructed_lanechange.h
+++ b/unobstructed_lanechange/include/unobstructed_lanechange.h
@@ -1,0 +1,121 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <math.h>
+#include <cav_msgs/TrajectoryPlan.h>
+#include <cav_msgs/TrajectoryPlanPoint.h>
+#include <cav_msgs/Plugin.h>
+// #include <autoware_msgs/Lane.h>
+#include <boost/shared_ptr.hpp>
+#include <carma_utils/CARMAUtils.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <cav_srvs/PlanTrajectory.h>
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+#include "spline.h"
+
+
+
+namespace unobstructed_lanechange
+{
+    class UnobstructedLaneChangePlugin
+    {
+        public:
+            
+            // Default constructor for UnobstructedLaneChangePlugin class
+            UnobstructedLaneChangePlugin();
+
+            // general starting point of this node
+            void run();
+
+            // postprocess traj to add plugin names and shift time origin to the current ROS time
+            std::vector<cav_msgs::TrajectoryPlanPoint> post_process_traj_points(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory);
+
+            /**
+                * \brief Given start and end points, create a continous lanechange trajectory
+                * \param start start point of lanechange
+                * \param end end point of lanechange
+                * \return vector of trajectory points
+            */
+            std::vector<cav_msgs::TrajectoryPlanPoint> create_lanechange_trajectory(std::vector<double> start, std::vector<double> end);
+
+            /**
+                * \brief Compose lane change trajectory given its input parameters
+                * \param start_id Lanechange starting point lanelet id
+                * \param start_downtrack Lanechange starting point downtrack
+                * \param end_id Lanechange ending point lanelet id
+                * \param end_downtrack Lanechange ending point downtrack
+                * \return vector of trajectory points
+            */
+            std::vector<cav_msgs::TrajectoryPlanPoint> compose_lanechange_trajectory(std::string start_id, double start_downtrack, std::string end_id, double end_downtrack);
+
+            /**
+                * \brief Given Lanelet id and downtrack, find the corresponding point coordinates on the lanelet's centerline
+                * \param lanelet_id Lanelet ID
+                * \param downtrack downtrack value
+                * \return Vector of x and y coordinates
+            */
+            std::vector<double> extract_point_from_lanelet(std::string lanelet_id, double downtrack);
+        
+        private:
+
+            
+            // node handles
+            std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
+
+
+            ros::Publisher ubobstructed_lanechange_plugin_discovery_pub_;
+
+            // service callbacks for carma trajectory planning
+            bool plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest &req, cav_srvs::PlanTrajectoryResponse &resp);
+
+            // ros service servers
+            ros::ServiceServer trajectory_srv_;
+            ros::ServiceServer maneuver_srv_;
+
+            // Plugin discovery message
+            cav_msgs::Plugin plugin_discovery_msg_;
+
+            // ROS params
+            double trajectory_time_length_;
+            double trajectory_point_spacing_;
+
+            // start vehicle speed
+            double start_speed_;
+            // target vehicle speed
+            double target_speed_;
+
+
+            int num_points = 60;
+
+            // initialize this node
+            void initialize();
+
+            // generated trajectory plan
+            cav_msgs::TrajectoryPlan trajectory_msg;
+
+            // wm listener pointer and pointer to the actual wm object
+            std::shared_ptr<carma_wm::WMListener> _wml{nullptr};
+            carma_wm::WorldModelConstPtr _wm;
+
+
+    
+    };
+}

--- a/unobstructed_lanechange/include/unobstructed_lanechange.h
+++ b/unobstructed_lanechange/include/unobstructed_lanechange.h
@@ -96,8 +96,8 @@ namespace unobstructed_lanechange
             double traj_freq = 10;
 
             // ROS params
-            double trajectory_time_length_;
-            std::string control_plugin_name_;
+            double trajectory_time_length_ = 6;
+            std::string control_plugin_name_ = "mpc_follower";
             
 
             // start vehicle speed

--- a/unobstructed_lanechange/include/unobstructed_lanechange.h
+++ b/unobstructed_lanechange/include/unobstructed_lanechange.h
@@ -63,7 +63,7 @@ namespace unobstructed_lanechange
                 * \param end_downtrack Lanechange ending point downtrack
                 * \return vector of trajectory points
             */
-            std::vector<cav_msgs::TrajectoryPlanPoint> compose_lanechange_trajectory(std::string start_id, double start_downtrack, std::string end_id, double end_downtrack);
+            std::vector<cav_msgs::TrajectoryPlanPoint> compose_lanechange_trajectory(const std::string& start_id, double start_downtrack, const std::string& end_id, double end_downtrack);
 
             /**
                 * \brief Given Lanelet id and downtrack, find the corresponding point coordinates on the lanelet's centerline
@@ -71,7 +71,7 @@ namespace unobstructed_lanechange
                 * \param downtrack downtrack value
                 * \return Vector of x and y coordinates
             */
-            std::vector<double> extract_point_from_lanelet(std::string lanelet_id, double downtrack);
+            std::vector<double> extract_point_from_lanelet(const std::string& lanelet_id, double downtrack);
         
         private:
 

--- a/unobstructed_lanechange/include/unobstructed_lanechange.h
+++ b/unobstructed_lanechange/include/unobstructed_lanechange.h
@@ -63,7 +63,7 @@ namespace unobstructed_lanechange
                 * \param end_downtrack Lanechange ending point downtrack
                 * \return vector of trajectory points
             */
-            std::vector<cav_msgs::TrajectoryPlanPoint> compose_lanechange_trajectory(const std::string& start_id, double start_downtrack, const std::string& end_id, double end_downtrack);
+            std::vector<cav_msgs::TrajectoryPlanPoint> compose_lanechange_trajectory(carma_wm::WorldModelConstPtr wm, const std::string& start_id, double start_downtrack, const std::string& end_id, double end_downtrack);
 
             /**
                 * \brief Given Lanelet id and downtrack, find the corresponding point coordinates on the lanelet's centerline
@@ -71,7 +71,7 @@ namespace unobstructed_lanechange
                 * \param downtrack downtrack value
                 * \return Vector of x and y coordinates
             */
-            std::vector<double> extract_point_from_lanelet(const std::string& lanelet_id, double downtrack);
+            std::vector<double> extract_point_from_lanelet(carma_wm::WorldModelConstPtr wm, const std::string& lanelet_id, double downtrack);
         
         private:
 

--- a/unobstructed_lanechange/include/unobstructed_lanechange.h
+++ b/unobstructed_lanechange/include/unobstructed_lanechange.h
@@ -21,7 +21,6 @@
 #include <cav_msgs/TrajectoryPlan.h>
 #include <cav_msgs/TrajectoryPlanPoint.h>
 #include <cav_msgs/Plugin.h>
-// #include <autoware_msgs/Lane.h>
 #include <boost/shared_ptr.hpp>
 #include <carma_utils/CARMAUtils.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -29,7 +28,7 @@
 #include <cav_srvs/PlanTrajectory.h>
 #include <carma_wm/WMListener.h>
 #include <carma_wm/WorldModel.h>
-#include "spline.h"
+#include "third_party_library/spline.h"
 
 
 
@@ -93,9 +92,13 @@ namespace unobstructed_lanechange
             // Plugin discovery message
             cav_msgs::Plugin plugin_discovery_msg_;
 
+            // trajectory frequency
+            double traj_freq = 10;
+
             // ROS params
             double trajectory_time_length_;
-            double trajectory_point_spacing_;
+            std::string control_plugin_name_;
+            
 
             // start vehicle speed
             double start_speed_;
@@ -103,7 +106,7 @@ namespace unobstructed_lanechange
             double target_speed_;
 
 
-            int num_points = 60;
+            int num_points = traj_freq * trajectory_time_length_;
 
             // initialize this node
             void initialize();

--- a/unobstructed_lanechange/launch/unobstructed_lanechange.launch
+++ b/unobstructed_lanechange/launch/unobstructed_lanechange.launch
@@ -1,0 +1,26 @@
+<!--
+
+  Copyright (C) 2018-2020 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+ 
+Primary launch file for driver shutdown node
+Loads parameters and configures logging for the node
+ 
+-->
+<launch>
+<!-- Driver Shutdown Node -->
+<node pkg="unobstructed_lanechange" type="unobstructed_lanechange" name="unobstructed_lanechange"/>
+</launch>

--- a/unobstructed_lanechange/launch/unobstructed_lanechange.launch
+++ b/unobstructed_lanechange/launch/unobstructed_lanechange.launch
@@ -22,5 +22,7 @@ Loads parameters and configures logging for the node
 -->
 <launch>
 <!-- Driver Shutdown Node -->
-<node pkg="unobstructed_lanechange" type="unobstructed_lanechange" name="unobstructed_lanechange"/>
+<node pkg="unobstructed_lanechange" type="unobstructed_lanechange" name="unobstructed_lanechange">
+        <rosparam command="load" file="$(find unobstructed_lanechange)/config/parameters.yaml" />
+    </node>
 </launch>

--- a/unobstructed_lanechange/package.xml
+++ b/unobstructed_lanechange/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>unobstructed_lanechange</name>
+  <version>3.3.0</version>
+  <description>The node is to plan an unobstructed lane change trajectory</description>
+  <maintainer email="CARMA@dot.gov">carma</maintainer>
+  <license>Apache 2.0 License</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>carma_utils</depend>
+  <depend>cav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>carma_wm</depend>
+</package>

--- a/unobstructed_lanechange/src/main.cpp
+++ b/unobstructed_lanechange/src/main.cpp
@@ -1,0 +1,11 @@
+
+#include <ros/ros.h>
+#include "unobstructed_lanechange.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "unobstructed_lanechange");
+    unobstructed_lanechange::UnobstructedLaneChangePlugin node;
+    node.run();
+    return 0;
+};

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -22,9 +22,8 @@
 
 namespace unobstructed_lanechange
 {
-    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin():
-                                    trajectory_time_length_(6.0),
-                                    control_plugin_name_("mpc_follower") {}
+    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin(){}
+    
 
     void UnobstructedLaneChangePlugin::initialize()
     {
@@ -42,7 +41,7 @@ namespace unobstructed_lanechange
         plugin_discovery_msg_.capability = "tactical_plan/plan_trajectory";
         
         pnh_->param<double>("trajectory_time_length", trajectory_time_length_, 6.0);
-        pnh_->param<std::string>("control_plugin_name", control_plugin_name_, "NULL");
+        pnh_->param<std::string>("control_plugin_name", control_plugin_name_, "mpc_follower");
 
         ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
             ubobstructed_lanechange_plugin_discovery_pub_.publish(plugin_discovery_msg_);
@@ -88,7 +87,7 @@ namespace unobstructed_lanechange
     }
 
 
-    std::vector<cav_msgs::TrajectoryPlanPoint> UnobstructedLaneChangePlugin::compose_lanechange_trajectory(std::string start_id, double start_downtrack, std::string end_id, double end_downtrack){
+    std::vector<cav_msgs::TrajectoryPlanPoint> UnobstructedLaneChangePlugin::compose_lanechange_trajectory(const std::string& start_id, double start_downtrack, const std::string& end_id, double end_downtrack){
         std::vector<double> start_point = extract_point_from_lanelet(start_id, start_downtrack);
         std::vector<double> end_point = extract_point_from_lanelet(end_id, end_downtrack);
         std::vector<cav_msgs::TrajectoryPlanPoint> tmp_trajectory = create_lanechange_trajectory(start_point, end_point);
@@ -184,7 +183,7 @@ namespace unobstructed_lanechange
     }
     
 
-    std::vector<double> UnobstructedLaneChangePlugin::extract_point_from_lanelet(std::string lanelet_id, double downtrack){
+    std::vector<double> UnobstructedLaneChangePlugin::extract_point_from_lanelet(const std::string& lanelet_id, double downtrack){
 
         std::vector<double> point;
         auto shortest_path = _wm->getRoute()->shortestPath();

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -22,7 +22,9 @@
 
 namespace unobstructed_lanechange
 {
-    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin(){}
+    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin():
+                                    trajectory_time_length_(6.0),
+                                    control_plugin_name_("mpc_follower") {}
 
     void UnobstructedLaneChangePlugin::initialize()
     {
@@ -40,7 +42,7 @@ namespace unobstructed_lanechange
         plugin_discovery_msg_.capability = "tactical_plan/plan_trajectory";
         
         pnh_->param<double>("trajectory_time_length", trajectory_time_length_, 6.0);
-        pnh_->param<double>("trajectory_point_spacing", trajectory_point_spacing_, 0.1);
+        pnh_->param<std::string>("control_plugin_name", control_plugin_name_, "NULL");
 
         ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
             ubobstructed_lanechange_plugin_discovery_pub_.publish(plugin_discovery_msg_);
@@ -173,7 +175,7 @@ namespace unobstructed_lanechange
         uint64_t current_nsec = ros::Time::now().toNSec();
         for(int i = 0; i < trajectory.size(); ++i)
         {
-            trajectory[i].controller_plugin_name = "mpc_follower";
+            trajectory[i].controller_plugin_name = control_plugin_name_;
             trajectory[i].planner_plugin_name = "unobstructed_lanechange";
             trajectory[i].target_time += current_nsec;
         }

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -22,8 +22,11 @@
 
 namespace unobstructed_lanechange
 {
-    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin(){}
-    
+    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin():
+                                    start_speed_(5.0),
+                                    target_speed_(6.0),
+                                    trajectory_time_length_(6.0),
+                                    control_plugin_name_("mpc_follower") {}
 
     void UnobstructedLaneChangePlugin::initialize()
     {
@@ -41,7 +44,7 @@ namespace unobstructed_lanechange
         plugin_discovery_msg_.capability = "tactical_plan/plan_trajectory";
         
         pnh_->param<double>("trajectory_time_length", trajectory_time_length_, 6.0);
-        pnh_->param<std::string>("control_plugin_name", control_plugin_name_, "mpc_follower");
+        pnh_->param<std::string>("control_plugin_name", control_plugin_name_, "NULL");
 
         ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
             ubobstructed_lanechange_plugin_discovery_pub_.publish(plugin_discovery_msg_);

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -1,0 +1,222 @@
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <ros/ros.h>
+#include <string>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "unobstructed_lanechange.h"
+
+namespace unobstructed_lanechange
+{
+    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin(){}
+
+    void UnobstructedLaneChangePlugin::initialize()
+    {
+        nh_.reset(new ros::CARMANodeHandle());
+        pnh_.reset(new ros::CARMANodeHandle("~"));
+        
+        trajectory_srv_ = nh_->advertiseService("plugins/UnobstructedLaneChangePlugin/plan_trajectory", &UnobstructedLaneChangePlugin::plan_trajectory_cb, this);
+                
+        ubobstructed_lanechange_plugin_discovery_pub_ = nh_->advertise<cav_msgs::Plugin>("plugin_discovery", 1);
+        plugin_discovery_msg_.name = "UnobstructedLaneChangePlugin";
+        plugin_discovery_msg_.versionId = "v1.0";
+        plugin_discovery_msg_.available = true;
+        plugin_discovery_msg_.activated = false;
+        plugin_discovery_msg_.type = cav_msgs::Plugin::TACTICAL;
+        plugin_discovery_msg_.capability = "tactical_plan/plan_trajectory";
+        
+        pnh_->param<double>("trajectory_time_length", trajectory_time_length_, 6.0);
+        pnh_->param<double>("trajectory_point_spacing", trajectory_point_spacing_, 0.1);
+
+        ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
+            ubobstructed_lanechange_plugin_discovery_pub_.publish(plugin_discovery_msg_);
+            return true;
+        });
+
+        _wml.reset(new carma_wm::WMListener());
+        _wm = _wml->getWorldModel();
+
+    }
+
+    void UnobstructedLaneChangePlugin::run()
+    {
+    	initialize();
+        ros::CARMANodeHandle::setSpinRate(10.0);
+        ros::CARMANodeHandle::spin();
+
+    }
+
+    bool UnobstructedLaneChangePlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest &req, cav_srvs::PlanTrajectoryResponse &resp){
+        
+        cav_msgs::Maneuver maneuver_msg = req.maneuver_plan.maneuvers[0];
+        std::string start_lanelet_id = maneuver_msg.lane_change_maneuver.starting_lane_id;
+        double start_downtrack = maneuver_msg.lane_change_maneuver.start_dist;
+        start_speed_ = maneuver_msg.lane_change_maneuver.start_speed;
+        
+        std::string end_lanelet_id = maneuver_msg.lane_change_maneuver.ending_lane_id;
+        double end_downtrack = maneuver_msg.lane_change_maneuver.end_dist;
+        target_speed_ = maneuver_msg.lane_change_maneuver.end_speed;
+
+
+        cav_msgs::TrajectoryPlan trajectory;
+        
+        trajectory.header.stamp = ros::Time::now();
+        trajectory.trajectory_id = boost::uuids::to_string(boost::uuids::random_generator()());
+        trajectory.trajectory_points = compose_lanechange_trajectory(start_lanelet_id, start_downtrack, end_lanelet_id, end_downtrack);
+
+        resp.trajectory_plan = trajectory;
+        resp.related_maneuvers.push_back(cav_msgs::Maneuver::LANE_CHANGE);
+        resp.maneuver_status.push_back(cav_srvs::PlanTrajectory::Response::MANEUVER_IN_PROGRESS);
+
+        return true;
+    }
+
+
+    std::vector<cav_msgs::TrajectoryPlanPoint> UnobstructedLaneChangePlugin::compose_lanechange_trajectory(std::string start_id, double start_downtrack, std::string end_id, double end_downtrack){
+        std::vector<double> start_point = extract_point_from_lanelet(start_id, start_downtrack);
+        std::vector<double> end_point = extract_point_from_lanelet(end_id, end_downtrack);
+        std::vector<cav_msgs::TrajectoryPlanPoint> tmp_trajectory = create_lanechange_trajectory(start_point, end_point);
+        std::vector<cav_msgs::TrajectoryPlanPoint> final_trajectory = post_process_traj_points(tmp_trajectory);
+        return final_trajectory;
+    }
+    
+
+    std::vector<cav_msgs::TrajectoryPlanPoint> UnobstructedLaneChangePlugin::create_lanechange_trajectory(std::vector<double> start, std::vector<double> end){
+        
+        tk::spline spl;
+        
+        std::vector<cav_msgs::TrajectoryPlanPoint> lc_trajectory;
+
+        // define spline points
+        std::vector<double> ptsx;
+        ptsx.push_back(start[0]);
+        ptsx.push_back((start[0]+end[0])/2);
+        ptsx.push_back(end[0]);
+
+        std::vector<double> ptsy;
+        ptsy.push_back(start[1]);
+        ptsy.push_back((start[1]+end[1])/2);
+        ptsy.push_back(end[1]);
+
+        if (ptsx.size()<3 || ptsy.size()<3){
+            throw std::invalid_argument("Insufficient Spline Points");
+        }
+
+        // set spline points
+        spl.set_points(ptsx, ptsy);
+
+        // Calculate how to break up spline points so that we travel at our desired reference velocity
+        double target_x = end[0];
+        double start_x = start[0];
+        double target_y = spl(target_x);
+        double delta_v = (target_speed_ - start_speed_)/num_points;
+        double delta_x = (target_x - start_x)/num_points;
+
+
+
+        cav_msgs::TrajectoryPlanPoint start_point;
+        start_point.x = start[0];
+        start_point.y = start[1];
+        start_point.target_time = 0.0;
+        lc_trajectory.push_back(start_point);
+
+        
+        
+        
+        double prev_x = start[0];
+        double prev_y = start[1];
+        double prev_t = 0.0;
+        double prev_v = start_speed_;
+
+        for (int i=1; i< num_points ; i++){
+            double v_point = prev_v + delta_v;
+            double x_point = prev_x + delta_x;
+            double y_point = spl(x_point);
+            double dist = sqrt(pow(x_point-prev_x,2) + pow(y_point-prev_y,2));
+            double t_point = dist/v_point + prev_t;
+
+            cav_msgs::TrajectoryPlanPoint traj_point;
+        
+            traj_point.x = x_point;
+            traj_point.y = y_point;
+            traj_point.target_time = t_point;
+
+            lc_trajectory.push_back(traj_point);
+
+            prev_x = x_point;
+            prev_y = y_point;
+            prev_v = v_point;
+            prev_t = t_point;
+
+        }
+
+        return lc_trajectory;
+
+    }
+
+    std::vector<cav_msgs::TrajectoryPlanPoint> UnobstructedLaneChangePlugin::post_process_traj_points(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory)
+    {
+        uint64_t current_nsec = ros::Time::now().toNSec();
+        for(int i = 0; i < trajectory.size(); ++i)
+        {
+            trajectory[i].controller_plugin_name = "mpc_follower";
+            trajectory[i].planner_plugin_name = "unobstructed_lanechange";
+            trajectory[i].target_time += current_nsec;
+        }
+
+        return trajectory;
+    }
+    
+
+    std::vector<double> UnobstructedLaneChangePlugin::extract_point_from_lanelet(std::string lanelet_id, double downtrack){
+
+        std::vector<double> point;
+        auto shortest_path = _wm->getRoute()->shortestPath();
+        std::vector<lanelet::ConstLanelet> tmp;
+        lanelet::ConstLanelet start_lanelet;
+
+        int lanelet_id_ = std::stoi(lanelet_id);
+
+        if(lanelet_id_ == -1)
+        {
+            throw std::invalid_argument("Invalid Lanelet ID");
+        }
+
+        for (lanelet::ConstLanelet l : shortest_path) {
+            if (l.id()==lanelet_id_) start_lanelet = l;
+        }
+
+        for (auto centerline_point:start_lanelet.centerline2d()){
+            double dt = _wm->routeTrackPos(centerline_point).downtrack;
+            if (dt - downtrack <= 1.0){
+                double px = centerline_point.x();
+                double py = centerline_point.y();
+                point.push_back(px);
+                point.push_back(py);
+            }
+        }
+
+        if(point.size() < 2)
+        {
+            throw std::invalid_argument("Invalid Downtrack Value");
+        }
+
+        return point;
+
+    }
+
+}

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -123,7 +123,6 @@ namespace unobstructed_lanechange
         // Calculate how to break up spline points so that we travel at our desired reference velocity
         double target_x = end[0];
         double start_x = start[0];
-        double target_y = spl(target_x);
         double delta_v = (target_speed_ - start_speed_)/num_points;
         double delta_x = (target_x - start_x)/num_points;
 

--- a/unobstructed_lanechange/src/unobstructed_lanechange.cpp
+++ b/unobstructed_lanechange/src/unobstructed_lanechange.cpp
@@ -22,11 +22,8 @@
 
 namespace unobstructed_lanechange
 {
-    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin():
-                                    start_speed_(5.0),
-                                    target_speed_(6.0),
-                                    trajectory_time_length_(6.0),
-                                    control_plugin_name_("mpc_follower") {}
+    UnobstructedLaneChangePlugin::UnobstructedLaneChangePlugin(){}
+                                    
 
     void UnobstructedLaneChangePlugin::initialize()
     {

--- a/unobstructed_lanechange/test/TestHelpers.h
+++ b/unobstructed_lanechange/test/TestHelpers.h
@@ -1,0 +1,162 @@
+#pragma once
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gmock/gmock.h>
+#include <iostream>
+#include <carma_wm/CARMAWorldModel.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+#include <lanelet2_core/Attribute.h>
+
+/**
+ * Helper file containing inline functions used to quickly build lanelet objects in unit tests
+ *
+ */
+namespace carma_wm
+{
+inline lanelet::Point3d getPoint(double x, double y, double z)
+{
+  return lanelet::Point3d(lanelet::utils::getId(), x, y, z);
+}
+
+inline lanelet::BasicPoint3d getBasicPoint(double x, double y, double z)
+{
+  return getPoint(x, y, z).basicPoint();
+}
+
+inline lanelet::BasicPoint2d getBasicPoint(double x, double y)
+{
+  return lanelet::utils::to2D(getPoint(x, y, 0.0)).basicPoint();
+}
+
+// Defaults to double solid line on left and double solid line on right
+inline lanelet::Lanelet getLanelet(lanelet::LineString3d& left_ls, lanelet::LineString3d& right_ls,
+                                   const lanelet::Attribute& left_sub_type = lanelet::AttributeValueString::SolidSolid,
+                                   const lanelet::Attribute& right_sub_type = lanelet::AttributeValueString::Solid)
+{
+  left_ls.attributes()[lanelet::AttributeName::Type] = lanelet::AttributeValueString::LineThin;
+  left_ls.attributes()[lanelet::AttributeName::Subtype] = left_sub_type;
+
+  right_ls.attributes()[lanelet::AttributeName::Type] = lanelet::AttributeValueString::LineThin;
+  right_ls.attributes()[lanelet::AttributeName::Subtype] = right_sub_type;
+
+  lanelet::Lanelet ll;
+  ll.setId(lanelet::utils::getId());
+  ll.setLeftBound(left_ls);
+  ll.setRightBound(right_ls);
+
+  ll.attributes()[lanelet::AttributeName::Type] = lanelet::AttributeValueString::Lanelet;
+  ll.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
+  ll.attributes()[lanelet::AttributeName::Location] = lanelet::AttributeValueString::Urban;
+  ll.attributes()[lanelet::AttributeName::OneWay] = "yes";
+  ll.attributes()[lanelet::AttributeName::Dynamic] = "no";
+
+  return ll;
+}
+
+inline lanelet::Lanelet getLanelet(std::vector<lanelet::Point3d> left, std::vector<lanelet::Point3d> right,
+                                   const lanelet::Attribute& left_sub_type = lanelet::AttributeValueString::SolidSolid,
+                                   const lanelet::Attribute& right_sub_type = lanelet::AttributeValueString::Solid)
+{
+  lanelet::LineString3d left_ls(lanelet::utils::getId(), left);
+
+  lanelet::LineString3d right_ls(lanelet::utils::getId(), right);
+
+  return getLanelet(left_ls, right_ls, left_sub_type, right_sub_type);
+}
+
+inline void addStraightRoute(CARMAWorldModel& cmw)
+{
+  // 1. Construct map
+  auto pl1 = getPoint(0, 0, 0);
+  auto pl2 = getPoint(0, 1, 0);
+  auto pl3 = getPoint(0, 2, 0);
+  auto pr1 = getPoint(1, 0, 0);
+  auto pr2 = getPoint(1, 1, 0);
+  auto pr3 = getPoint(1, 2, 0);
+  std::vector<lanelet::Point3d> left_1 = { pl1, pl2 };
+  std::vector<lanelet::Point3d> right_1 = { pr1, pr2 };
+  auto ll_1 = getLanelet(left_1, right_1);
+
+  std::vector<lanelet::Point3d> left_2 = { pl2, pl3 };
+  std::vector<lanelet::Point3d> right_2 = { pr2, pr3 };
+  auto ll_2 = getLanelet(left_2, right_2);
+
+  // 2. Build map but do not assign
+  // Create basic map and verify that the map and routing graph can be build, but the route remains false
+  lanelet::LaneletMapPtr map = lanelet::utils::createMap({ ll_1, ll_2 }, {});
+
+  // 3. Build routing graph but do not assign
+  // Build routing graph from map
+  lanelet::traffic_rules::TrafficRulesUPtr traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+      lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
+  lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
+
+  // 4. Generate route
+  auto optional_route = map_graph->getRoute(ll_1, ll_2);
+  lanelet::routing::Route route = std::move(*optional_route);
+  LaneletRoutePtr route_ptr = std::make_shared<lanelet::routing::Route>(std::move(route));
+  // 5. Set route and map
+  cmw.setRoute(route_ptr);
+  cmw.setMap(map);
+}
+
+inline void addDisjointRoute(CARMAWorldModel& cmw)
+{
+  // 1. Construct map
+  auto p1 = getPoint(0, 0, 0);
+  auto p2 = getPoint(0, 1, 0);
+  auto p3 = getPoint(1, 1, 0);
+  auto p4 = getPoint(1, 2, 0);
+  auto p5 = getPoint(1, 0, 0);
+  auto p6 = getPoint(2, 0, 0);
+  auto p7 = getPoint(2, 1, 0);
+  auto p8 = getPoint(2, 2, 0);
+  lanelet::LineString3d left_ls_1(lanelet::utils::getId(), { p1, p2 });
+  lanelet::LineString3d right_ls_1(lanelet::utils::getId(), { p5, p3 });
+  auto ll_1 = getLanelet(left_ls_1, right_ls_1, lanelet::AttributeValueString::SolidSolid,
+                         lanelet::AttributeValueString::Dashed);
+
+  lanelet::LineString3d right_ls_2(lanelet::utils::getId(), { p6, p7 });
+  auto ll_2 =
+      getLanelet(right_ls_1, right_ls_2, lanelet::AttributeValueString::Dashed, lanelet::AttributeValueString::Solid);
+
+  lanelet::LineString3d left_ls_3(lanelet::utils::getId(), { p3, p4 });
+  lanelet::LineString3d right_ls_3(lanelet::utils::getId(), { p7, p8 });
+  auto ll_3 =
+      getLanelet(left_ls_3, right_ls_3, lanelet::AttributeValueString::Solid, lanelet::AttributeValueString::Solid);
+
+  // 2. Build map but do not assign
+  // Create basic map and verify that the map and routing graph can be build, but the route remains false
+  lanelet::LaneletMapPtr map = lanelet::utils::createMap({ ll_1, ll_2, ll_3 }, {});
+
+  // 3. Build routing graph but do not assign
+  // Build routing graph from map
+  lanelet::traffic_rules::TrafficRulesUPtr traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+      lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
+  lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
+
+  // 4. Generate route
+  auto optional_route = map_graph->getRoute(ll_1, ll_3);
+  // map_graph->exportGraphViz("my_graph"); // Uncomment to visualize route graph
+  lanelet::routing::Route route = std::move(*optional_route);
+  LaneletRoutePtr route_ptr = std::make_shared<lanelet::routing::Route>(std::move(route));
+  // 5. Set route and map
+  cmw.setRoute(route_ptr);
+  cmw.setMap(map);
+}
+}  // namespace carma_wm

--- a/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
+++ b/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "unobstructed_lanechange.h"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+
+
+TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
+{
+    std::vector<double> start_point = {0.0, 0.0};
+    std::vector<double> end_point = {10.0, 3.0};
+    unobstructed_lanechange::UnobstructedLaneChangePlugin lc;
+    std::vector<cav_msgs::TrajectoryPlanPoint> res = lc.create_lanechange_trajectory(start_point, end_point);
+    EXPECT_EQ(60, res.size());
+    EXPECT_NEAR(5.0, res[30].x, 0.01);
+    EXPECT_NEAR(1.5, res[30].y, 0.01);
+}
+
+
+// Run all the tests
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
+++ b/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
@@ -38,7 +38,6 @@ TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
     EXPECT_NEAR(2.25, res[45].y, 0.05);
     EXPECT_NEAR(9.85, res[59].x, 0.05);
     EXPECT_NEAR(2.95, res[59].y, 0.05);
-    EXPECT_NEAR(1.0, res[59].target_time, 0.01);
 }
 
 

--- a/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
+++ b/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
@@ -27,6 +27,7 @@ TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
     unobstructed_lanechange::UnobstructedLaneChangePlugin lc;
     std::vector<cav_msgs::TrajectoryPlanPoint> res = lc.create_lanechange_trajectory(start_point, end_point);
     EXPECT_EQ(60, res.size());
+    EXPECT_NEAR(0.0, res[0].target_time, 0.01);
     EXPECT_NEAR(0.0, res[0].x, 0.05);
     EXPECT_NEAR(0.0, res[0].y, 0.05);
     EXPECT_NEAR(2.5, res[15].x, 0.05);
@@ -37,6 +38,7 @@ TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
     EXPECT_NEAR(2.25, res[45].y, 0.05);
     EXPECT_NEAR(9.85, res[59].x, 0.05);
     EXPECT_NEAR(2.95, res[59].y, 0.05);
+    EXPECT_NEAR(1.0, res[59].target_time, 0.01);
 }
 
 

--- a/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
+++ b/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
@@ -27,8 +27,16 @@ TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
     unobstructed_lanechange::UnobstructedLaneChangePlugin lc;
     std::vector<cav_msgs::TrajectoryPlanPoint> res = lc.create_lanechange_trajectory(start_point, end_point);
     EXPECT_EQ(60, res.size());
-    EXPECT_NEAR(5.0, res[30].x, 0.01);
-    EXPECT_NEAR(1.5, res[30].y, 0.01);
+    EXPECT_NEAR(0.0, res[0].x, 0.05);
+    EXPECT_NEAR(0.0, res[0].y, 0.05);
+    EXPECT_NEAR(2.5, res[15].x, 0.05);
+    EXPECT_NEAR(0.75, res[15].y, 0.05);
+    EXPECT_NEAR(5.0, res[30].x, 0.05);
+    EXPECT_NEAR(1.5, res[30].y, 0.05);
+    EXPECT_NEAR(7.5, res[45].x, 0.05);
+    EXPECT_NEAR(2.25, res[45].y, 0.05);
+    EXPECT_NEAR(9.85, res[59].x, 0.05);
+    EXPECT_NEAR(2.95, res[59].y, 0.05);
 }
 
 

--- a/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
+++ b/unobstructed_lanechange/test/test_unobstructed_lanechange_plugin.cpp
@@ -17,6 +17,13 @@
 #include "unobstructed_lanechange.h"
 #include <gtest/gtest.h>
 #include <ros/ros.h>
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+#include <carma_wm/CARMAWorldModel.h>
+#include "TestHelpers.h"
+
+
+
 
 
 
@@ -39,6 +46,88 @@ TEST(UnobstructedLaneChangePluginTest, testCreateLaneChangeTrajectory1)
     EXPECT_NEAR(9.85, res[59].x, 0.05);
     EXPECT_NEAR(2.95, res[59].y, 0.05);
 }
+
+
+
+
+
+
+TEST(UnobstructedLaneChangePluginTest, testextract1)
+{
+    std::shared_ptr<carma_wm::CARMAWorldModel> cmw = std::make_shared<carma_wm::CARMAWorldModel>();
+
+    auto pl1 = carma_wm::getPoint(0, 0, 0);
+    auto pl2 = carma_wm::getPoint(0, 1, 0);
+    auto pl3 = carma_wm::getPoint(0, 2, 0);
+    auto pr1 = carma_wm::getPoint(1, 0, 0);
+    auto pr2 = carma_wm::getPoint(1, 1, 0);
+    auto pr3 = carma_wm::getPoint(1, 2, 0);
+
+    std::vector<lanelet::Point3d> left_1 = { pl1, pl2 };
+    std::vector<lanelet::Point3d> right_1 = { pr1, pr2 };
+    auto ll_1 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidSolid, lanelet::AttributeValueString::Dashed);
+
+    std::vector<lanelet::Point3d> left_2 = { pl2, pl3 };
+    std::vector<lanelet::Point3d> right_2 = { pr2, pr3 };
+    auto ll_2 = carma_wm::getLanelet(left_2, right_2);
+
+    // 1. Confirm all pointers are false (done above)
+    // Ensure that none of the returned pointers are valid if the map has not been set
+    ASSERT_FALSE((bool)cmw->getMap());
+    ASSERT_FALSE((bool)cmw->getRoute());
+    ASSERT_FALSE((bool)cmw->getMapRoutingGraph());
+
+    // 2. Build map but do not assign
+    // Create basic map and verify that the map and routing graph can be build, but the route remains false
+    lanelet::LaneletMapPtr map = lanelet::utils::createMap({ ll_1, ll_2 }, {});
+    // 3. Build routing graph but do not assign
+    // Build routing graph from map
+    lanelet::traffic_rules::TrafficRulesUPtr traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
+    lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
+
+    // 4. Generate route
+    auto optional_route = map_graph->getRoute(ll_1, ll_2);
+    ASSERT_TRUE((bool)optional_route);
+
+    lanelet::routing::Route route = std::move(*optional_route);
+    carma_wm::LaneletRoutePtr route_ptr = std::make_shared<lanelet::routing::Route>(std::move(route));
+    // 5. Try to set route without map and ensure it passes
+    cmw->setRoute(route_ptr);
+    // 6. getRoute is true but other pointers are false
+    ASSERT_FALSE((bool)cmw->getMap());
+    ASSERT_TRUE((bool)cmw->getRoute());
+    ASSERT_FALSE((bool)cmw->getMapRoutingGraph());
+
+    cmw->setMap(map);
+    // 8. All pointers exist
+    ASSERT_TRUE((bool)cmw->getMap());
+    ASSERT_TRUE((bool)cmw->getRoute());
+    ASSERT_TRUE((bool)cmw->getMapRoutingGraph());
+    // 9. Call setRoute again to confirm no errors
+    cmw->setRoute(route_ptr);
+    // 10. All pointers exist
+    ASSERT_TRUE((bool)cmw->getMap());
+    ASSERT_TRUE((bool)cmw->getRoute());
+    ASSERT_TRUE((bool)cmw->getMapRoutingGraph());
+
+    auto id = cmw->getRoute()->shortestPath()[0].id();
+
+
+    std::string id_ = std::to_string(id);
+    double dt_ = 1;
+    unobstructed_lanechange::UnobstructedLaneChangePlugin lc;
+    std::vector<double> res = lc.extract_point_from_lanelet(cmw, id_, dt_);
+    
+    
+
+    EXPECT_EQ(2, res.size());
+    EXPECT_NEAR(0.5, res[0], 0.05);
+    EXPECT_NEAR(0, res[1], 0.05);
+}
+
+
+
 
 
 // Run all the tests


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Adds the unobstructed lane-change capability to CARMA. This feature is based on the CARMA new routing feature and generates trajectory directly using the lanelet's information. Spline library is used to ensure the continuity of the generated trajectory. 

## Related Issue
#710 

## Motivation and Context
This feature allows the vehicle to change the lane when requested by the routing plugin.
## How Has This Been Tested?
This code has beem unit tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
