### PR TITLE
Fix checkout.bash for integration/routing branch

### DIFF
--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -94,6 +94,11 @@ void WMListenerWorker::roadwayObjectListCallback(const cav_msgs::RoadwayObstacle
 
 void WMListenerWorker::routeCallback(const cav_msgs::RouteConstPtr& route_msg)
 {
+  if (!world_model_->getMap()) {
+    ROS_ERROR_STREAM("WMListener received a route before a map was available. Dropping route message.");
+    return;
+  }
+
   auto path = lanelet::ConstLanelets();
   for(auto id : route_msg->shortest_path_lanelet_ids)
   {

--- a/carma_wm/test/WMListenerWorkerTest.cpp
+++ b/carma_wm/test/WMListenerWorkerTest.cpp
@@ -122,16 +122,13 @@ TEST(WMListenerWorkerTest, routeCallback)
   ///// Test with user defined route callback
   wmlw.setRouteCallback([&flag]() { flag = true; });
 
-  std::cerr << "C" << std::endl;
   wmlw.routeCallback(rpt);
 
   ASSERT_TRUE(flag);
-  std::cerr << "B" << std::endl;
 }
 
 TEST(WMListenerWorkerTest, mapUpdateCallback)
 {
-  std::cerr << "A" << std::endl;
   // build the geofence msg to test the mapUpdateCallback
   using namespace lanelet::units::literals;
   // add a lanelet
@@ -139,7 +136,6 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   auto p2 = getPoint(0, 1, 0);
   auto p3 = getPoint(1, 1, 0);
   auto p4 = getPoint(1, 0, 0);
-  std::cerr << "1" << std::endl;
   lanelet::LineString3d left_ls_1(lanelet::utils::getId(), { p1, p2 });
   lanelet::LineString3d right_ls_1(lanelet::utils::getId(), { p4, p3 });
 
@@ -155,7 +151,6 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   // Create the geofence object
   auto gf_ptr = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl());
   gf_ptr->id_ = boost::uuids::random_generator()();
-std::cerr << "2" << std::endl;
   gf_ptr->remove_list_.push_back(std::make_pair(ll_1.id(), speed_limit_old));
   gf_ptr->update_list_.push_back(std::make_pair(ll_1.id(), speed_limit_new));
 
@@ -164,7 +159,6 @@ std::cerr << "2" << std::endl;
   auto received_data = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl(gf_ptr->id_, gf_ptr->update_list_, gf_ptr->remove_list_));
   carma_wm::toBinMsg(received_data, &gf_obj_msg);
 
-  std::cerr << "3" << std::endl;
   // create a listener
   WMListenerWorker wmlw; 
   // create basic map
@@ -175,7 +169,6 @@ std::cerr << "2" << std::endl;
   autoware_lanelet2_msgs::MapBinConstPtr map_msg_ptr(new autoware_lanelet2_msgs::MapBin(map_msg));
   wmlw.mapCallback(map_msg_ptr);
 
-std::cerr << "4" << std::endl;
   // make sure it had old speed limit before
   auto regems = wmlw.getWorldModel()->getMap()->laneletLayer.get(ll_1.id()).regulatoryElements();
   ASSERT_EQ(regems.size(), 1);
@@ -206,7 +199,6 @@ std::cerr << "4" << std::endl;
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data).size(), 0);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(speed_limit_old).size(), 0);
 
-std::cerr << "5" << std::endl;
   // now the change should be reversable
   gf_ptr->update_list_ = {};
   gf_ptr->remove_list_ = {};
@@ -231,13 +223,11 @@ std::cerr << "5" << std::endl;
   ASSERT_NE(wmlw.getWorldModel()->getMap()->regulatoryElementLayer.find(speed_limit_old->id()), 
             wmlw.getWorldModel()->getMap()->regulatoryElementLayer.end());
 
-  std::cerr << "6" << std::endl;
   // old_speed_limit's data is also stored at a different address from the one we created locally because
   // we serialized the whole map and deserialized before setting the map.
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->regulatoryElementLayer.get(speed_limit_old->id()), regem_old_correct_data);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data).size(), 1);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data)[0].id(), ll_1.id());
-  std::cerr << "7" << std::endl;
 }
 
 

