### PR TITLE
Update localization stack to use random filter to cap NDT input

### DIFF
--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -96,7 +96,7 @@
       <arg name="pose_stddev_y" default="0.05"/>
       <arg name="pose_stddev_yaw" default="0.025"/>
       <arg name="twist_additional_delay" default="0.0"/>
-      <arg name="twist_rate" default="10.0"/>
+      <arg name="twist_rate" default="30.0"/>
       <arg name="twist_gate_dist" default="10000.0"/>
       <arg name="twist_stddev_vx" default="0.2"/>
       <arg name="twist_stddev_wz" default="0.03"/>
@@ -117,8 +117,7 @@
     <rosparam command="load" file="$(arg vehicle_calibration_dir)/lidar_localizer/ndt_matching/params.yaml"/>
 
     <remap from="/config/ndt" to="config/ndt"/>
-    <remap from="estimated_pose" to="current_pose"/>
-
+    <remap from="filtered_points" to="random_points"/>
     <include file="$(find lidar_localizer)/launch/ndt_matching.launch">
       <arg name="get_height" value="true" />
       <arg name="use_odom" value="true" />
@@ -142,14 +141,31 @@
     <arg name="current_odom" value="vehicle/odom" />
   </include>
 
+    <!-- Random Sampler -->
+  <group>
+    <node pkg="rostopic" type="rostopic" name="config_random_filter"
+      args="pub --latch config/random_filter autoware_config_msgs/ConfigRandomFilter '{
+        sample_num: 700,
+        measurement_range: 200
+      }'"/>
+    <remap from="/filtered_points" to="random_points"/>
+    <include file="$(find points_downsampler)/launch/points_downsample.launch">
+      <arg name="node_name" default="random_filter" />
+      <arg name="points_topic" default="filtered_points" />
+      <arg name="output_log" default="false" />
+    </include>
+  </group>
+
+
+
   <!-- Voxel Grid Filter -->
   <group>
     <remap from="/config/voxel_grid_filter" to="config/voxel_grid_filter"/>
 
     <node pkg="rostopic" type="rostopic" name="config_voxel_grid_filter"
       args="pub --latch config/voxel_grid_filter autoware_config_msgs/ConfigVoxelGridFilter '{
-        voxel_leaf_size: 4,
-        measurement_range: 150
+        voxel_leaf_size: 3.0,
+        measurement_range: 200
       }'"/>
 
     <include file="$(find points_downsampler)/launch/points_downsample.launch">

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -26,7 +26,7 @@ cd ~/carma_ws
 sudo apt-get update
 rosdep update
 rosdep install --from-paths src --ignore-src -y
-./src/carma-platform/carma_build.bash -c ~/carma_ws -a /opt/autoware.ai/ -x
+./src/carma-platform/carma_build.bash -c ~/carma_ws -a /opt/autoware.ai/ -x -m "-DCMAKE_BUILD_TYPE=Release"
 
 # Copy the installed files
 cd ~/carma_ws 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The linked issue has many details which should be reviewed first. 

This PR improves the performance of the localization stack in CARMA Platform by utilizing the random_filter node from autoware.ai to cap the number of input points to NDT matching to a value that demonstrates a reasonable performance in terms of computation time and reliability. The current input point count is set to 700 points which is roughly 3 times what was used in 3.2.0 and about 10% of what was used in 3.3.0. While the drop from 3.3.0 is not ideal, I believe this will be mitigated by the inclusion of ground points back into the lidar scan which are used for estimating the vertical position and will likely be more useful in Aberdeen where there are fewer vertical features. The fix cap on the number of points should also keep the performance of NDT between the truck and the car more consistent since both will have the same computational load for NDT.

In addition, a bug was fixed in the EKF configuration where the expected input twist rate was set to 10Hz when it is in fact 30Hz and the build type of carma-platform was changed to Release for docker images to improve system performance. Testing showed that using optimizations made a massive difference in NDT performance. So while this was already enabled for Autoware we should also do this for carma to minimize CPU load. Finally, the measurement range was changed to 200 to match the range of the VLP-32C lidar. We may want to make this value a hardware configuration parameter in the future but I don't think there is an issue to it being larger than your input data set anyway. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/766
## Motivation and Context
Please see the above issue for the motivation
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested at TFHRC in the blue lexus for multiple runs.
This image is representative of the general behavior
![image](https://user-images.githubusercontent.com/10292079/88328489-85fa0e80-ccf6-11ea-81ab-4d41a58ec7f2.png)
As you can see there are still some spikes above 100, but they are spikes rather than consistent averages. I hope this provides the trade off needed to operate the vehicles at aberdeen as well as TFHRC
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