--- a/carma_wm/test/WMListenerWorkerTest.cpp
+++ b/carma_wm/test/WMListenerWorkerTest.cpp
@@ -83,13 +83,37 @@ TEST(WMListenerWorkerTest, mapCallback)
 TEST(WMListenerWorkerTest, routeCallback)
 {
   WMListenerWorker wmlw;
+
+  CARMAWorldModel cwm;
+
+  addStraightRoute(cwm);
+
+  ASSERT_TRUE((bool)cwm.getMap());
+  ASSERT_TRUE((bool)cwm.getRoute());
+  ASSERT_TRUE((bool)cwm.getMapRoutingGraph());
+
+  auto map_ptr = lanelet::utils::removeConst(cwm.getMap());
+
+  autoware_lanelet2_msgs::MapBin msg;
+  lanelet::utils::conversion::toBinMsg(map_ptr, &msg);
+
+  autoware_lanelet2_msgs::MapBinConstPtr map_msg_ptr(new autoware_lanelet2_msgs::MapBin(msg));
+
   cav_msgs::Route route_msg;
-  route_msg.shortest_path_lanelet_ids.push_back(130);
-  route_msg.shortest_path_lanelet_ids.push_back(111);
+  route_msg.shortest_path_lanelet_ids.push_back(cwm.getRoute()->shortestPath()[0].id());
+  route_msg.shortest_path_lanelet_ids.push_back(cwm.getRoute()->shortestPath()[1].id());
   cav_msgs::RouteConstPtr rpt(new cav_msgs::Route(route_msg));
 
+  //// Test route callback without map to verify no crash
+  wmlw.routeCallback(rpt);
+
+  wmlw.mapCallback(map_msg_ptr);
+
+  ///// Test without user defined route callback
+  wmlw.routeCallback(rpt);
+
   bool flag = false;
-  
+
   ///// Test without user defined route callback
   wmlw.routeCallback(rpt);
 
@@ -98,13 +122,16 @@ TEST(WMListenerWorkerTest, routeCallback)
   ///// Test with user defined route callback
   wmlw.setRouteCallback([&flag]() { flag = true; });
 
+  std::cerr << "C" << std::endl;
   wmlw.routeCallback(rpt);
 
   ASSERT_TRUE(flag);
+  std::cerr << "B" << std::endl;
 }
 
 TEST(WMListenerWorkerTest, mapUpdateCallback)
 {
+  std::cerr << "A" << std::endl;
   // build the geofence msg to test the mapUpdateCallback
   using namespace lanelet::units::literals;
   // add a lanelet
@@ -112,7 +139,7 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   auto p2 = getPoint(0, 1, 0);
   auto p3 = getPoint(1, 1, 0);
   auto p4 = getPoint(1, 0, 0);
-
+  std::cerr << "1" << std::endl;
   lanelet::LineString3d left_ls_1(lanelet::utils::getId(), { p1, p2 });
   lanelet::LineString3d right_ls_1(lanelet::utils::getId(), { p4, p3 });
 
@@ -128,7 +155,7 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   // Create the geofence object
   auto gf_ptr = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl());
   gf_ptr->id_ = boost::uuids::random_generator()();
-
+std::cerr << "2" << std::endl;
   gf_ptr->remove_list_.push_back(std::make_pair(ll_1.id(), speed_limit_old));
   gf_ptr->update_list_.push_back(std::make_pair(ll_1.id(), speed_limit_new));
 
@@ -137,6 +164,7 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   auto received_data = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl(gf_ptr->id_, gf_ptr->update_list_, gf_ptr->remove_list_));
   carma_wm::toBinMsg(received_data, &gf_obj_msg);
 
+  std::cerr << "3" << std::endl;
   // create a listener
   WMListenerWorker wmlw; 
   // create basic map
@@ -147,6 +175,7 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   autoware_lanelet2_msgs::MapBinConstPtr map_msg_ptr(new autoware_lanelet2_msgs::MapBin(map_msg));
   wmlw.mapCallback(map_msg_ptr);
 
+std::cerr << "4" << std::endl;
   // make sure it had old speed limit before
   auto regems = wmlw.getWorldModel()->getMap()->laneletLayer.get(ll_1.id()).regulatoryElements();
   ASSERT_EQ(regems.size(), 1);
@@ -177,6 +206,7 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data).size(), 0);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(speed_limit_old).size(), 0);
 
+std::cerr << "5" << std::endl;
   // now the change should be reversable
   gf_ptr->update_list_ = {};
   gf_ptr->remove_list_ = {};
@@ -201,11 +231,13 @@ TEST(WMListenerWorkerTest, mapUpdateCallback)
   ASSERT_NE(wmlw.getWorldModel()->getMap()->regulatoryElementLayer.find(speed_limit_old->id()), 
             wmlw.getWorldModel()->getMap()->regulatoryElementLayer.end());
 
+  std::cerr << "6" << std::endl;
   // old_speed_limit's data is also stored at a different address from the one we created locally because
   // we serialized the whole map and deserialized before setting the map.
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->regulatoryElementLayer.get(speed_limit_old->id()), regem_old_correct_data);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data).size(), 1);
   ASSERT_EQ(wmlw.getWorldModel()->getMap()->laneletLayer.findUsages(regem_old_correct_data)[0].id(), ll_1.id());
+  std::cerr << "7" << std::endl;
 }
 
 

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -38,12 +38,12 @@ done
 cd ${dir}/src
 
 if [[ "$BRANCH" = "develop" ]]; then
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch integration/merged-develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch $BRANCH
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch integration/merged-develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch integration/routing
       git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch CARMANovatelGpsDriver_1.2.0
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix checkout.bash script on the integration/routing branch to target correct carma-msgs branch. In addition, resolves a seg fault which was occurring in the carma_wm unit tests routeCallback test. 
<!--- Describe your changes in detail -->

## Related Issue
Supports
https://github.com/usdot-fhwa-stol/carma-platform/issues/566
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Stable integration/routing branch
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CI
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
