### PR TITLE
Feature/routing ctrl wm update

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -53,8 +53,10 @@ sonar.modules= mock_drivers, \
   carma_wm_ctrl, \
   mpc_follower_wrapper, \
   roadway_objects, \
+  platooning_strategic, \
   mock_lightbar_driver, \
   platooning_tactical_plugin
+
 
 mock_drivers.sonar.projectBaseDir              = /opt/carma/src/CARMAPlatform/carmajava/mock_drivers
 carma_transform_server.sonar.projectBaseDir    = /opt/carma/src/CARMAPlatform/carma_transform_server
@@ -76,8 +78,10 @@ carma_wm_ctrl.sonar.projectBaseDir             = /opt/carma/src/CARMAPlatform/ca
 mpc_follower_wrapper.sonar.projectBaseDir      = /opt/carma/src/CARMAPlatform/mpc_follower_wrapper
 truck_inspection_client.sonar.projectBaseDir   = /opt/carma/src/CARMAPlatform/truck_inspection_client
 roadway_objects.sonar.projectBaseDir           = /opt/carma/src/CARMAPlatform/roadway_objects
+platooning_strategic.sonar.projectBaseDir      = /opt/carma/src/CARMAPlatform/platooning_strategic
 platooning_tactical_plugin.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/platooning_tactical_plugin
 mock_lightbar_driver.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/mock_drivers/mock_lightbar_driver
+
 
 # C++ Package differences
 # Sources
@@ -100,8 +104,10 @@ carma_wm_ctrl.sonar.sources             = src
 mpc_follower_wrapper.sonar.sources      = src
 truck_inspection_client.sonar.sources   = src
 roadway_objects.sonar.sources           = src
+platooning_strategic.sonar.sources      = src
 platooning_tactical_plugin.sonar.sources           = src
 mock_lightbar_driver.sonar.sources      = src
+
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
@@ -120,5 +126,6 @@ carma_wm_ctrl.sonar.tests           = test
 mpc_follower_wrapper.sonar.tests    = test
 truck_inspection_client.sonar.tests = test
 roadway_objects.sonar.tests         = test 
-platooning_tactical_plugin.sonar.tests         = test 
+platooning_strategic.sonar.tests    = test
+platooning_tactical_plugin.sonar.tests         = test
 mock_lightbar_driver.sonar.tests    = test

--- a/arbitrator/package.xml
+++ b/arbitrator/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>arbitrator</name>
   <version>3.3.0</version>
   <description>The arbitrator package</description>

--- a/autoware_plugin/package.xml
+++ b/autoware_plugin/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>autoware_plugin</name>
   <version>3.3.0</version>
   <description>The autoware_plugin converts final waypoint plan from autoware to a CARMA trajectory</description>

--- a/bsm_generator/package.xml
+++ b/bsm_generator/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>bsm_generator</name>
   <version>3.3.0</version>
   <description>This generates BSM according to J2735 standard.</description>

--- a/carma_transform_server/package.xml
+++ b/carma_transform_server/package.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<package>
+<package format ="3">
   <name>carma_transform_server</name>
   <version>3.3.0</version>
   <description>The carma_transform_server package maintains a tf2 tree and makes this tree available via a service call</description>
@@ -46,8 +46,8 @@
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use depend for packages you need at compile time: -->
+  <!--   <depend>message_generation</depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
@@ -55,20 +55,14 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_msgs</build_depend>
-  <build_depend>cav_msgs</build_depend>
-  <build_depend>cav_srvs</build_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf2_msgs</run_depend>
-  <run_depend>cav_msgs</run_depend>
-  <run_depend>cav_srvs</run_depend>
+  <depend>geometry_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>cav_msgs</depend>
+  <depend>cav_srvs</depend>
+  
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/carma_wm/package.xml
+++ b/carma_wm/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>carma_wm</name>
   <version>3.3.0</version>
   <description>The carma_wm package</description>

--- a/carma_wm/test/TrafficControlTest.cpp
+++ b/carma_wm/test/TrafficControlTest.cpp
@@ -23,10 +23,7 @@
 #include <atomic>
 #include "TestHelpers.h"
 
-#include <cav_msgs/ControlMessage.h>
-#include <cav_msgs/DaySchedule.h>
-#include <cav_msgs/Schedule.h>
-#include <cav_msgs/ScheduleParams.h>
+#include <cav_msgs/TrafficControlMessage.h>
 
 using ::testing::_;
 using ::testing::A;

--- a/carma_wm_ctrl/include/carma_wm_ctrl/Geofence.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/Geofence.h
@@ -36,7 +36,7 @@ class Geofence
 public:
   boost::uuids::uuid id_;  // Unique id of this geofence
 
-  GeofenceSchedule schedule;  // The schedule this geofence operates with
+  std::vector<GeofenceSchedule> schedules;  // The schedules this geofence operates with
 
   std::string proj;
 

--- a/carma_wm_ctrl/include/carma_wm_ctrl/GeofenceSchedule.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/GeofenceSchedule.h
@@ -28,9 +28,10 @@ public:
   ros::Time schedule_end_;    // Overall schedule end
 
   ros::Duration control_start_;     // Duration from start of day
-  ros::Duration control_end_;       // Duration from start of day
-  ros::Duration control_duration_;  // Duration of active status. Starts from control_start
-  ros::Duration control_interval_;  // Interval between active status within control_start and control_end
+  ros::Duration control_duration_;  // Duration from start of control_start
+  ros::Duration control_offset_;    // Duration from start of day (specifies start time for repeat parameters - span, period)
+  ros::Duration control_span_;      // Duration of active status. Starts from offset
+  ros::Duration control_period_;    // Interval between active status within control_duration since control_start
 
   using DayOfTheWeekSet =
       std::unordered_set<boost::gregorian::greg_weekday, std::hash<int>>;  // Set of week days where geofence is active.
@@ -38,23 +39,24 @@ public:
   DayOfTheWeekSet week_day_set_;  // NOTE: If no day of the week is included then all should be
 
   /**
-   * @brief Default Constructor does not intialize any members
+   * @brief Default Constructor does not initialize any members
    */
   GeofenceSchedule();
 
   /**
    * @brief Constructor
    *
-   * @param schedule_start Overall schedule start in UTC
-   * @param schedule_end Overall schedule end in UTC
-   * @param control_start Duration from start of day
-   * @param control_end Duration from start of day
-   * @param control_duration Duration of active status. Starts from control_start
-   * @param control_interval Interval between active status within control_start and control_end
-   * @param week_day_set Set of days of the week which this schedule applies to. Defaults as all days of the week
+   * @param schedule_start    Overall schedule start in UTC
+   * @param schedule_end      Overall schedule end in UTC
+   * @param control_start     Duration from start of day
+   * @param control_duration  Duration from start of control_start
+   * @param control_offset    Duration from start of day (specifies start time for repeat parameters - span, period)
+   * @param control_span      Duration of active status. Starts from offset
+   * @param control_period    Interval between active status within control_duration since control_start
+   * @param week_day_set      Set of days of the week which this schedule applies to. Defaults as all days of the week
    */
   GeofenceSchedule(ros::Time schedule_start, ros::Time schedule_end, ros::Duration control_start,
-                   ros::Duration control_end, ros::Duration control_duration, ros::Duration control_interval,
+                   ros::Duration control_duration, ros::Duration control_offset, ros::Duration control_span, ros::Duration control_period,
                    DayOfTheWeekSet week_day_set = { 0, 1, 2, 3, 4, 5, 6 });  // Include all weekdays as default (0-6) ->
                                                                              // (Sun-Sat)
 

--- a/carma_wm_ctrl/include/carma_wm_ctrl/GeofenceScheduler.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/GeofenceScheduler.h
@@ -90,17 +90,19 @@ private:
    *
    * @param event The record of the timer event causing this to trigger
    * @param gf The geofence which is being activated
+   * @param schedule_id index number of the schedule being used corresponding to this geofence
    * @param timer_id The id of the timer which caused this callback to occur
    */
-  void startGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const int32_t timer_id);
+  void startGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const unsigned int schedule_id, const int32_t timer_id);
   /**
    * @brief The callback which is triggered when a geofence becomes in-active
    *        This will call the user set inactive_callback set from the onGeofenceInactive function
    *
    * @param event The record of the timer event causing this to trigger
    * @param gf The geofence which is being un-activated
+   * @param schedule_id index number of the schedule being used corresponding to this geofence
    * @param timer_id The id of the timer which caused this callback to occur
    */
-  void endGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const int32_t timer_id);
+  void endGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const unsigned int schedule_id, const int32_t timer_id);
 };
 }  // namespace carma_wm_ctrl

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -44,7 +44,7 @@
 #include "MapConformer.h"
 
 #include <lanelet2_extension/traffic_rules/CarmaUSTrafficRules.h>
-#include <cav_msgs/ControlMessage.h>
+#include <cav_msgs/TrafficControlMessage.h>
 #include <carma_wm/TrafficControl.h>
 #include <std_msgs/String.h>
 #include <unordered_set>
@@ -89,11 +89,11 @@ public:
   void geoReferenceCallback(const std_msgs::String& geo_ref);
 
   /*!
-   * \brief Callback to add a geofence to the map
+   * \brief Callback to add a geofence to the map. Currently only supports version 1 TrafficControlMessage
    *
    * \param geofence_msg The ROS msg of the geofence to add. 
    */
-  void geofenceCallback(const cav_msgs::ControlMessage& geofence_msg);
+  void geofenceCallback(const cav_msgs::TrafficControlMessage& geofence_msg);
 
   /*!
    * \brief Adds a geofence to the current map and publishes the ROS msg
@@ -126,7 +126,7 @@ public:
    * NOTE:Currently this function only checks lanelets and will be expanded 
    * to areas in the future.
    */
-  lanelet::ConstLaneletOrAreas getAffectedLaneletOrAreas(const cav_msgs::ControlMessage& geofence_msg);
+  lanelet::ConstLaneletOrAreas getAffectedLaneletOrAreas(const cav_msgs::TrafficControlMessageV01& geofence_msg);
 
   /*!
    * \brief Sets the max lane width in meters. Geofence points are associated to a lanelet if they are 
@@ -139,7 +139,7 @@ private:
   void addBackSpeedLimit(std::shared_ptr<Geofence> gf_ptr);
   void removeGeofenceHelper(std::shared_ptr<Geofence> gf_ptr);
   void addGeofenceHelper(std::shared_ptr<Geofence> gf_ptr);
-  std::shared_ptr<Geofence> geofenceFromMsg(const cav_msgs::ControlMessage& geofence_msg);
+  std::shared_ptr<Geofence> geofenceFromMsg(const cav_msgs::TrafficControlMessageV01& geofence_msg);
   std::unordered_set<lanelet::Lanelet> filterSuccessorLanelets(const std::unordered_set<lanelet::Lanelet>& possible_lanelets, const std::unordered_set<lanelet::Lanelet>& root_lanelets);
   lanelet::LaneletMapPtr base_map_;
   lanelet::LaneletMapPtr current_map_;

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -36,8 +36,8 @@
 #include <lanelet2_core/primitives/BoundingBox.h>
 #include <carma_wm/WMListener.h>
 #include <cav_msgs/Route.h>
-#include <cav_msgs/ControlRequest.h>
-#include <cav_msgs/ControlBounds.h>
+#include <cav_msgs/TrafficControlRequest.h>
+#include <cav_msgs/TrafficControlBounds.h>
 #include <autoware_lanelet2_msgs/MapBin.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
@@ -65,7 +65,7 @@ class WMBroadcaster
 public:
   using PublishMapCallback = std::function<void(const autoware_lanelet2_msgs::MapBin&)>;
   using PublishMapUpdateCallback = std::function<void(const autoware_lanelet2_msgs::MapBin&)>;
-  using PublishCtrlRequestCallback = std::function<void(const cav_msgs::ControlRequest&)>;
+  using PublishCtrlRequestCallback = std::function<void(const cav_msgs::TrafficControlRequest&)>;
 
   /*!
    * \brief Constructor
@@ -106,17 +106,17 @@ public:
   void removeGeofence(std::shared_ptr<Geofence> gf_ptr);
   
   /*!
-  * \brief Calls controlRequestFromRoute() and publishes the ControlRequest Message returned after the completed operations
+  * \brief Calls controlRequestFromRoute() and publishes the TrafficControlRequest Message returned after the completed operations
   * \param route_msg The message containing route information
   */
-  void routeCallbackMessage(const cav_msgs::Route& route_msg) const;
+  void routeCallbackMessage(const cav_msgs::Route& route_msg);
 
  /*!
-  * \brief Pulls vehicle information from CARMA Cloud at startup by providing its selected route in a ControlRequest message that is published after a route is selected.
+  * \brief Pulls vehicle information from CARMA Cloud at startup by providing its selected route in a TrafficControlRequest message that is published after a route is selected.
   * During operation at ~10s intervals the vehicle will make another control request for the remainder of its route.
   * \param route_msg The message containing route information pulled from routeCallbackMessage()
   */
-  cav_msgs::ControlRequest controlRequestFromRoute(const cav_msgs::Route& route_msg) const; 
+  cav_msgs::TrafficControlRequest controlRequestFromRoute(const cav_msgs::Route& route_msg); 
 
 
   /*!
@@ -144,6 +144,7 @@ private:
   lanelet::LaneletMapPtr base_map_;
   lanelet::LaneletMapPtr current_map_;
   std::unordered_set<std::string>  checked_geofence_ids_;
+  std::unordered_set<std::string>  generated_geofence_reqids_;
   std::vector<lanelet::LaneletMapPtr> cached_maps_;
   std::mutex map_mutex_;
   PublishMapCallback map_pub_;
@@ -152,6 +153,7 @@ private:
   GeofenceScheduler scheduler_;
   std::string base_map_georef_;
   double max_lane_width_;
+
 };
 }  // namespace carma_wm_ctrl
 

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcasterNode.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcasterNode.h
@@ -18,7 +18,7 @@
 
 #include <functional>
 #include <autoware_lanelet2_msgs/MapBin.h>
-#include <cav_msgs/ControlRequest.h>
+#include <cav_msgs/TrafficControlRequest.h>
 #include <carma_utils/CARMAUtils.h>
 #include <carma_wm_ctrl/WMBroadcaster.h>
 #include <ros/ros.h>
@@ -56,11 +56,11 @@ public:
   void publishMap(const autoware_lanelet2_msgs::MapBin& map_msg);
   
   /**
-   * @brief Callback to publish ControlRequest Messages
+   * @brief Callback to publish TrafficControlRequest Messages
    *
-   * @param route_msg The ControlRequest message to publish
+   * @param route_msg The TrafficControlRequest message to publish
    */
-  void publishCtrlReq(const cav_msgs::ControlRequest& ctrlreq_msg) const;
+  void publishCtrlReq(const cav_msgs::TrafficControlRequest& ctrlreq_msg) const;
 
   /**
    * @brief Callback to publish map updates (geofences)

--- a/carma_wm_ctrl/package.xml
+++ b/carma_wm_ctrl/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>carma_wm_ctrl</name>
   <version>1.0.0</version>
   <description>The carma_wm_ctrl package</description>

--- a/carma_wm_ctrl/src/GeofenceSchedule.cpp
+++ b/carma_wm_ctrl/src/GeofenceSchedule.cpp
@@ -25,11 +25,11 @@ GeofenceSchedule::GeofenceSchedule()
 }
 
 GeofenceSchedule::GeofenceSchedule(ros::Time schedule_start, ros::Time schedule_end, ros::Duration control_start,
-                                   ros::Duration control_end, ros::Duration control_duration,
-                                   ros::Duration control_interval, DayOfTheWeekSet week_day_set):
+                                   ros::Duration control_duration, ros::Duration control_offset,
+                                   ros::Duration control_span, ros::Duration control_period, DayOfTheWeekSet week_day_set):
                                    schedule_start_(schedule_start), schedule_end_(schedule_end),
-                                   control_start_(control_start), control_end_(control_end),
-                                   control_duration_(control_duration), control_interval_(control_interval), week_day_set_(week_day_set)
+                                   control_start_ (control_start), control_duration_ (control_duration),
+                                   control_offset_ (control_offset), control_span_ (control_span), control_period_ (control_period), week_day_set_(week_day_set)
 {}
 
 bool GeofenceSchedule::scheduleExpired(const ros::Time& time) const
@@ -66,10 +66,10 @@ std::pair<bool, ros::Time> GeofenceSchedule::getNextInterval(const ros::Time& ti
 
   ros::Time ros_time_of_day = ros::Time::fromBoost(time_of_day);
   ros::Time abs_day_start = ros::Time::fromBoost(ptime_start_of_day);
-  ros::Duration cur_start = control_start_;
+  ros::Duration cur_start = control_start_ + control_offset_; // accounting for the shift of repetition start
 
   // Check if current time is after end of control
-  if (ros_time_of_day > ros::Time(control_end_.toSec()))
+  if (ros_time_of_day > ros::Time((control_start_ + control_duration_).toSec()))
   {
     // The requested time is after control end so there will not be another interval
     return std::make_pair(false, ros::Time(0));
@@ -78,21 +78,21 @@ std::pair<bool, ros::Time> GeofenceSchedule::getNextInterval(const ros::Time& ti
   // Iterate over the day to find the next control interval
   constexpr int num_sec_in_day = 86400;
   const ros::Duration full_day(num_sec_in_day);
-  bool time_in_active_period = false;  // Flag indicating if the requested time is within an active control period
+  bool time_in_active_period = false;  // Flag indicating if the requested time is within an active control span
 
   while (cur_start < full_day && ros_time_of_day > ros::Time(cur_start.toSec()))
   {
     // Check if the requested time is within the control period being evaluated
     if (ros::Time(cur_start.toSec()) < ros_time_of_day &&
-        ros_time_of_day < ros::Time((cur_start + control_duration_).toSec()))
+        ros_time_of_day < ros::Time((cur_start + control_span_).toSec()))
     {
       time_in_active_period = true;
     }
-    cur_start += control_interval_;
+    cur_start += control_period_;
   }
 
   // check if the only next interval is after the schedule end or past the end of the day
-  if (abs_day_start + cur_start > schedule_end_ || cur_start > full_day || cur_start > control_end_)
+  if (abs_day_start + cur_start > schedule_end_ || cur_start > full_day || cur_start > (control_start_ + control_duration_))
   {
     return std::make_pair(time_in_active_period, ros::Time(0));
   }
@@ -100,5 +100,5 @@ std::pair<bool, ros::Time> GeofenceSchedule::getNextInterval(const ros::Time& ti
   // At this point we should have the next start time which is still within the schedule and day
   return std::make_pair(time_in_active_period, abs_day_start + cur_start);
 }
-// TODO the UTC offset is provided in the geofence spec but for now we will ignore and assume all times are UTC
+
 }  // namespace carma_wm_ctrl

--- a/carma_wm_ctrl/src/GeofenceScheduler.cpp
+++ b/carma_wm_ctrl/src/GeofenceScheduler.cpp
@@ -63,36 +63,38 @@ void GeofenceScheduler::addGeofence(std::shared_ptr<Geofence> gf_ptr)
   ROS_INFO_STREAM("Attempting to add Geofence with Id: " << gf_ptr->id_);
 
   // Create timer for next start time
-  auto interval_info = gf_ptr->schedule.getNextInterval(ros::Time::now());
-  ros::Time startTime = interval_info.second;
-  if (!interval_info.first && startTime == ros::Time(0))
+  for (auto schedule_idx = 0; schedule_idx < gf_ptr->schedules.size(); schedule_idx++)
   {
-    ROS_WARN_STREAM(
-        "Failed to add geofence as its schedule did not contain an active or upcoming control period. GF Id: "
-        << gf_ptr->id_);
-    return;
+    auto interval_info = gf_ptr->schedules[schedule_idx].getNextInterval(ros::Time::now());
+    ros::Time startTime = interval_info.second;
+    if (!interval_info.first && startTime == ros::Time(0))
+    {
+      ROS_WARN_STREAM(
+          "Failed to add geofence as its schedule did not contain an active or upcoming control period. GF Id: "
+          << gf_ptr->id_);
+      return;
+    }
+    // If this geofence is currently active set the start time to now
+    if (interval_info.first)
+    {
+      startTime = ros::Time::now();
+    }
+
+    int32_t timer_id = nextId();
+
+    // Build timer to trigger when this geofence becomes active
+    TimerPtr timer = timerFactory_->buildTimer(
+        timer_id, startTime - ros::Time::now(),
+        std::bind(&GeofenceScheduler::startGeofenceCallback, this, _1, gf_ptr, schedule_idx, timer_id), true, true);
+
+    timers_[timer_id] = std::make_pair(std::move(timer), false);  // Add start timer to map by Id
   }
-  // If this geofence is currently active set the start time to now
-  if (interval_info.first)
-  {
-    startTime = ros::Time::now();
-  }
-
-  int32_t timer_id = nextId();
-
-  // Build timer to trigger when this geofence becomes active
-  TimerPtr timer = timerFactory_->buildTimer(
-      timer_id, startTime - ros::Time::now(),
-      std::bind(&GeofenceScheduler::startGeofenceCallback, this, _1, gf_ptr, timer_id), true, true);
-
-  timers_[timer_id] = std::make_pair(std::move(timer), false);  // Add start timer to map by Id
 }
 
-void GeofenceScheduler::startGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const int32_t timer_id)
+void GeofenceScheduler::startGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const unsigned int schedule_id, const int32_t timer_id)
 {
   std::lock_guard<std::mutex> guard(mutex_);
-
-  ros::Time endTime = ros::Time::now() + gf_ptr->schedule.control_duration_;
+  ros::Time endTime = ros::Time::now() + gf_ptr->schedules[schedule_id].control_span_;
 
   ROS_INFO_STREAM("Activating Geofence with Id: " << gf_ptr->id_);
 
@@ -102,13 +104,13 @@ void GeofenceScheduler::startGeofenceCallback(const ros::TimerEvent& event, std:
   int32_t ending_timer_id = nextId();
   TimerPtr timer = timerFactory_->buildTimer(
       ending_timer_id, endTime - ros::Time::now(),
-      std::bind(&GeofenceScheduler::endGeofenceCallback, this, _1, gf_ptr, ending_timer_id), true, true);
+      std::bind(&GeofenceScheduler::endGeofenceCallback, this, _1, gf_ptr, schedule_id, ending_timer_id), true, true);
   timers_[ending_timer_id] = std::make_pair(std::move(timer), false);  // Add end timer to map by Id
 
   timers_[timer_id].second = true;  // Mark start timer for deletion
 }
 
-void GeofenceScheduler::endGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const int32_t timer_id)
+void GeofenceScheduler::endGeofenceCallback(const ros::TimerEvent& event, std::shared_ptr<Geofence> gf_ptr, const unsigned int schedule_id, const int32_t timer_id)
 {
   std::lock_guard<std::mutex> guard(mutex_);
 
@@ -118,7 +120,7 @@ void GeofenceScheduler::endGeofenceCallback(const ros::TimerEvent& event, std::s
   timers_[timer_id].second = true;  // Mark timer for deletion
 
   // Determine if a new timer is needed for this geofence
-  auto interval_info = gf_ptr->schedule.getNextInterval(ros::Time::now());
+  auto interval_info = gf_ptr->schedules[schedule_id].getNextInterval(ros::Time::now());
   ros::Time startTime = interval_info.second;
 
   // If this geofence should currently be active set the start time to now
@@ -138,7 +140,7 @@ void GeofenceScheduler::endGeofenceCallback(const ros::TimerEvent& event, std::s
 
   TimerPtr timer = timerFactory_->buildTimer(
       start_timer_id, startTime - ros::Time::now(),
-      std::bind(&GeofenceScheduler::startGeofenceCallback, this, _1, gf_ptr, start_timer_id), true, true);
+      std::bind(&GeofenceScheduler::startGeofenceCallback, this, _1, gf_ptr, schedule_id, start_timer_id), true, true);
 
   timers_[start_timer_id] = std::make_pair(std::move(timer), false);  // Add start timer to map by Id
 }

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -29,7 +29,6 @@
 #include <lanelet2_core/primitives/Polygon.h>
 #include <proj.h>
 #include <lanelet2_io/Projection.h>
-#include <j2735_msgs/ControlType.h>
 #include <lanelet2_core/utility/Units.h>
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_extension/utility/utilities.h>
@@ -76,7 +75,6 @@ void WMBroadcaster::baseMapCallback(const autoware_lanelet2_msgs::MapBinConstPtr
 
   base_map_ = new_map;  // Store map
   current_map_ = new_map_to_change; // broadcaster makes changes to this
-                                    // TODO publication of this modified map will be handled in the future
 
   lanelet::MapConformer::ensureCompliance(base_map_);     // Update map to ensure it complies with expectations
   lanelet::MapConformer::ensureCompliance(current_map_);
@@ -87,14 +85,14 @@ void WMBroadcaster::baseMapCallback(const autoware_lanelet2_msgs::MapBinConstPtr
   map_pub_(compliant_map_msg);
 };
 
-std::shared_ptr<Geofence> WMBroadcaster::geofenceFromMsg(const cav_msgs::ControlMessage& geofence_msg)
+std::shared_ptr<Geofence> WMBroadcaster::geofenceFromMsg(const cav_msgs::TrafficControlMessageV01& msg_v01)
 {
   auto gf_ptr = std::make_shared<Geofence>(Geofence());
   // Get ID
-  std::copy(geofence_msg.id.begin(), geofence_msg.id.end(), gf_ptr->id_.begin());
+  std::copy(msg_v01.id.id.begin(), msg_v01.id.id.end(), gf_ptr->id_.begin());
 
   // Get affected lanelet or areas by converting the georeference and querying the map using points in the geofence
-  gf_ptr->affected_parts_ = getAffectedLaneletOrAreas(geofence_msg);
+  gf_ptr->affected_parts_ = getAffectedLaneletOrAreas(msg_v01);
   std::vector<lanelet::Lanelet> affected_llts;
   std::vector<lanelet::Area> affected_areas;
 
@@ -108,41 +106,54 @@ std::shared_ptr<Geofence> WMBroadcaster::geofenceFromMsg(const cav_msgs::Control
   // TODO: logic to determine what type of geofence goes here
   // currently only converting portion of control message that is relevant to digital speed limit geofence
   // Convert from double to Velocity
+  
+  cav_msgs::TrafficControlDetail msg_detail = msg_v01.params.detail;
 
-  if (geofence_msg.control_type.control_type == j2735_msgs::ControlType::MAXSPEED) 
+  if (msg_detail.choice == cav_msgs::TrafficControlDetail::MAXSPEED_CHOICE) 
   {
     gf_ptr->max_speed_limit_ = std::make_shared<lanelet::DigitalSpeedLimit>(lanelet::DigitalSpeedLimit::buildData(lanelet::utils::getId(), 
-                                        lanelet::Velocity(geofence_msg.control_value.value * lanelet::units::MPH()),
+                                        lanelet::Velocity(msg_detail.maxspeed * lanelet::units::MPH()),
                                         affected_llts, affected_areas, { lanelet::Participants::VehicleCar }));
   }
-  if (geofence_msg.control_type.control_type == j2735_msgs::ControlType::MINSPEED) 
+  if (msg_detail.choice == cav_msgs::TrafficControlDetail::MINSPEED_CHOICE) 
   {
     gf_ptr->min_speed_limit_ = std::make_shared<lanelet::DigitalSpeedLimit>(lanelet::DigitalSpeedLimit::buildData(lanelet::utils::getId(), 
-                                        lanelet::Velocity(geofence_msg.control_value.value * lanelet::units::MPH()),
+                                        lanelet::Velocity(msg_detail.minspeed * lanelet::units::MPH()),
                                         affected_llts, affected_areas, { lanelet::Participants::VehicleCar }));
   }
   
-  // Get schedule (assuming everything is in UTC currently)
-  gf_ptr->schedule = GeofenceSchedule(geofence_msg.schedule.start,  
-                                 geofence_msg.schedule.end,
-                                 geofence_msg.schedule.between.start,     
-                                 geofence_msg.schedule.between.end, 
-                                 geofence_msg.schedule.repeat.duration,   
-                                 geofence_msg.schedule.repeat.interval);
+  cav_msgs::TrafficControlSchedule msg_schedule = msg_v01.params.schedule;
+  
+  // Get schedule
+  for (auto daily_schedule : msg_schedule.between)
+  {
+    gf_ptr->schedules.push_back(GeofenceSchedule(msg_schedule.start,  
+                                 msg_schedule.end,
+                                 daily_schedule.begin,     
+                                 daily_schedule.duration,
+                                 msg_schedule.repeat.offset,
+                                 msg_schedule.repeat.span,   
+                                 msg_schedule.repeat.period));
+  }
+  
   return gf_ptr;
 }
 
-void WMBroadcaster::geofenceCallback(const cav_msgs::ControlMessage& geofence_msg)
+// currently only supports geofence message version 1: TrafficControlMessageV01 
+void WMBroadcaster::geofenceCallback(const cav_msgs::TrafficControlMessage& geofence_msg)
 {
   std::lock_guard<std::mutex> guard(map_mutex_);
   // quickly check if the id has been added
+  if (geofence_msg.choice != cav_msgs::TrafficControlMessage::TCMV01)
+    return;
+
   boost::uuids::uuid id;
-  std::copy(geofence_msg.id.begin(), geofence_msg.id.end(), id.begin());
+  std::copy(geofence_msg.tcmV01.id.id.begin(), geofence_msg.tcmV01.id.id.end(), id.begin());
   if (checked_geofence_ids_.find(boost::uuids::to_string(id)) != checked_geofence_ids_.end())
     return;
   
   checked_geofence_ids_.insert(boost::uuids::to_string(id));
-  auto gf_ptr = geofenceFromMsg(geofence_msg);
+  auto gf_ptr = geofenceFromMsg(geofence_msg.tcmV01);
   scheduler_.addGeofence(gf_ptr);  // Add the geofence to the scheduler
   ROS_INFO_STREAM("New geofence message received by WMBroadcaster with id" << gf_ptr->id_);
   
@@ -159,7 +170,8 @@ void WMBroadcaster::setMaxLaneWidth(double max_lane_width)
   max_lane_width_ = max_lane_width;
 }
 
-lanelet::ConstLaneletOrAreas WMBroadcaster::getAffectedLaneletOrAreas(const cav_msgs::ControlMessage& geofence_msg)
+// currently only supports geofence message version 1: TrafficControlMessageV01 
+lanelet::ConstLaneletOrAreas WMBroadcaster::getAffectedLaneletOrAreas(const cav_msgs::TrafficControlMessageV01& tcmV01)
 {
   if (!current_map_)
   {
@@ -169,13 +181,13 @@ lanelet::ConstLaneletOrAreas WMBroadcaster::getAffectedLaneletOrAreas(const cav_
     throw lanelet::InvalidObjectStateError(std::string("Base lanelet map has empty proj string loaded as georeference. Therefore, WMBroadcaster failed to\n ") +
                                           std::string("get transformation between the geofence and the map"));
 
-  PJ* geofence_in_map_proj = proj_create_crs_to_crs(PJ_DEFAULT_CTX, geofence_msg.proj.c_str(), base_map_georef_.c_str(), NULL);
+  PJ* geofence_in_map_proj = proj_create_crs_to_crs(PJ_DEFAULT_CTX, tcmV01.geometry.proj.c_str(), base_map_georef_.c_str(), NULL);
   
   // convert all geofence points into our map's frame
   std::vector<lanelet::Point3d> gf_pts;
-  for (auto pt : geofence_msg.points)
+  for (auto pt : tcmV01.geometry.nodes)
   {
-    PJ_COORD c{{pt.x, pt.y, pt.z, 0}};
+    PJ_COORD c {{pt.x, pt.y, 0, 0}}; // z is not currently used
     PJ_COORD c_out;
     c_out = proj_trans(geofence_in_map_proj, PJ_FWD, c);
     gf_pts.push_back(lanelet::Point3d{current_map_->pointLayer.uniqueId(), c_out.xyz.x, c_out.xyz.y});
@@ -358,6 +370,7 @@ void WMBroadcaster::addGeofence(std::shared_ptr<Geofence> gf_ptr)
   auto send_data = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl(gf_ptr->id_, gf_ptr->update_list_, gf_ptr->remove_list_));
   carma_wm::toBinMsg(send_data, &gf_msg);
   map_update_pub_(gf_msg);
+  
 };
 
 void WMBroadcaster::removeGeofence(std::shared_ptr<Geofence> gf_ptr)

--- a/carma_wm_ctrl/src/WMBroadcasterNode.cpp
+++ b/carma_wm_ctrl/src/WMBroadcasterNode.cpp
@@ -33,7 +33,7 @@ void WMBroadcasterNode::publishMapUpdate(const autoware_lanelet2_msgs::MapBin& g
 }
 
   
-void WMBroadcasterNode::publishCtrlReq(const cav_msgs::ControlRequest& ctrlreq_msg) const
+void WMBroadcasterNode::publishCtrlReq(const cav_msgs::TrafficControlRequest& ctrlreq_msg) const
 {
   control_msg_pub_.publish(ctrlreq_msg);
 }
@@ -50,7 +50,7 @@ int WMBroadcasterNode::run()
   // Map Update Publisher
   map_update_pub_ = cnh_.advertise<autoware_lanelet2_msgs::MapBin>("map_update", 1, true);
   //Route Message Publisher
-  control_msg_pub_= cnh_.advertise<cav_msgs::ControlRequest>("outgoing_geofence_request", 1, true);
+  control_msg_pub_= cnh_.advertise<cav_msgs::TrafficControlRequest>("outgoing_geofence_request", 1, true);
   // Base Map Sub
   base_map_sub_ = cnh_.subscribe("base_map", 1, &WMBroadcaster::baseMapCallback, &wmb_);
   // Base Map Georeference Sub

--- a/carma_wm_ctrl/test/GeofenceScheduleTest.cpp
+++ b/carma_wm_ctrl/test/GeofenceScheduleTest.cpp
@@ -32,9 +32,10 @@ TEST(GeofenceSchedule, scheduleStarted)
   sch.schedule_start_ = ros::Time(0);
   sch.schedule_end_ = ros::Time(1);
   sch.control_start_ = ros::Duration(0);
-  sch.control_end_ = ros::Duration(1);
   sch.control_duration_ = ros::Duration(1);
-  sch.control_interval_ = ros::Duration(2);
+  sch.control_offset_ = ros::Duration(0);
+  sch.control_span_ = ros::Duration(1);
+  sch.control_period_ = ros::Duration(2);
 
   ASSERT_TRUE(sch.scheduleStarted(ros::Time(0)));
   ASSERT_TRUE(sch.scheduleStarted(ros::Time(0.9)));
@@ -55,7 +56,7 @@ TEST(GeofenceSchedule, getNextInterval)
 {
   // Test before start
 
-  GeofenceSchedule sch(ros::Time(1), ros::Time(6), ros::Duration(2), ros::Duration(3), ros::Duration(1),
+  GeofenceSchedule sch(ros::Time(1), ros::Time(6), ros::Duration(2), ros::Duration(1), ros::Duration(0), ros::Duration(1),
                        ros::Duration(2)  // This means the next schedule is a 4 (2+2)
   );
 
@@ -72,7 +73,7 @@ TEST(GeofenceSchedule, getNextInterval)
   ASSERT_NEAR(0.0, sch.getNextInterval(ros::Time(3.5)).second.toSec(), 0.00001);
   ASSERT_FALSE(sch.getNextInterval(ros::Time(3.5)).first);
 
-  sch = GeofenceSchedule(ros::Time(1), ros::Time(6), ros::Duration(2), ros::Duration(5), ros::Duration(1),
+  sch = GeofenceSchedule(ros::Time(1), ros::Time(6), ros::Duration(2), ros::Duration(3), ros::Duration(0), ros::Duration(1),
                          ros::Duration(2)  // This means the next schedule is a 4 (2+2)
   );
   // Test between end of first control and start of second

--- a/carma_wm_ctrl/test/GeofenceSchedulerTest.cpp
+++ b/carma_wm_ctrl/test/GeofenceSchedulerTest.cpp
@@ -56,13 +56,14 @@ TEST(GeofenceScheduler, addGeofence)
   std::size_t first_id_hashed = boost::hash<boost::uuids::uuid>()(first_id);
   gf_ptr->id_ = first_id;
 
-  gf_ptr->schedule =
-      GeofenceSchedule(ros::Time(1),  // Schedule between 1 and 6
+  gf_ptr->schedules.push_back(
+      GeofenceSchedule(ros::Time(1),  // Schedule between 1 and 8
                        ros::Time(8),
-                       ros::Duration(2),    // Start's at 2
-                       ros::Duration(5.5),  // Ends at by 5.5
-                       ros::Duration(1),    // Duration of 1 and interval of two so active durations are (2-3 and 4-5)
-                       ros::Duration(2));
+                       ros::Duration(2),    // Starts at 2
+                       ros::Duration(3.5),  // Ends at by 5.5
+                       ros::Duration(0),    // repetition start 0 offset, so still start at 2
+                       ros::Duration(1),    // Duration of 1 and interval of 2 so active durations are (2-3 and 4-5)
+                       ros::Duration(2)));
   ros::Time::setNow(ros::Time(0));  // Set current time
 
   GeofenceScheduler scheduler(std::make_unique<TestTimerFactory>());  // Create scheduler

--- a/carma_wm_ctrl/test/WMBroadcasterTest.cpp
+++ b/carma_wm_ctrl/test/WMBroadcasterTest.cpp
@@ -52,7 +52,7 @@ namespace carma_wm_ctrl
 TEST(WMBroadcaster, Constructor)
 {
   WMBroadcaster([](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const autoware_lanelet2_msgs::MapBin& map_bin) {},
-   [](const cav_msgs::ControlRequest& control_msg_pub_){}, std::make_unique<TestTimerFactory>());  // Create broadcaster with test timers. Having this check helps
+   [](const cav_msgs::TrafficControlRequest& control_msg_pub_){}, std::make_unique<TestTimerFactory>());  // Create broadcaster with test timers. Having this check helps
                                                         // verify that the timers do not crash on destruction
 }
 TEST(WMBroadcaster, baseMapCallback)
@@ -69,7 +69,7 @@ TEST(WMBroadcaster, baseMapCallback)
         ASSERT_EQ(4, map->laneletLayer.size());  // Verify the map can be decoded
 
         base_map_call_count++;
-      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
 
   // Get and convert map to binary message
@@ -100,7 +100,7 @@ TEST(WMBroadcaster, getAffectedLaneletOrAreasFromTransform)
         ASSERT_EQ(4, map->laneletLayer.size());  // Verify the map can be decoded
 
         base_map_call_count++;
-      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
 
   //////
@@ -164,7 +164,7 @@ TEST(WMBroadcaster, getAffectedLaneletOrAreasOnlyLogic)
         lanelet::utils::conversion::fromBinMsg(map_bin, map);
         
         base_map_call_count++;
-      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
 
   //////
@@ -298,7 +298,7 @@ TEST(WMBroadcaster, geofenceCallback)
         ASSERT_EQ(data_received->id_, gf.id_);
         ASSERT_EQ(data_received->remove_list_.size(), 0);
         ASSERT_EQ(data_received->update_list_.size(), 0);
-      }, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
 
   // Get and convert map to binary message
@@ -365,7 +365,7 @@ TEST(WMBroadcaster, routeCallbackMessage)
         ASSERT_EQ(2, map->laneletLayer.size());  // Verify the map can be decoded
 
         base_map_call_count++;
-      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
  
   
@@ -405,29 +405,17 @@ TEST(WMBroadcaster, routeCallbackMessage)
   ASSERT_FALSE(target_frame.empty());
   // loading end
   
-  cav_msgs::ControlRequest coRe;
+  cav_msgs::TrafficControlRequest coRe;
       ROS_INFO_STREAM("This works. ");
 
- 
 
   ///// Test without user defined route callback
   coRe = wmb.controlRequestFromRoute(route_msg);
   ROS_INFO_STREAM("This is yet another test: ");
 
-
-
- ASSERT_TRUE(coRe.bounds.size() > 0);
-
-
+  ASSERT_TRUE(coRe.tcrV01.bounds.size() > 0);
 
 }
-
-
-
-
-
-
-
 
 
 TEST(WMBroadcaster, addAndRemoveGeofence)
@@ -446,7 +434,7 @@ TEST(WMBroadcaster, addAndRemoveGeofence)
       [&](const autoware_lanelet2_msgs::MapBin& map_bin) {
         // Publish map update callback
         map_update_call_count++;
-      }, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      }, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
 
   //////
@@ -537,7 +525,7 @@ using namespace lanelet::units::literals;
         lanelet::utils::conversion::fromBinMsg(map_bin, map);
         base_map_call_count++;
       },
-      [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::ControlRequest& control_msg_pub_){},
+      [](const autoware_lanelet2_msgs::MapBin& map_bin) {}, [](const cav_msgs::TrafficControlRequest& control_msg_pub_){},
       std::make_unique<TestTimerFactory>());
   
   /////

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -96,7 +96,7 @@
       <arg name="pose_stddev_y" default="0.05"/>
       <arg name="pose_stddev_yaw" default="0.025"/>
       <arg name="twist_additional_delay" default="0.0"/>
-      <arg name="twist_rate" default="10.0"/>
+      <arg name="twist_rate" default="30.0"/>
       <arg name="twist_gate_dist" default="10000.0"/>
       <arg name="twist_stddev_vx" default="0.2"/>
       <arg name="twist_stddev_wz" default="0.03"/>
@@ -117,8 +117,7 @@
     <rosparam command="load" file="$(arg vehicle_calibration_dir)/lidar_localizer/ndt_matching/params.yaml"/>
 
     <remap from="/config/ndt" to="config/ndt"/>
-    <remap from="estimated_pose" to="current_pose"/>
-
+    <remap from="filtered_points" to="random_points"/>
     <include file="$(find lidar_localizer)/launch/ndt_matching.launch">
       <arg name="get_height" value="true" />
       <arg name="use_odom" value="true" />
@@ -142,14 +141,31 @@
     <arg name="current_odom" value="vehicle/odom" />
   </include>
 
+    <!-- Random Sampler -->
+  <group>
+    <node pkg="rostopic" type="rostopic" name="config_random_filter"
+      args="pub --latch config/random_filter autoware_config_msgs/ConfigRandomFilter '{
+        sample_num: 700,
+        measurement_range: 200
+      }'"/>
+    <remap from="/filtered_points" to="random_points"/>
+    <include file="$(find points_downsampler)/launch/points_downsample.launch">
+      <arg name="node_name" default="random_filter" />
+      <arg name="points_topic" default="filtered_points" />
+      <arg name="output_log" default="false" />
+    </include>
+  </group>
+
+
+
   <!-- Voxel Grid Filter -->
   <group>
     <remap from="/config/voxel_grid_filter" to="config/voxel_grid_filter"/>
 
     <node pkg="rostopic" type="rostopic" name="config_voxel_grid_filter"
       args="pub --latch config/voxel_grid_filter autoware_config_msgs/ConfigVoxelGridFilter '{
-        voxel_leaf_size: 4,
-        measurement_range: 150
+        voxel_leaf_size: 3.0,
+        measurement_range: 200
       }'"/>
 
     <include file="$(find points_downsampler)/launch/points_downsample.launch">

--- a/carmajava/launch/message.launch
+++ b/carmajava/launch/message.launch
@@ -51,6 +51,9 @@
 
   </node>
 
-  <include file="$(find bsm_generator)/launch/bsm_generator.launch">
-  </include>
+  <include file="$(find bsm_generator)/launch/bsm_generator.launch"/>
+
+  <!-- Message Encoder/Decoder Node -->
+  <include file="$(find cpp_message)/launch/cpp_message.launch"/>
+
 </launch>

--- a/carmajava/package.xml
+++ b/carmajava/package.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<package>
+<package format = "3">
   <name>carma</name>
   <version>3.3.0</version>
   <description>The carma package.</description>
@@ -46,8 +46,8 @@
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use depend for packages you need at compile time: -->
+  <!--   <depend>message_generation</depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
@@ -55,21 +55,20 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rosjava_build_tools</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>genjava</build_depend>
-  <build_depend>rosjava_messages</build_depend>
-  <build_depend>cav_msgs</build_depend>
-  <build_depend>cav_srvs</build_depend>
-  <build_depend>j2735_msgs</build_depend>
-  <build_depend>rostest</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>autoware_msgs</build_depend>
-  <build_depend>derived_object_msgs</build_depend>
-  <build_depend>radar_msgs</build_depend>
-  <build_depend>rosjava_utils</build_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
+  <depend>rosjava_build_tools</depend>
+  <depend>message_generation</depend>
+  <depend>genjava</depend>
+  <depend>rosjava_messages</depend>
+  <depend>cav_msgs</depend>
+  <depend>cav_srvs</depend>
+  <depend>j2735_msgs</depend>
+  <depend>rostest</depend>
+  <depend>rospy</depend>
+  <depend>autoware_msgs</depend>
+  <depend>derived_object_msgs</depend>
+  <depend>radar_msgs</depend>
+  <depend>rosjava_utils</depend>
+  <exec_depend>robot_state_publisher</exec_depend>
 
 
 

--- a/cost_plugin_system/package.xml
+++ b/cost_plugin_system/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>cost_plugin_system</name>
   <version>3.2.0</version>
   <description>The Cost Plugin System</description>

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -26,7 +26,7 @@ cd ~/carma_ws
 sudo apt-get update
 rosdep update
 rosdep install --from-paths src --ignore-src -y
-./src/carma-platform/carma_build.bash -c ~/carma_ws -a /opt/autoware.ai/ -x
+./src/carma-platform/carma_build.bash -c ~/carma_ws -a /opt/autoware.ai/ -x -m "-DCMAKE_BUILD_TYPE=Release"
 
 # Copy the installed files
 cd ~/carma_ws 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -308,6 +308,13 @@ carma__exec() {
 
     # Check if the -i argument was provided
     # If the image was specified then use that
+
+    if [ "$1" = "--gui" ]; then 
+        local RUNTIME=nvidia
+        echo "setting docker runtime to $RUNTIME"
+        shift
+    fi
+
     if [ "$1" = "-i" ]; then 
 
         if [ -z "$2" ]; then
@@ -319,7 +326,6 @@ carma__exec() {
 
         shift
         shift
-
     # If the image was not specified use what was in the carma config
     elif docker container inspect carma-config > /dev/null 2>&1; then
 
@@ -366,9 +372,10 @@ carma__exec() {
     if [ -n "$1" ]; then
 
         local COMMAND="source $INIT_FILE && ${@}"
-
+        
         docker run \
             -e DISPLAY=$DISPLAY \
+            --runtime=$RUNTIME \
             --group-add video \
             --volume=$XSOCK:$XSOCK:rw \
             --volume=$XAUTH:$XAUTH:rw \
@@ -379,10 +386,12 @@ carma__exec() {
             --volume=/opt/carma/maps:/opt/carma/maps \
             --volume=/opt/carma/routes:/opt/carma/routes \
             --env="XAUTHORITY=${XAUTH}" \
+            --env QT_X11_NO_MITSHM=1 \
             --device=/dev/dri:/dev/dri \
             --network=host \
             --entrypoint="$entrypoint" \
             -it $TARGET_IMAGE -c "$COMMAND"
+
     else
         docker run \
             -e DISPLAY=$DISPLAY \
@@ -465,6 +474,7 @@ Please enter one of the following commands:
     exec <optional bash command>
         - Opens a new container with GUI support from the carma-platform or carma-messenger image with the version specified in docker compose. If no version is found it will use latest.
           This container can be used to interact with CARMA using ROS tooling such as Rviz and RQT.
+        - If --gui argument is provided it will start docker using nvidia runtime. this flag should be provided as the first flag to work.
         - If the -i <image> argument is provided then the target image will be used instead
         -d
             - uses a usdotfhwastoldev image

--- a/gnss_ndt_selector/package.xml
+++ b/gnss_ndt_selector/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>gnss_ndt_selector</name>
   <version>3.3.0</version>
   <description>The localizer package provides ndt or GNSS localization selection and publishes pose info as tf2 transformation messages</description>

--- a/gnss_to_map_convertor/package.xml
+++ b/gnss_to_map_convertor/package.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<package>
+<package format = "3">
   <name>gnss_to_map_convertor</name>
   <version>3.3.0</version>
   <description>The gnss_to_map_convertor converts incomping GNSS messages (NavSatFix) to poses in the ECEF and Map frames </description>
@@ -46,8 +46,8 @@
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use depend for packages you need at compile time: -->
+  <!--   <depend>message_generation</depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
@@ -55,30 +55,19 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_msgs</build_depend>
-  <build_depend>cav_msgs</build_depend>
-  <build_depend>cav_srvs</build_depend>
-  <build_depend>wgs84_utils</build_depend>
-  <build_depend>message_filters</build_depend>
-  <build_depend>novatel_gps_msgs</build_depend>
-  <build_depend>carma_utils</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf2_msgs</run_depend>
-  <run_depend>cav_msgs</run_depend>
-  <run_depend>cav_srvs</run_depend>
-  <run_depend>wgs84_utils</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>novatel_gps_msgs</run_depend>
-  <run_depend>carma_utils</run_depend>
-  <run_depend>tf2_geometry_msgs</run_depend>
+  <depend>geometry_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>cav_msgs</depend>
+  <depend>cav_srvs</depend>
+  <depend>wgs84_utils</depend>
+  <depend>message_filters</depend>
+  <depend>novatel_gps_msgs</depend>
+  <depend>carma_utils</depend>
+  <depend>tf2_geometry_msgs</depend>
+  
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/guidance_command_repeater/package.xml
+++ b/guidance_command_repeater/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>guidance_command_repeater</name>
   <version>3.3.0</version>
   <description>The guidance_command_repeater package</description>

--- a/health_monitor/package.xml
+++ b/health_monitor/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>health_monitor</name>
   <version>3.3.0</version>
   <description>The node is used to manage and monitor plugin and driver status</description>

--- a/lightbar_manager/package.xml
+++ b/lightbar_manager/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>lightbar_manager</name>
   <version>3.3.0</version>
   <description>LightBar Manager</description>

--- a/mock_drivers/mock_lightbar_driver/package.xml
+++ b/mock_drivers/mock_lightbar_driver/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>mock_lightbar_driver</name>
   <description>The mock_lightbar_driver package</description>
   <version>1.0.0</version>

--- a/mpc_follower_wrapper/package.xml
+++ b/mpc_follower_wrapper/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>mpc_follower_wrapper</name>
   <version>3.3.0</version>
   <description>The mpc_follower_wrapper package</description>

--- a/object_detection_tracking/package.xml
+++ b/object_detection_tracking/package.xml
@@ -13,7 +13,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>object_detection_tracking</name>
   <version>0.0.0</version>
   <description>The object_detection_tracking package</description>

--- a/plan_delegator/package.xml
+++ b/plan_delegator/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>plan_delegator</name>
   <version>3.3.0</version>
   <description>The plan_delegator package</description>

--- a/platooning_strategic/CMakeLists.txt
+++ b/platooning_strategic/CMakeLists.txt
@@ -1,0 +1,114 @@
+# Copyright (C) 2018-2020 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+cmake_minimum_required(VERSION 2.8.3)
+project(platoon_strategic)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++14)
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  carma_utils
+  cav_msgs
+  cav_srvs
+  roscpp
+  std_msgs
+  carma_wm
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+
+catkin_package(
+   INCLUDE_DIRS include
+   CATKIN_DEPENDS carma_utils cav_msgs roscpp std_msgs carma_wm cav_srvs
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+file(GLOB_RECURSE headers */*.hpp */*.h)
+
+add_executable( ${PROJECT_NAME}
+  ${headers}
+  src/platoon_strategic.cpp
+  src/platoon_manager.cpp
+  src/main.cpp)
+
+
+add_library(platoon_strategic_plugin_lib
+ src/platoon_strategic.cpp
+ src/state_machine.cpp
+ src/platoon_manager.cpp)
+
+add_dependencies(platoon_strategic_plugin_lib ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(${PROJECT_NAME} platoon_strategic_plugin_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+
+#############
+## Install ##
+#############
+
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Install C++
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Mark other files for installation (e.g. launch and bag files, etc.)
+install(DIRECTORY
+  launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+
+#############
+## Testing ##
+#############
+
+catkin_add_gmock(${PROJECT_NAME}-test
+  test/test_platoon_manager.cpp
+  test/test_state_machine.cpp
+  test/mobility_messages.cpp
+  test/main_test.cpp)
+
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test platoon_strategic_plugin_lib ${catkin_LIBRARIES})
+endif()

--- a/platooning_strategic/config/parameters.yaml
+++ b/platooning_strategic/config/parameters.yaml
@@ -1,0 +1,5 @@
+# The length of the trajectory in time domain, in seconds
+trajectory_time_length: 6.0
+
+# The default control plugin name
+control_plugin_name: "mpc_follower"

--- a/platooning_strategic/include/platoon_manager.hpp
+++ b/platooning_strategic/include/platoon_manager.hpp
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <ros/ros.h>
+#include <cav_msgs/MobilityOperation.h>
+#include <cav_msgs/MobilityRequest.h>
+#include <cav_msgs/MobilityResponse.h>
+#include <cav_msgs/PlanType.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <autoware_msgs/ControlCommandStamped.h>
+
+
+
+
+namespace platoon_strategic
+{
+        struct PlatoonMember{
+            // Static ID is permanent ID for each vehicle
+            std::string staticId;
+            // Current BSM Id for each CAV
+            std::string bsmId;
+            // Vehicle real time command speed in m/s
+            double commandSpeed;
+            // Actual vehicle speed in m/s
+            double vehicleSpeed;
+            // Vehicle current down track distance on the current route in m
+            double vehiclePosition;
+            // The local time stamp when the host vehicle update any informations of this member
+            long   timestamp;
+            PlatoonMember(): staticId(""), bsmId(""), commandSpeed(0.0), vehicleSpeed(0.0), timestamp(0) {} 
+            PlatoonMember(std::string staticId, std::string bsmId, double commandSpeed, double vehicleSpeed, double vehiclePosition, long timestamp): staticId(staticId),
+            bsmId(bsmId), commandSpeed(commandSpeed), vehicleSpeed(vehicleSpeed), timestamp(timestamp) {}
+        };
+
+
+    class PlatoonManager
+    {
+    public:
+
+        std::vector<PlatoonMember> platoon;
+
+        PlatoonManager();
+
+        PlatoonManager(std::shared_ptr<ros::NodeHandle> nh);
+
+        ros::Subscriber twist_sub_;
+        ros::Subscriber cmd_sub_;
+        ros::Subscriber pose_sub_;
+
+        // Current vehicle pose in map
+        geometry_msgs::PoseStamped pose_msg_;
+
+        // wm listener pointer and pointer to the actual wm object
+        std::shared_ptr<carma_wm::WMListener> wml_;
+        carma_wm::WorldModelConstPtr wm_;
+
+
+
+        void memberUpdates(const std::string& senderId,const std::string& platoonId,const std::string& senderBsmId,const std::string& params);
+
+        /**
+         * Given any valid platooning mobility STATUS operation parameters and sender staticId,
+         * in leader state this method will add/updates the information of platoon member if it is using
+         * the same platoon ID, in follower state this method will updates the vehicle information who
+         * is in front of the subject vehicle or update platoon id if the leader is join another platoon
+         * @param senderId sender ID for the current info
+         * @param platoonId sender platoon id
+         * @param senderBsmId sender BSM ID
+         * @param params strategy params from STATUS message in the format of "CMDSPEED:xx,DOWNTRACK:xx,SPEED:xx"
+         **/
+        void updatesOrAddMemberInfo(std::string senderId, std::string senderBsmId, double cmdSpeed, double dtDistance, double curSpeed);
+
+        int getTotalPlatooningSize() const;
+
+
+        PlatoonMember getLeader();
+
+        /**
+         * This is the implementation of all predecessor following (APF) algorithm for leader
+         * selection in a platoon. This function will recognize who is acting as the current leader
+         * of the subject vehicle. The current leader of the subject vehicle will be any ONE of
+         * the vehicles in front of it. Having a vehicle further downstream function as the leader
+         * is more efficient and more stable; however, having a vehicle closer to the subject vehicle
+         * function as the leader is safer. For this reason, the subject vehicle will monitor
+         * all time headways between every single set of consecutive vehicles starting from itself
+         * to the leader. If the time headways are within some safe thresholds then vehicles further
+         * downstream may function as the leader. Otherwise, for the sake of safety, vehicles closer
+         * to the subject vehicle, potentially even the predecessor, will function as the leader.
+         * @return the index of the leader in the platoon list
+         */
+
+        int allPredecessorFollowing();
+
+        void changeFromFollowerToLeader();
+        void changeFromLeaderToFollower(std::string newPlatoonId);
+        int getNumberOfVehicleInFront();
+        double getCurrentPlatoonLength();
+        double getPlatoonRearDowntrackDistance();
+
+
+        double getDistanceFromRouteStart() const;
+        double getDistanceToFrontVehicle();
+        double getCurrentSpeed() const;
+        double getCommandSpeed();
+        double getCurrentDowntrackDistance() const;
+
+
+        int platoonSize;
+        std::string leaderID;
+        std::string currentPlatoonID;
+        bool isFollower;
+
+        double current_speed_;
+        double command_speed_;
+
+
+    private:
+    
+
+    std::shared_ptr<ros::NodeHandle> nh_;
+
+
+    double minGap = 22.0;
+    double maxGap = 32.0;
+    std::string previousFunctionalLeaderID = "";
+    int previousFunctionalLeaderIndex = -1;
+
+    double maxSpacing = 4.0;
+    double minSpacing = 3.9;
+    double lowerBoundary = 1.6;
+    double upperBoundary = 1.7 ;
+
+    double vehicleLength = 5.0;  // m
+
+    double gapWithFront = 0.0;
+
+
+    std::string algorithmType = "APF_ALGORITHM";
+
+    bool insufficientGapWithPredecessor(double distanceToFrontVehicle);
+    std::vector<double> calculateTimeHeadway(std::vector<double> downtrackDistance, std::vector<double> speed) const;
+    int determineLeaderBasedOnViolation(std::vector<double> timeHeadways);
+
+    // helper method for APF algorithm
+    int findLowerBoundaryViolationClosestToTheHostVehicle(std::vector<double> timeHeadways) const;
+
+    // helper method for APF algorithm
+    int findMaximumSpacingViolationClosestToTheHostVehicle(std::vector<double> timeHeadways) const;
+
+    std::vector<double> getTimeHeadwayFromIndex(std::vector<double> timeHeadways, int start) const;
+
+
+    void twist_cd(const geometry_msgs::TwistStampedConstPtr& msg);
+    void cmd_cd(const geometry_msgs::TwistStampedConstPtr& msg);
+    void pose_cb(const geometry_msgs::PoseStampedConstPtr& msg);
+
+    std::string HostMobilityId = "hostid";
+
+    
+
+    };
+}

--- a/platooning_strategic/include/platoon_strategic.hpp
+++ b/platooning_strategic/include/platoon_strategic.hpp
@@ -1,0 +1,174 @@
+
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#pragma once
+
+#include <vector>
+#include <math.h>
+#include <cav_msgs/TrajectoryPlan.h>
+#include <cav_msgs/TrajectoryPlanPoint.h>
+#include <cav_msgs/Plugin.h>
+#include <boost/shared_ptr.hpp>
+#include <carma_utils/CARMAUtils.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <cav_srvs/PlanTrajectory.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <cav_msgs/MobilityOperation.h>
+#include <cav_msgs/MobilityRequest.h>
+#include <cav_msgs/MobilityResponse.h>
+#include <cav_msgs/PlanType.h>
+#include <state_machine.hpp>
+
+// #include <leader_state.hpp>
+
+
+
+namespace platoon_strategic
+{
+    class PlatoonStrategicPlugin
+    {
+        public:
+            
+            // Default constructor for PlatoonStrategicPlugin class
+            PlatoonStrategicPlugin();
+
+            // general starting point of this node
+            void run();
+
+            // local copy of pose
+            boost::shared_ptr<geometry_msgs::PoseStamped const> pose_msg_;
+
+            void run_states();
+
+            PlatooningStateMachine psm_{nh_};
+
+        protected:
+
+            void run_leader();
+            void run_leader_waiting();
+            void run_candidate_follower();
+            void run_follower();
+
+        
+        private:
+
+            
+
+            // CARMA ROS node handles
+            std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
+
+            
+
+            long waitingStartTime;
+            long candidatestateStartTime;
+
+
+            ros::Publisher platoon_strategic_plugin_discovery_pub_;
+            ros::Publisher mob_op_pub_;
+            ros::Publisher mob_req_pub_;
+
+            ros::Subscriber pose_sub_;
+            
+            ros::Subscriber mob_req_sub_;
+            ros::Subscriber mob_resp_sub_;
+            ros::Subscriber mob_op_sub_;
+
+
+            // service callbacks for carma trajectory planning
+            bool plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp);
+
+            void pose_cb(const geometry_msgs::PoseStampedConstPtr& msg);
+
+            void mob_req_cb(const cav_msgs::MobilityRequest& msg);
+            void mob_resp_cb(const cav_msgs::MobilityResponse& msg);
+            void mob_op_cb(const cav_msgs::MobilityOperation& msg);
+
+            // ros service servers
+            ros::ServiceServer maneuver_srv_;
+
+            // Plugin discovery message
+            cav_msgs::Plugin plugin_discovery_msg_;
+
+            // trajectory frequency
+            double traj_freq = 10;
+
+            // ROS params
+            double trajectory_time_length_ = 6;
+            std::string control_plugin_name_ = "mpc_follower";
+            
+
+            // start vehicle speed
+            double start_speed_;
+            // target vehicle speed
+            double target_speed_;
+
+
+            int num_points = traj_freq * trajectory_time_length_;
+
+            // initialize this node
+            void initialize();
+
+            // generated trajectory plan
+            cav_msgs::TrajectoryPlan trajectory_msg;
+
+
+
+            cav_msgs::MobilityRequest mobility_req_msg_;
+            cav_msgs::MobilityResponse mobility_resp_msg_;
+            cav_msgs::MobilityOperation mobility_op_msg_;
+
+
+            void composeMobilityOperationLeader(cav_msgs::MobilityOperation &msg, const std::string& type);
+            void composeMobilityOperationFollower(cav_msgs::MobilityOperation &msg) const;
+            void composeMobilityOperationLeaderWaiting(cav_msgs::MobilityOperation &msg) const;
+            void composeMobilityOperationCandidateFollower(cav_msgs::MobilityOperation &msg);
+
+
+            double maxAllowedJoinTimeGap = 15.0;
+            double maxAllowedJoinGap = 90;
+            int maxPlatoonSize = 10;
+            double vehicleLength = 5.0;
+            std::mutex plan_mutex_;
+            int infoMessageInterval;
+            long lastHeartBeatTime = 0.0;
+            int statusMessageInterval = 100;
+            int NEGOTIATION_TIMEOUT = 5000;  // ms
+            int noLeaderUpdatesCounter = 0;
+            int LEADER_TIMEOUT_COUNTER_LIMIT = 5;
+            double waitingStateTimeout = 25.0; // s
+            double desiredJoinGap = 30.0; // m
+            double desiredJoinTimeGap = 4.0; // s
+
+
+            const std::string MOBILITY_STRATEGY = "Carma/Platooning";
+            const std::string OPERATION_INFO_TYPE = "INFO";
+            const std::string OPERATION_STATUS_TYPE = "STATUS";
+            const std::string OPERATION_STATUS_PARAMS = "STATUS|CMDSPEED:%1%,DTD:%2%,SPEED:%3%";
+
+
+            // Check these values
+            std::string HostMobilityId = "hostid";
+            std::string BSMID = "BSM";
+            std::string MobilityId = "mobilityid";
+            
+
+
+    
+    };
+}

--- a/platooning_strategic/include/state_machine.hpp
+++ b/platooning_strategic/include/state_machine.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <ros/ros.h>
+#include <iostream>
+#include <cav_msgs/MobilityOperation.h>
+#include <cav_msgs/MobilityRequest.h>
+#include <cav_msgs/MobilityResponse.h>
+#include <cav_srvs/PlanManeuvers.h>
+#include <cav_msgs/PlanType.h>
+#include <mutex>
+#include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <platoon_manager.hpp>
+
+namespace platoon_strategic
+{
+    struct PlatoonPlan {
+        
+        bool valid;
+        long planStartTime;
+        std::string planId;
+        std::string peerId;
+        PlatoonPlan():valid(""), planStartTime(0), planId(""), peerId("") {} ;
+        PlatoonPlan(bool valid, long planStartTime, std::string planId, std::string peerId): 
+            valid(valid), planStartTime(planStartTime), planId(planId), peerId(peerId) {}  
+    };
+
+    /**
+        * A response to an MobilityRequest message.
+        * ACK - indicates that the plugin accepts the MobilityRequest and will handle making any adjustments needed to avoid a conflict
+        * NACK - indicates that the plugin rejects the MobilityRequest and would suggest the other vehicle replan
+        * NO_RESPONSE - indicates that the plugin is indifferent but sees no conflict
+    */
+
+    enum MobilityRequestResponse {
+            ACK,
+            NACK,
+            NO_RESPONSE
+    };
+
+    enum PlatoonState{
+        STANDBY,
+        LEADERWAITING,
+        LEADER,
+        CANDIDATEFOLLOWER,
+        FOLLOWER
+    };
+
+    class PlatooningStateMachine
+    {
+    public:
+
+        PlatooningStateMachine();
+        
+        PlatooningStateMachine(std::shared_ptr<ros::CARMANodeHandle> nh);
+
+        /**
+         * Callback method to handle mobility requests which may result in
+         * state changing, trajectory re-plan and platooning info updates. 
+         * @param msg the detailed proposal from other vehicles
+         * @return simple yes/no response to the incoming proposal
+         */
+        MobilityRequestResponse onMobilityRequestMessage(cav_msgs::MobilityRequest &msg);
+
+        /**
+         * Callback method to handle mobility response.
+         * @param msg response for the current plan from other vehicles
+         */
+        void onMobilityResponseMessage(cav_msgs::MobilityResponse &msg);
+
+        /**
+         * Callback method to handle mobility operation.
+         * @param msg the necessary operational info from other vehicles
+         */
+        void onMobilityOperationMessage(cav_msgs::MobilityOperation &msg);
+
+        cav_msgs::Maneuver composeManeuver();
+        
+        PlatoonState current_platoon_state;
+        std::string applicantID = "";
+        PlatoonPlan current_plan;
+
+        std::string targetLeaderId = "";
+
+        PlatoonManager pm_{nh_};
+
+
+    private:
+    
+        std::shared_ptr<ros::CARMANodeHandle> nh_;
+
+        ros::Publisher mob_req_pub_;
+
+        double mvr_duration_ = 16.0;
+        
+        MobilityRequestResponse onMobilityRequestMessageFollower(cav_msgs::MobilityRequest &msg) const;
+        void onMobilityResponseMessageFollower(cav_msgs::MobilityResponse &msg) const;
+        void onMobilityOperationMessageFollower(cav_msgs::MobilityOperation &msg);
+
+        MobilityRequestResponse onMobilityRequestMessageLeader(cav_msgs::MobilityRequest &msg);
+        void onMobilityResponseMessageLeader(cav_msgs::MobilityResponse &msg);
+        void onMobilityOperationMessageLeader(cav_msgs::MobilityOperation &msg);
+
+        MobilityRequestResponse onMobilityRequestMessageLeaderWaiting(cav_msgs::MobilityRequest &msg);
+        void onMobilityResponseMessageLeaderWaiting(cav_msgs::MobilityResponse &msg) const;
+        void onMobilityOperationMessageLeaderWaiting(cav_msgs::MobilityOperation &msg);
+
+        MobilityRequestResponse onMobilityRequestMessageCandidateFollower(cav_msgs::MobilityRequest &msg) const;
+        void onMobilityResponseMessageCandidateFollower(cav_msgs::MobilityResponse &msg);
+        void onMobilityOperationMessageCandidateFollower(cav_msgs::MobilityOperation &msg);
+
+
+        MobilityRequestResponse onMobilityRequestMessageStandby(cav_msgs::MobilityRequest &msg) const;
+        void onMobilityResponseMessageStandby(cav_msgs::MobilityResponse &msg) const;
+        void onMobilityOperationMessageStandby(cav_msgs::MobilityOperation &msg) const;
+
+
+
+        
+        bool isVehicleRightInFront(std::string rearVehicleBsmId, double downtrack) const;
+
+        std::mutex plan_mutex_;
+
+        double maxAllowedJoinTimeGap = 15.0;
+        double maxAllowedJoinGap = 90;
+        int maxPlatoonSize = 10;
+        double vehicleLength = 5.0;
+        int infoMessageInterval;
+        const std::string targetPlatoonId;
+        const std::string OPERATION_INFO_TYPE = "INFO";
+        const std::string OPERATION_STATUS_TYPE = "STATUS";
+        const std::string JOIN_AT_REAR_PARAMS = "SIZE:%1%,SPEED:%2%,DTD:%3%";
+        const std::string  MOBILITY_STRATEGY = "Carma/Platooning";
+    };
+}
+

--- a/platooning_strategic/launch/platoon_strategic.launch
+++ b/platooning_strategic/launch/platoon_strategic.launch
@@ -1,0 +1,27 @@
+<!--
+
+  Copyright (C) 2018-2020 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+ 
+Primary launch file for platooning strategic plugin node
+Loads parameters and configures logging for the node
+ 
+-->
+<launch>
+<node pkg="platoon_strategic" type="platoon_strategic" name="platoon_strategic">
+        <rosparam command="load" file="$(find platoon_strategic)/config/parameters.yaml" />
+    </node>
+</launch>

--- a/platooning_strategic/package.xml
+++ b/platooning_strategic/package.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>guidance</name>
+  <name>platoon_strategic</name>
   <version>3.3.0</version>
-  <description>The Guidance package</description>
-  <maintainer email="rushk1@leidos.com">rushk</maintainer>
+  <description>The node is to plan a platooning maneuver</description>
+  <maintainer email="CARMA@dot.gov">carma</maintainer>
   <license>Apache 2.0 License</license>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>carma_utils</depend>
   <depend>cav_msgs</depend>
-  <depend>cav_srvs</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
+  <depend>carma_wm</depend>
+  <depend>cav_srvs</depend>
 </package>

--- a/platooning_strategic/src/main.cpp
+++ b/platooning_strategic/src/main.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include "platoon_strategic.hpp"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "platoon_strategic");
+    platoon_strategic::PlatoonStrategicPlugin node;
+    node.run();
+    return 0;
+};

--- a/platooning_strategic/src/platoon_manager.cpp
+++ b/platooning_strategic/src/platoon_manager.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "platoon_manager.hpp"
+#include <boost/algorithm/string.hpp>
+#include <ros/ros.h>
+#include <array>
+
+
+namespace platoon_strategic
+{
+    PlatoonManager::PlatoonManager(){}
+
+    PlatoonManager::PlatoonManager(std::shared_ptr<ros::NodeHandle> nh): nh_(nh) {
+                twist_sub_ = nh_->subscribe("current_velocity", 1, &PlatoonManager::twist_cd, this);
+                cmd_sub_ = nh_->subscribe("command_velocity", 1, &PlatoonManager::cmd_cd, this);
+                pose_sub_ = nh_->subscribe("current_pose", 1, &PlatoonManager::pose_cb, this);
+        };
+
+    void PlatoonManager::memberUpdates(const std::string& senderId,const std::string& platoonId,const std::string& senderBsmId,const std::string& params){
+
+        std::vector<std::string> inputsParams;
+        boost::algorithm::split(inputsParams, params, boost::is_any_of(","));
+
+        std::vector<std::string> cmd_parsed;
+        boost::algorithm::split(cmd_parsed, inputsParams[0], boost::is_any_of(":"));
+        double cmdSpeed = std::stod(cmd_parsed[1]);
+
+
+        std::vector<std::string> dtd_parsed;
+        boost::algorithm::split(dtd_parsed, inputsParams[1], boost::is_any_of(":"));
+        double dtDistance = std::stod(dtd_parsed[1]);
+
+
+        std::vector<std::string> cur_parsed;
+        boost::algorithm::split(cur_parsed, inputsParams[2], boost::is_any_of(":"));
+        double curSpeed = std::stod(cur_parsed[1]);
+
+
+        // If we are currently in a follower state:
+        // 1. We will update platoon ID based on leader's STATUS
+        // 2. We will update platoon members info based on platoon ID if it is in front of us 
+        if(isFollower) {
+                    
+            bool isFromLeader = (leaderID == senderId);
+            
+            bool needPlatoonIdChange = isFromLeader && (currentPlatoonID == platoonId);
+            
+            bool isVehicleInFrontOf = (dtDistance >= getCurrentDowntrackDistance());
+
+            if(needPlatoonIdChange) {
+                ROS_DEBUG("It seems that the current leader is joining another platoon.");
+                ROS_DEBUG("So the platoon ID is changed from " , currentPlatoonID , " to " , platoonId);
+                currentPlatoonID = platoonId;
+                updatesOrAddMemberInfo(senderId, senderBsmId, cmdSpeed, dtDistance, curSpeed);
+
+            } else if((currentPlatoonID == platoonId) && isVehicleInFrontOf) {
+                ROS_DEBUG("This STATUS messages is from our platoon in front of us. Updating the info...");
+                updatesOrAddMemberInfo(senderId, senderBsmId, cmdSpeed, dtDistance, curSpeed);
+                leaderID = (platoon.size()==0) ? HostMobilityId : platoon[0].staticId;
+                ROS_DEBUG("The first vehicle in our list is now " , leaderID);
+
+            } else{
+                ROS_DEBUG("This STATUS message is not from our platoon. We ignore this message with id: " , senderId);
+            }
+        }else {
+            // If we are currently in any leader state, we only updates platoon member based on platoon ID
+            if(currentPlatoonID == platoonId) {
+                ROS_DEBUG("This STATUS messages is from our platoon. Updating the info...");
+                updatesOrAddMemberInfo(senderId, senderBsmId, cmdSpeed, dtDistance, curSpeed);
+            }
+        }
+
+    }
+
+    
+
+    void PlatoonManager::updatesOrAddMemberInfo(std::string senderId, std::string senderBsmId, double cmdSpeed, double dtDistance, double curSpeed) {
+
+        bool isExisted = false;
+        // update/add this info into the list
+        for (PlatoonMember pm : platoon){
+            if(pm.staticId == senderId) {
+                pm.bsmId = senderBsmId;
+                pm.commandSpeed = cmdSpeed;
+                pm.vehiclePosition = dtDistance;
+                pm.vehicleSpeed = curSpeed;
+                pm.timestamp = ros::Time::now().toSec()*1000;
+                ROS_DEBUG("Receive and update platooning info on vehicel " , pm.staticId);
+                ROS_DEBUG("    BSM ID = "                                  , pm.bsmId);
+                ROS_DEBUG("    Speed = "                                   , pm.vehicleSpeed);
+                ROS_DEBUG("    Location = "                                , pm.vehiclePosition);
+                ROS_DEBUG("    CommandSpeed = "                            , pm.commandSpeed);
+                isExisted = true;
+                break;
+            }
+        }
+
+        if(!isExisted) {
+            long cur_t = ros::Time::now().toSec()*1000;
+            PlatoonMember newMember;// = new PlatoonMember(senderId, senderBsmId, cmdSpeed, curSpeed, dtDistance, cur_t);
+            platoon.push_back(newMember);
+
+            std::sort(std::begin(platoon), std::end(platoon), [](const PlatoonMember &a, const PlatoonMember &b){return a.vehiclePosition < b.vehiclePosition;});
+
+            ROS_DEBUG("Add a new vehicle into our platoon list " , newMember.staticId);
+        }
+
+    }
+
+
+
+    int PlatoonManager::getTotalPlatooningSize() const{
+        if(isFollower) {
+            return platoonSize;
+        }
+        return platoon.size() + 1;
+    }
+        
+    double PlatoonManager::getPlatoonRearDowntrackDistance(){
+        if(platoon.size() == 0) {
+            double dist = getCurrentDowntrackDistance();
+            return dist;
+        }
+        return platoon[platoon.size() - 1].vehiclePosition;
+    }
+
+    PlatoonMember PlatoonManager::getLeader(){
+        PlatoonMember leader ;
+        if(isFollower && platoon.size() != 0) {
+            // return the first vehicle in the platoon as default if no valid algorithm applied
+            leader = platoon[0];
+            if (algorithmType == "APF_ALGORITHM"){
+                    int newLeaderIndex = allPredecessorFollowing();
+                    
+                    if(newLeaderIndex < platoon.size() && newLeaderIndex >= 0) {
+                        leader = platoon[newLeaderIndex];
+                        ROS_DEBUG("APF output: " , leader.staticId);
+                        previousFunctionalLeaderIndex = newLeaderIndex;
+                        previousFunctionalLeaderID = leader.staticId;
+                    }
+                    else {
+                        // it might happened when the subject vehicle gets far away from the preceding vehicle so we follow the one in front
+                        leader = platoon[platoon.size() - 1];
+                        previousFunctionalLeaderIndex = platoon.size() - 1;
+                        previousFunctionalLeaderID = leader.staticId;
+                        ROS_DEBUG("Based on the output of APF algorithm we start to follow our predecessor.");
+                    }
+            }
+        }
+
+        return leader;
+
+    }
+
+    int PlatoonManager::allPredecessorFollowing(){
+        ///***** Case Zero *****///
+        // If we are the second vehicle in this platoon,we will always follow the leader vehicle
+        if(platoon.size() == 1) {
+            ROS_DEBUG("As the second vehicle in the platoon, it will always follow the leader. Case Zero");
+            return 0;
+        }
+        ///***** Case One *****///
+        // If we do not have a leader in the previous time step, we follow the first vehicle as default 
+        if(previousFunctionalLeaderID == "") {
+            ROS_DEBUG("APF algorithm did not found a leader in previous time step. Case one");
+            return 0;
+        }
+        // Generate an array of downtrack distance for every vehicles in this platoon including the host vehicle
+        // The size of distance array is platoon.size() + 1, because the platoon list did not contain the host vehicle
+        std::vector<double> downtrackDistance(platoon.size() + 1);
+        for(int i = 0; i < platoon.size(); i++) {
+            downtrackDistance[i] = platoon[i].vehiclePosition; 
+        }
+        double dt = getCurrentDowntrackDistance();// getDistanceFromRouteStart();
+        downtrackDistance[downtrackDistance.size() - 1] = dt;
+        
+        // Generate an array of speed for every vehicles in this platoon including the host vehicle
+        // The size of speed array is platoon.size() + 1, because the platoon list did not contain the host vehicle
+        std::vector<double> speed(platoon.size() + 1);
+        for(int i = 0; i < platoon.size(); i++) {
+            speed[i] = platoon[i].vehicleSpeed;
+        }
+        double cur_speed = getCurrentSpeed();
+        speed[speed.size() - 1] = cur_speed;
+
+        ///***** Case Two *****///
+        // If the distance headway between the subject vehicle and its predecessor is an issue
+        // according to the "min_gap" and "max_gap" thresholds, then it should follow its predecessor
+        // The following line will not throw exception because the length of downtrack array is larger than two in this case
+        double timeHeadwayWithPredecessor = downtrackDistance[downtrackDistance.size() - 2] - downtrackDistance[downtrackDistance.size() - 1];
+        gapWithFront = timeHeadwayWithPredecessor;
+        if(insufficientGapWithPredecessor(timeHeadwayWithPredecessor)) {
+            ROS_DEBUG("APF algorithm decides there is an issue with the gap with preceding vehicle: " , timeHeadwayWithPredecessor , ". Case Two");
+            return platoon.size() - 1;
+        }
+        else{
+            // implementation of the main part of APF algorithm
+            // calculate the time headway between every consecutive pair of vehicles
+            std::vector<double> timeHeadways = calculateTimeHeadway(downtrackDistance, speed);
+            // ROS_DEBUG("APF calculate time headways: " , Arrays.toString(timeHeadways));
+            ROS_DEBUG("APF found the previous leader is " , previousFunctionalLeaderID);
+            // if the previous leader is the first vehicle in the platoon
+            
+            if(previousFunctionalLeaderIndex == 0) {
+                ///***** Case Three *****///
+                // If there is a violation, the return value is the desired leader index
+                ROS_DEBUG("APF use violations on lower boundary or maximum spacing to choose leader. Case Three.");
+                return determineLeaderBasedOnViolation(timeHeadways);
+            }
+            else{
+                // if the previous leader is not the first vehicle
+                // get the time headway between every consecutive pair of vehicles from indexOfPreviousLeader
+                std::vector<double> partialTimeHeadways = getTimeHeadwayFromIndex(timeHeadways, previousFunctionalLeaderIndex);
+                // ROS_DEBUG("APF partial time headways array: " + Arrays.toString(partialTimeHeadways));
+                int closestLowerBoundaryViolation, closestMaximumSpacingViolation;
+                closestLowerBoundaryViolation = findLowerBoundaryViolationClosestToTheHostVehicle(partialTimeHeadways);
+                closestMaximumSpacingViolation = findMaximumSpacingViolationClosestToTheHostVehicle(partialTimeHeadways);
+                // if there are no violations anywhere between the subject vehicle and the current leader,
+                // then depending on the time headways of the ENTIRE platoon, the subject vehicle may switch
+                // leader further downstream. This is because the subject vehicle has determined that there are
+                // no time headways between itself and the current leader which would cause the platoon to be unsafe.
+                // if there are violations somewhere betweent the subject vehicle and the current leader,
+                // then rather than assigning leadership further DOWNSTREAM, we must go further UPSTREAM in the following lines
+                if(closestLowerBoundaryViolation == -1 && closestMaximumSpacingViolation == -1) {
+                    // In order for the subject vehicle to assign leadership further downstream,
+                    // two criteria must be satisfied: first the leading vehicle and its immediate follower must
+                    // have a time headway greater than "upper_boundary." The purpose of this criteria is to
+                    // introduce a hysteresis in order to eliminate the possibility of a vehicle continually switching back 
+                    // and forth between two leaders because one of the time headways is hovering right around
+                    // the "lower_boundary" threshold; second the leading vehicle and its predecessor must have
+                    // a time headway less than "min_spacing" second. Just as with "upper_boundary", "min_spacing" exists to
+                    // introduce a hysteresis where leaders are continually being switched.
+                    bool condition1 = timeHeadways[previousFunctionalLeaderIndex] > upperBoundary;
+                    bool condition2 = timeHeadways[previousFunctionalLeaderIndex - 1] < minSpacing;
+                    ///***** Case Four *****///
+                    //we may switch leader further downstream
+                    if(condition1 && condition2) {
+                        ROS_DEBUG("APF found two conditions for assigning leadership further downstream are satisfied. Case Four");
+                        return determineLeaderBasedOnViolation(timeHeadways);
+                    } else {
+                        ///***** Case Five *****///
+                        // We may not switch leadership to another vehicle further downstream because some criteria are not satisfied
+                        ROS_DEBUG("APF found two conditions for assigning leadership further downstream are not satisfied. Case Five.");
+                        ROS_DEBUG("condition1: " , condition1 , " & condition2: " , condition2);
+                        return previousFunctionalLeaderIndex;
+                    }
+                } else if(closestLowerBoundaryViolation != -1 && closestMaximumSpacingViolation == -1) {
+                    // The rest four cases have roughly the same logic: locate the closest violation and assign leadership accordingly
+                    ///***** Case Six *****///
+                    ROS_DEBUG("APF found closestLowerBoundaryViolation on partial time headways. Case Six.");
+                    return previousFunctionalLeaderIndex - 1 + closestLowerBoundaryViolation;
+
+                } else if(closestLowerBoundaryViolation == -1 && closestMaximumSpacingViolation != -1) {
+                    ///***** Case Seven *****///
+                    ROS_DEBUG("APF found closestMaximumSpacingViolation on partial time headways. Case Seven.");
+                    return previousFunctionalLeaderIndex + closestMaximumSpacingViolation;
+                } else{
+                    ROS_DEBUG("APF found closestMaximumSpacingViolation and closestLowerBoundaryViolation on partial time headways.");
+                    if(closestLowerBoundaryViolation > closestMaximumSpacingViolation) {
+                        ///***** Case Eight *****///
+                        ROS_DEBUG("closestLowerBoundaryViolation is higher than closestMaximumSpacingViolation on partial time headways. Case Eight.");
+                        return previousFunctionalLeaderIndex - 1 + closestLowerBoundaryViolation;
+                    } else if(closestLowerBoundaryViolation < closestMaximumSpacingViolation) {
+                        ///***** Case Nine *****///
+                        ROS_DEBUG("closestMaximumSpacingViolation is higher than closestLowerBoundaryViolation on partial time headways. Case Nine.");
+                        return previousFunctionalLeaderIndex + closestMaximumSpacingViolation;
+                    } else {
+                        ROS_DEBUG("APF Leader selection parameter is wrong!");
+                        return 0;
+                    }
+                }
+            }
+
+        }
+    }
+
+    std::vector<double> PlatoonManager::getTimeHeadwayFromIndex(std::vector<double> timeHeadways, int start) const {
+        std::vector<double> result(timeHeadways.begin() + start-1, timeHeadways.end());
+        return result;
+    }
+    
+
+    bool PlatoonManager::insufficientGapWithPredecessor(double distanceToFrontVehicle) {
+        bool frontGapIsTooSmall = distanceToFrontVehicle < minGap;
+        bool previousLeaderIsPredecessor = (previousFunctionalLeaderID == platoon[platoon.size() - 1].staticId);
+        bool frontGapIsNotLargeEnough = (distanceToFrontVehicle < maxGap && previousLeaderIsPredecessor);
+        return (frontGapIsTooSmall || frontGapIsNotLargeEnough);
+    }
+
+    std::vector<double> PlatoonManager::calculateTimeHeadway(std::vector<double> downtrackDistance, std::vector<double> speed) const{
+        std::vector<double> timeHeadways(downtrackDistance.size() - 1);
+        for (int i=0; i<timeHeadways.size(); i++){
+            if (speed[i+1]!=0){
+                timeHeadways[i] = (downtrackDistance[i] - downtrackDistance[i + 1]) / speed[i + 1];
+            } else{
+                timeHeadways[i] = std::numeric_limits<double>::infinity();
+            }
+        }
+        return timeHeadways;
+    }
+
+
+    int PlatoonManager::determineLeaderBasedOnViolation(std::vector<double> timeHeadways){
+        int closestLowerBoundaryViolation = findLowerBoundaryViolationClosestToTheHostVehicle(timeHeadways);
+        int closestMaximumSpacingViolation = findMaximumSpacingViolationClosestToTheHostVehicle(timeHeadways);
+        if(closestLowerBoundaryViolation > closestMaximumSpacingViolation) {
+            ROS_DEBUG("APF found violation on closestLowerBoundaryViolation at " , closestLowerBoundaryViolation);
+            return closestLowerBoundaryViolation;
+        } else if(closestLowerBoundaryViolation < closestMaximumSpacingViolation){
+            ROS_DEBUG("APF found violation on closestMaximumSpacingViolation at " , closestMaximumSpacingViolation);
+            return closestMaximumSpacingViolation + 1;
+        }
+        else{
+            ROS_DEBUG("APF found no violations on both closestLowerBoundaryViolation and closestMaximumSpacingViolation");
+            return 0;
+        }
+    }
+
+        // helper method for APF algorithm
+    int PlatoonManager::findLowerBoundaryViolationClosestToTheHostVehicle(std::vector<double> timeHeadways) const{
+        for(int i = timeHeadways.size() - 1; i >= 0; i--) {
+            if(timeHeadways[i] < lowerBoundary) {
+                return i;
+            }
+        }
+        return -1;
+    }
+    
+    // helper method for APF algorithm
+    int PlatoonManager::findMaximumSpacingViolationClosestToTheHostVehicle(std::vector<double> timeHeadways) const {
+        for(int i = timeHeadways.size() - 1; i >= 0; i--) {
+            if(timeHeadways[i] > maxSpacing) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    void PlatoonManager::changeFromFollowerToLeader() {
+        isFollower = false;
+        platoon = {};
+        leaderID = HostMobilityId;
+        currentPlatoonID = boost::uuids::to_string(boost::uuids::random_generator()());
+        previousFunctionalLeaderID = "";
+        previousFunctionalLeaderIndex = -1;
+        ROS_DEBUG("The platoon manager is changed from follower state to leader state.");
+    }
+
+    void PlatoonManager::changeFromLeaderToFollower(std::string newPlatoonId) {
+        isFollower = true;
+        currentPlatoonID = newPlatoonId;
+        platoon = {};
+        ROS_DEBUG("The platoon manager is changed from leader state to follower state.");
+    }
+
+    int PlatoonManager::getNumberOfVehicleInFront() {
+        if(isFollower) {
+            return platoon.size();
+        }
+        return 0;
+    }
+
+    
+     //Currently not used in implementation
+    double PlatoonManager::getDistanceFromRouteStart() const{
+        return 0.0;
+    }
+
+    double PlatoonManager::getDistanceToFrontVehicle() {
+        return gapWithFront;
+    }
+
+    double PlatoonManager::getCurrentSpeed() const {
+        return current_speed_;
+    }
+
+    double PlatoonManager::getCommandSpeed(){
+        return command_speed_;
+    }
+
+    double PlatoonManager::getCurrentDowntrackDistance() const{
+        
+        lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
+        auto current_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, current_loc, 1);
+        if(current_lanelets.size() == 0)
+        {
+            ROS_WARN_STREAM("Cannot find any lanelet in map!");
+            return true;
+        }
+        auto current_lanelet = current_lanelets[0];
+        auto shortest_path = wm_->getRoute()->shortestPath();
+        double current_progress = wm_->routeTrackPos(current_loc).downtrack;
+        return current_progress;
+    }
+
+    
+
+    double PlatoonManager::getCurrentPlatoonLength() {
+        if(platoon.size() == 0) {
+            return vehicleLength;
+        } else {
+            return getCurrentDowntrackDistance() - platoon[platoon.size() - 1].vehiclePosition + vehicleLength; 
+        }
+    }
+
+
+    void PlatoonManager::cmd_cd(const geometry_msgs::TwistStampedConstPtr& msg)
+    {
+        command_speed_ = msg->twist.linear.x;
+    }
+
+    void PlatoonManager::twist_cd(const geometry_msgs::TwistStampedConstPtr& msg)
+    {
+        current_speed_ = msg->twist.linear.x;
+    }
+
+    void PlatoonManager::pose_cb(const geometry_msgs::PoseStampedConstPtr& msg){
+        pose_msg_ = geometry_msgs::PoseStamped(*msg.get());
+    }
+
+}

--- a/platooning_strategic/src/platoon_strategic.cpp
+++ b/platooning_strategic/src/platoon_strategic.cpp
@@ -1,0 +1,414 @@
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <ros/ros.h>
+#include <string>
+#include "platoon_strategic.hpp"
+
+namespace platoon_strategic
+{
+    PlatoonStrategicPlugin::PlatoonStrategicPlugin(){}
+                                    
+
+    void PlatoonStrategicPlugin::initialize()
+    {
+        nh_.reset(new ros::CARMANodeHandle());
+        pnh_.reset(new ros::CARMANodeHandle("~"));
+
+        
+        
+        maneuver_srv_ = nh_->advertiseService("strategic_plan/plan_maneuvers", &PlatoonStrategicPlugin::plan_maneuver_cb, this);
+
+        mob_op_pub_ = nh_->advertise<cav_msgs::MobilityOperation>("mobility_operation_message", 5);
+        mob_req_pub_ = nh_->advertise<cav_msgs::MobilityRequest>("mobility_request_message", 5);
+                
+        platoon_strategic_plugin_discovery_pub_ = nh_->advertise<cav_msgs::Plugin>("plugin_discovery", 1);
+        plugin_discovery_msg_.name = "PlatooningStrategicPlugin";
+        plugin_discovery_msg_.versionId = "v1.0";
+        plugin_discovery_msg_.available = true;
+        plugin_discovery_msg_.activated = false;
+        plugin_discovery_msg_.type = cav_msgs::Plugin::STRATEGIC;
+        plugin_discovery_msg_.capability = "strategic_plan/plan_maneuvers";
+        
+        pose_sub_ = nh_->subscribe("current_pose", 1, &PlatoonStrategicPlugin::pose_cb, this);
+
+        mob_req_sub_ = nh_->subscribe("incoming_mobility_request_message", 1, &PlatoonStrategicPlugin::mob_req_cb, this);
+        mob_resp_sub_ = nh_->subscribe("incoming_mobility_response_message", 1, &PlatoonStrategicPlugin::mob_resp_cb, this);
+        mob_op_sub_ = nh_->subscribe("incoming_mobility_operation_message", 1, &PlatoonStrategicPlugin::mob_op_cb, this);
+
+
+        ros::CARMANodeHandle::setSpinCallback([this]() -> bool {
+            platoon_strategic_plugin_discovery_pub_.publish(plugin_discovery_msg_);
+            return true;
+        });
+
+
+    }
+
+    void PlatoonStrategicPlugin::run_states(){
+        
+        switch (psm_.current_platoon_state)
+        {
+        case PlatoonState::STANDBY:
+            break;
+        case PlatoonState::LEADERWAITING:
+            waitingStartTime = ros::Time::now().toSec()*1000;
+            run_leader_waiting();
+            break;
+
+        case PlatoonState::LEADER:
+            run_leader();
+            break;
+        
+        case PlatoonState::CANDIDATEFOLLOWER:
+            candidatestateStartTime = ros::Time::now().toSec()*1000;
+            run_candidate_follower();
+            break;
+        
+        case PlatoonState::FOLLOWER:
+            run_follower();
+            break;
+        
+        default:
+            throw std::invalid_argument("Invalid State");
+            break;
+        }
+
+
+    }
+
+    void PlatoonStrategicPlugin::run()
+    {
+    	initialize();
+        psm_.onMobilityRequestMessage(mobility_req_msg_);
+        psm_.onMobilityOperationMessage(mobility_op_msg_);
+        psm_.onMobilityResponseMessage(mobility_resp_msg_);
+        run_states();
+        ros::CARMANodeHandle::setSpinRate(10.0);
+        ros::CARMANodeHandle::spin();
+
+    }
+
+    void PlatoonStrategicPlugin::pose_cb(const geometry_msgs::PoseStampedConstPtr& msg)
+    {
+        pose_msg_ = msg;
+    }
+
+    bool PlatoonStrategicPlugin::plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp){
+        
+        cav_msgs::Maneuver new_maneuver = psm_.composeManeuver();
+        resp.new_plan.maneuvers.push_back(new_maneuver);
+        return true;
+    }
+
+
+
+    void PlatoonStrategicPlugin::run_leader_waiting(){
+        long tsStart = ros::Time::now().toSec()*1000;
+            // Task 1
+                if(tsStart - waitingStartTime > waitingStateTimeout * 1000) {
+                    //TODO if the current state timeouts, we need to have a kind of ABORT message to inform the applicant
+                    ROS_DEBUG("LeaderWaitingState is timeout, changing back to PlatoonLeaderState.");
+                    psm_.current_platoon_state = PlatoonState::LEADER;
+                }
+                // Task 2
+                cav_msgs::MobilityOperation status;
+                composeMobilityOperationLeaderWaiting(status);
+                mob_op_pub_.publish(status);
+                long tsEnd = ros::Time::now().toSec()*1000;
+                int sleepDuration = std::max(int(statusMessageInterval - (tsEnd - tsStart)), 0);
+                ros::Duration(sleepDuration/1000).sleep();
+    }
+
+    void PlatoonStrategicPlugin::run_leader(){
+
+        long tsStart = ros::Time::now().toSec()*1000;
+            // Task 1
+            bool isTimeForHeartBeat = tsStart - lastHeartBeatTime >= infoMessageInterval;
+            if(isTimeForHeartBeat) {
+                    cav_msgs::MobilityOperation infoOperation;
+                    composeMobilityOperationLeader(infoOperation, "INFO");
+                    mob_op_pub_.publish(infoOperation);
+                    lastHeartBeatTime = ros::Time::now().toSec()*1000.0;
+                    ROS_DEBUG("Published heart beat platoon INFO mobility operatrion message");
+                }
+            // Task 2
+            if (isTimeForHeartBeat) {
+                    // updateLightBar();
+            }
+            // Task 3
+            {
+                std::lock_guard<std::mutex> lock(plan_mutex_);
+                if(psm_.current_plan.valid) {
+                    bool isCurrentPlanTimeout = ((ros::Time::now().toSec()*1000 - psm_.current_plan.planStartTime) > NEGOTIATION_TIMEOUT);
+                    if(isCurrentPlanTimeout) {
+                        ROS_DEBUG("Give up current on waiting plan with planId: " , psm_.current_plan.planId);
+                        psm_.current_plan.valid = false;
+                    }    
+                }
+            }
+
+            // Task 4
+            bool hasFollower = (psm_.pm_.getTotalPlatooningSize() > 1);
+            if(hasFollower) {
+                cav_msgs::MobilityOperation statusOperation;
+                composeMobilityOperationLeader(statusOperation, "STATUS");
+                mob_op_pub_.publish(statusOperation);
+                ROS_DEBUG("Published platoon STATUS operation message");
+            }
+            long tsEnd =  ros::Time::now().toSec()*1000;
+            long sleepDuration = std::max(int(statusMessageInterval - (tsEnd - tsStart)), 0);
+            ros::Duration(sleepDuration/1000).sleep();
+        
+    }
+
+    void PlatoonStrategicPlugin::run_follower(){
+        // This is a interrupted-safe loop.
+        // This loop has four tasks:
+        // 1. Check the state start time, if it exceeds a limit it will give up current plan and change back to leader state
+        // 2. Abort current request if we wait for long enough time for response from leader and change back to leader state
+        // 3. Check the current distance with the target platoon rear and send out CANDIDATE-JOIN request when we get close
+        // 4. Publish operation status every 100 milliseconds if we still have followers
+        long tsStart = ros::Time::now().toSec()*1000;
+            // Job 1
+            cav_msgs::MobilityOperation status;
+            composeMobilityOperationFollower(status);
+            mob_op_pub_.publish(status);
+            // Job 2
+            // Get the number of vehicles in this platoon who is in front of us
+            int vehicleInFront = psm_.pm_.getNumberOfVehicleInFront();
+                if(vehicleInFront == 0) {
+                    noLeaderUpdatesCounter++;
+                    if(noLeaderUpdatesCounter >= LEADER_TIMEOUT_COUNTER_LIMIT) {
+                        ROS_DEBUG("noLeaderUpdatesCounter = " , noLeaderUpdatesCounter , " and change to leader state");
+                        psm_.pm_.changeFromFollowerToLeader();
+                        psm_.current_platoon_state = PlatoonState::LEADER;
+                        
+                    }
+                } else {
+                    // reset counter to zero when we get updates again
+                    noLeaderUpdatesCounter = 0;
+                }
+                long tsEnd = ros::Time::now().toSec()*1000.0;
+                long sleepDuration = std::max(int(statusMessageInterval - (tsEnd - tsStart)), 0);
+                ros::Duration(sleepDuration/1000).sleep();
+        
+    }
+
+    void PlatoonStrategicPlugin::run_candidate_follower(){
+        long tsStart = ros::Time::now().toSec()*1000.0; 
+        // Task 1
+        bool isCurrentStateTimeout = (tsStart - candidatestateStartTime) > waitingStateTimeout * 1000;
+        if(isCurrentStateTimeout) {
+            ROS_DEBUG("The current candidate follower state is timeout. Change back to leader state.");
+            psm_.current_platoon_state = PlatoonState::LEADER;
+        }
+        // Task 2
+
+        if(psm_.current_plan.valid) {
+            {
+                std::lock_guard<std::mutex> lock(plan_mutex_);
+                if(psm_.current_plan.valid) {
+                    bool isPlanTimeout = (tsStart - psm_.current_plan.planStartTime) > NEGOTIATION_TIMEOUT;
+                    if(isPlanTimeout) {
+                        psm_.current_plan.valid = false;
+                        ROS_DEBUG("The current plan did not receive any response. Abort and change to leader state.");
+                        psm_.current_platoon_state = PlatoonState::LEADER;
+                    }    
+                }
+            }
+        }
+
+        // Task 3
+                double desiredJoinGap2 = desiredJoinTimeGap;
+                double maxJoinGap = std::max(desiredJoinGap, desiredJoinGap2);
+                double currentGap = psm_.pm_.getDistanceToFrontVehicle();
+                ROS_DEBUG("Based on desired join time gap, the desired join distance gap is " , desiredJoinGap2 , " ms");
+                ROS_DEBUG("Since we have max allowed gap as " , desiredJoinGap , " m then max join gap became " , maxJoinGap , " m");
+                ROS_DEBUG("The current gap from radar is " , currentGap , " m");
+                if(currentGap <= maxJoinGap && psm_.current_plan.valid == false) {
+                    cav_msgs::MobilityRequest request;
+                    std::string planId = boost::uuids::to_string(boost::uuids::random_generator()());
+                    long currentTime = ros::Time::now().toSec()*1000.0; 
+                    request.header.plan_id = planId;
+                    request.header.recipient_id = psm_.targetLeaderId;
+                    request.header.sender_bsm_id = BSMID;
+                    request.header.sender_id = MobilityId;
+                    request.header.timestamp = currentTime;
+                    cav_msgs::LocationECEF loc;
+                    request.location = loc;
+                    request.plan_type.type = cav_msgs::PlanType::PLATOON_FOLLOWER_JOIN;
+                    std::string MOBILITY_STRATEGY;
+                    request.strategy = MOBILITY_STRATEGY;
+                    request.strategy_params = "";
+                    request.urgency = 50;
+                    mob_req_pub_.publish(request);
+                    ROS_DEBUG("Published Mobility Candidate-Join request to the leader");
+                    
+                    PlatoonPlan* new_plan = new PlatoonPlan(true, currentTime, planId, psm_.targetLeaderId);
+
+                    psm_.current_plan = *new_plan;
+                }
+        
+         //Task 4
+                if(psm_.pm_.getTotalPlatooningSize() > 1) {
+                    cav_msgs::MobilityOperation status;
+                    composeMobilityOperationCandidateFollower(status);
+                    mob_op_pub_.publish(status);
+                    ROS_DEBUG("Published platoon STATUS operation message");
+                }
+                long tsEnd =  ros::Time::now().toSec()*1000;
+                long sleepDuration = std::max(int(statusMessageInterval - (tsEnd - tsStart)), 0);
+                ros::Duration(sleepDuration/1000).sleep();
+        
+    }
+
+
+
+    void PlatoonStrategicPlugin::mob_req_cb(const cav_msgs::MobilityRequest& msg)
+    {
+        mobility_req_msg_ = msg;
+    }
+
+    void PlatoonStrategicPlugin::mob_resp_cb(const cav_msgs::MobilityResponse& msg)
+    {
+        mobility_resp_msg_ = msg;
+    }
+
+    void PlatoonStrategicPlugin::mob_op_cb(const cav_msgs::MobilityOperation& msg)
+    {
+        mobility_op_msg_ = msg;
+    }
+
+
+    void PlatoonStrategicPlugin::composeMobilityOperationLeader(cav_msgs::MobilityOperation &msg, const std::string& type){
+        msg.header.plan_id = psm_.pm_.currentPlatoonID;
+        msg.header.recipient_id = "";
+        msg.header.sender_bsm_id = BSMID;
+        std::string hostStaticId = HostMobilityId;
+        msg.header.sender_id = hostStaticId;
+        msg.header.timestamp = ros::Time::now().toSec()*1000.0;
+        msg.strategy = MOBILITY_STRATEGY;
+
+        if (type == OPERATION_INFO_TYPE){
+            // For INFO params, the string format is INFO|REAR:%s,LENGTH:%.2f,SPEED:%.2f,SIZE:%d
+
+            std::string PlatoonRearBsmId = BSMID;
+            int CurrentPlatoonLength = psm_.pm_.getCurrentPlatoonLength();
+            double current_speed = psm_.pm_.getCurrentSpeed();
+            int PlatoonSize = psm_.pm_.getTotalPlatooningSize();
+            double PlatoonRearDowntrackDistance = psm_.pm_.getPlatoonRearDowntrackDistance();
+
+            boost::format fmter(OPERATION_INFO_TYPE);
+            fmter %PlatoonRearBsmId;
+            fmter %CurrentPlatoonLength;
+            fmter %current_speed;
+            fmter %PlatoonSize;
+            fmter %PlatoonRearDowntrackDistance;
+
+            std::string infoParams = fmter.str();
+            msg.strategy_params = infoParams;
+        }
+        else if (type == OPERATION_STATUS_TYPE){
+            // For STATUS params, the string format is "STATUS|CMDSPEED:xx,DTD:xx,SPEED:xx"
+            double cmdSpeed, current_speed, current_downtrack;
+            boost::format fmter(OPERATION_STATUS_PARAMS);
+            fmter %cmdSpeed;
+            fmter %current_downtrack;
+            fmter %current_speed;
+                    
+            std::string statusParams = fmter.str();
+            msg.strategy_params = statusParams;
+        } else {
+            ROS_ERROR("UNKNOW strategy param string!!!");
+            msg.strategy_params = "";
+        }
+        ROS_DEBUG("Composed a mobility operation message with params " , msg.strategy_params);
+    
+    }
+
+    void PlatoonStrategicPlugin::composeMobilityOperationFollower(cav_msgs::MobilityOperation &msg) const{
+        msg.header.plan_id = psm_.pm_.currentPlatoonID;
+        // All platoon mobility operation message is just for broadcast
+        msg.header.recipient_id = "";
+        msg.header.sender_bsm_id = BSMID;
+        std::string hostStaticId = HostMobilityId;
+        msg.header.sender_id = hostStaticId;
+        msg.header.timestamp = ros::Time::now().toSec()*1000.0;
+        msg.strategy = MOBILITY_STRATEGY;
+        
+        double cmdSpeed, current_speed, current_downtrack;
+
+        boost::format fmter(OPERATION_STATUS_PARAMS);
+        fmter %cmdSpeed;
+        fmter %current_downtrack;
+        fmter %current_speed;
+                    
+        std::string statusParams = fmter.str();
+        msg.strategy_params = statusParams;
+        ROS_DEBUG("Composed a mobility operation message with params " , msg.strategy_params);
+    }
+
+
+    void PlatoonStrategicPlugin::composeMobilityOperationLeaderWaiting(cav_msgs::MobilityOperation &msg) const
+    {
+        msg.header.plan_id = psm_.pm_.currentPlatoonID;
+        // This message is for broadcast
+        msg.header.recipient_id = "";
+        msg.header.sender_bsm_id = BSMID;
+        std::string hostStaticId = HostMobilityId;
+        msg.header.sender_id = hostStaticId;
+        msg.header.timestamp = ros::Time::now().toSec()*1000;
+        msg.strategy = MOBILITY_STRATEGY;
+        // For STATUS params, the string format is "STATUS|CMDSPEED:5.0,DOWNTRACK:100.0,SPEED:5.0"
+        double cmdSpeed, current_speed, current_downtrack;
+        boost::format fmter(OPERATION_STATUS_PARAMS);
+        fmter %cmdSpeed;
+        fmter %current_downtrack;
+        fmter %current_speed;
+                    
+        std::string statusParams = fmter.str();
+        msg.strategy_params = statusParams;
+        
+    }
+
+
+    void PlatoonStrategicPlugin::composeMobilityOperationCandidateFollower(cav_msgs::MobilityOperation &msg)
+    {
+        msg.header.plan_id = psm_.pm_.currentPlatoonID;
+        // All platoon mobility operation message is just for broadcast
+        msg.header.recipient_id = "";
+        msg.header.sender_bsm_id = BSMID;
+        std::string hostStaticId = HostMobilityId;
+        msg.header.sender_id = hostStaticId;
+        msg.header.timestamp = ros::Time::now().toSec()*1000.0; 
+        msg.strategy = MOBILITY_STRATEGY;
+        
+        // // For STATUS params, the string format is "STATUS|CMDSPEED:xx,DTD:xx,SPEED:xx"
+        
+        double cmdSpeed, current_speed, current_downtrack;
+        boost::format fmter(OPERATION_STATUS_PARAMS);
+        fmter %cmdSpeed;
+        fmter %current_downtrack;
+        fmter %current_speed;
+                    
+        std::string statusParams = fmter.str();
+        msg.strategy_params = statusParams;
+        ROS_DEBUG("Composed a mobility operation message with params " , msg.strategy_params);
+    }
+
+
+}

--- a/platooning_strategic/src/state_machine.cpp
+++ b/platooning_strategic/src/state_machine.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "state_machine.hpp"
+
+namespace platoon_strategic
+{
+
+    PlatooningStateMachine::PlatooningStateMachine(): current_platoon_state(PlatoonState::STANDBY){};
+
+
+
+    PlatooningStateMachine::PlatooningStateMachine(std::shared_ptr<ros::CARMANodeHandle> nh): 
+        nh_(nh),
+        current_platoon_state(PlatoonState::STANDBY) {
+            mob_req_pub_ = nh_->advertise<cav_msgs::MobilityRequest>("mobility_request_message", 5);
+        };
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessage(cav_msgs::MobilityRequest &msg){
+        switch (current_platoon_state)
+        {
+        case PlatoonState::FOLLOWER:
+            return onMobilityRequestMessageFollower(msg);
+            break;
+        case PlatoonState::LEADER:
+            return onMobilityRequestMessageLeader(msg);
+            break;
+
+        case PlatoonState::LEADERWAITING:
+            return onMobilityRequestMessageLeaderWaiting(msg);
+            break;
+
+        case PlatoonState::CANDIDATEFOLLOWER:
+            return onMobilityRequestMessageCandidateFollower(msg);
+            break;
+        
+        case PlatoonState::STANDBY:
+            return onMobilityRequestMessageStandby(msg);
+            break;
+        
+        default:
+            throw std::invalid_argument("State machine attempting to process an illegal state value");
+        }
+        
+    }
+
+    void PlatooningStateMachine::onMobilityResponseMessage(cav_msgs::MobilityResponse &msg){
+        switch (current_platoon_state)
+        {
+        case PlatoonState::FOLLOWER:
+            onMobilityResponseMessageFollower(msg);
+            break;
+        case PlatoonState::LEADER:
+            onMobilityResponseMessageLeader(msg);
+            break;
+
+        case PlatoonState::LEADERWAITING:
+            onMobilityResponseMessageLeaderWaiting(msg);
+            break;
+
+        case PlatoonState::CANDIDATEFOLLOWER:
+            onMobilityResponseMessageCandidateFollower(msg);
+            break;
+        
+        case PlatoonState::STANDBY:
+            onMobilityResponseMessageStandby(msg);
+            break;
+        
+        default:
+            throw std::invalid_argument("State machine attempting to process an illegal state value");
+        }
+    }
+
+
+    void PlatooningStateMachine::onMobilityOperationMessage(cav_msgs::MobilityOperation &msg){
+        switch (current_platoon_state)
+        {
+        case PlatoonState::FOLLOWER:
+            onMobilityOperationMessageFollower(msg);
+            break;
+        case PlatoonState::LEADER:
+            onMobilityOperationMessageLeader(msg);
+            break;
+
+        case PlatoonState::LEADERWAITING:
+            onMobilityOperationMessageLeaderWaiting(msg);
+            break;
+
+        case PlatoonState::CANDIDATEFOLLOWER:
+            onMobilityOperationMessageCandidateFollower(msg);
+            break;
+        
+        case PlatoonState::STANDBY:
+            onMobilityOperationMessageStandby(msg);
+            break;
+        
+        default:
+            throw std::invalid_argument("State machine attempting to process an illegal state value");
+        }
+        
+    }
+
+    cav_msgs::Maneuver PlatooningStateMachine::composeManeuver(){
+        cav_msgs::Maneuver maneuver_msg;
+        
+
+        if (current_platoon_state == PlatoonState::FOLLOWER){
+            ros::Time current_time = ros::Time::now();
+            maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
+            double start_dist = pm_.getCurrentDowntrackDistance();
+            maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::PLATOONING;
+            maneuver_msg.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
+            maneuver_msg.lane_following_maneuver.parameters.planning_tactical_plugin = "PlatooningTacticalPlugin";
+            maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = "PlatooningStrategicPlugin";
+            maneuver_msg.lane_following_maneuver.start_dist = start_dist;
+            maneuver_msg.lane_following_maneuver.start_speed = pm_.command_speed_;
+            maneuver_msg.lane_following_maneuver.start_time = current_time;
+            maneuver_msg.lane_following_maneuver.end_dist = start_dist + (mvr_duration_*pm_.command_speed_);
+            maneuver_msg.lane_following_maneuver.end_speed = pm_.command_speed_;
+            // because it is a rough plan, assume vehicle can always reach to the target speed in a lanelet
+            maneuver_msg.lane_following_maneuver.end_time = current_time + ros::Duration(mvr_duration_);
+	    //TODO: Add actual lane id here
+            maneuver_msg.lane_following_maneuver.lane_id = "";
+        }
+        
+        return maneuver_msg;
+    }
+
+
+
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessageFollower(cav_msgs::MobilityRequest &msg) const
+    {
+        return MobilityRequestResponse::NO_RESPONSE;
+    }
+
+
+    void PlatooningStateMachine::onMobilityResponseMessageFollower(cav_msgs::MobilityResponse &msg) const
+    {
+
+    }
+
+    void PlatooningStateMachine::onMobilityOperationMessageFollower(cav_msgs::MobilityOperation &msg)
+    {
+        std::string strategyParams = msg.strategy_params;
+        // In the current state, we care about the STATUS message
+        bool isPlatoonStatusMsg = (strategyParams.find(OPERATION_STATUS_TYPE) == 0);
+        bool isPlatoonInfoMsg = (strategyParams.find(OPERATION_INFO_TYPE) == 0);
+        // If it is platoon status message, the params string is in format:
+        // STATUS|CMDSPEED:xx,DTD:xx,SPEED:xx
+        if(isPlatoonStatusMsg) {
+            std::string vehicleID = msg.header.sender_id;
+            std::string platoonID = msg.header.plan_id;
+            std::string statusParams = strategyParams.substr(OPERATION_STATUS_TYPE.size()+1);
+            ROS_DEBUG("Receive operation message from vehicle: " , vehicleID);
+            std::string SenderBsmId = msg.header.sender_bsm_id;
+            pm_.memberUpdates(vehicleID, platoonID, SenderBsmId, statusParams);
+        } else if(isPlatoonInfoMsg) {
+                if(msg.header.sender_id == pm_.leaderID) {
+                    std::string infoParams = strategyParams.substr(OPERATION_INFO_TYPE.size()+1);
+
+                    std::vector<std::string> parsed_params;
+                    boost::algorithm::split(parsed_params, infoParams, boost::is_any_of(","));
+                    std::vector<std::string> parsed_size;
+                    boost::algorithm::split(parsed_size, parsed_params[3], boost::is_any_of(":"));
+
+                    pm_.platoonSize = std::stoi(parsed_size[1]);
+
+                    ROS_DEBUG("Update from the lead: the current platoon size is " , pm_.getTotalPlatooningSize());
+                }
+        }else{
+            ROS_DEBUG("Ignore other operation messages with params: " , strategyParams);
+        }
+    }
+
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessageLeader(cav_msgs::MobilityRequest &msg)
+    {
+        // If we received a JOIN request, we decide whether we allow that CAV to join.
+        // If we agree on its join, we need to change to LeaderWaiting state.
+        if (msg.plan_type.type == cav_msgs::PlanType::JOIN_PLATOON_AT_REAR){
+            // We are currently checking two basic JOIN conditions:
+            //     1. The size limitation on current platoon based on the plugin's parameters.
+            //     2. Calculate how long that vehicle can be in a reasonable distance to actually join us.
+            std::string params = msg.strategy_params;
+            std::string applicantId = msg.header.sender_id;
+            ROS_DEBUG("Receive mobility JOIN request from " , applicantId, " and PlanId = " , msg.header.plan_id);
+            ROS_DEBUG("The strategy parameters are " , params);
+            // For JOIN_PLATOON_AT_REAR message, the strategy params is defined as "SIZE:xx,SPEED:xx,DTD:xx"
+            // TODO In future, we should remove down track distance from this string and use location field in request message
+            
+            std::vector<std::string> parsed_params;
+            boost::algorithm::split(parsed_params, params, boost::is_any_of(","));
+
+            std::vector<std::string> parsed_size;
+            boost::algorithm::split(parsed_size, parsed_params[0], boost::is_any_of(":"));
+            int applicantSize = std::stoi(parsed_size[1]);
+
+            std::vector<std::string> parsed_speed;
+            boost::algorithm::split(parsed_speed, parsed_params[1], boost::is_any_of(":"));
+            double applicantCurrentSpeed = std::stod(parsed_size[1]);
+
+            std::vector<std::string> parsed_dtd;
+            boost::algorithm::split(parsed_dtd, parsed_params[1], boost::is_any_of(":"));
+            double applicantCurrentDtd = std::stod(parsed_size[1]);
+
+            // Check if we have enough room for that applicant
+            int currentPlatoonSize = pm_.getTotalPlatooningSize();
+            bool hasEnoughRoomInPlatoon = applicantSize + currentPlatoonSize <= maxPlatoonSize;
+            if(hasEnoughRoomInPlatoon) {
+                ROS_DEBUG("The current platoon has enough room for the applicant with size " , applicantSize);
+                double currentRearDtd = pm_.getPlatoonRearDowntrackDistance();
+                ROS_DEBUG("The current platoon rear dtd is " , currentRearDtd);
+                double currentGap = currentRearDtd - applicantCurrentDtd - vehicleLength;
+                double currentTimeGap = currentGap / applicantCurrentSpeed;
+                ROS_DEBUG("The gap between current platoon rear and applicant is " , currentGap , "m or " , currentTimeGap , "s");
+                if(currentGap < 0) {
+                    ROS_WARN("We should not receive any request from the vehicle in front of us. NACK it.");
+                    return MobilityRequestResponse::NACK;
+                }
+                // Check if the applicant can join based on max timeGap/gap
+                bool isDistanceCloseEnough = (currentGap <= maxAllowedJoinGap) || (currentTimeGap <= maxAllowedJoinTimeGap);
+                if(isDistanceCloseEnough) {
+                    ROS_DEBUG("The applicant is close enough and we will allow it to try to join");
+                    ROS_DEBUG("Change to LeaderWaitingState and waiting for " , msg.header.sender_id , " to join");
+                    current_platoon_state = PlatoonState::LEADERWAITING;
+                    // applicantID = applicantId;
+                    return MobilityRequestResponse::ACK;
+                }
+                else {
+                    ROS_DEBUG("The applicant is too far away from us. NACK.");
+                    return MobilityRequestResponse::NACK;
+                }
+            }
+            else {
+                ROS_DEBUG("The current platoon does not have enough room for applicant of size " , applicantSize , ". NACK");
+                return MobilityRequestResponse::NACK;
+            }
+        }
+        else {
+            ROS_DEBUG("Received mobility request with type " , msg.plan_type.type , " and ignored." );
+        }
+        return MobilityRequestResponse::NO_RESPONSE;
+    }
+
+
+    void PlatooningStateMachine::onMobilityResponseMessageLeader(cav_msgs::MobilityResponse &msg)
+    {
+        // Only care the response message for the plan for which we are waiting
+        {
+            std::lock_guard<std::mutex> lock(plan_mutex_);
+            if (current_plan.valid){
+                if ((current_plan.planId == msg.header.plan_id) && (current_plan.peerId == msg.header.sender_id)){
+                    if (msg.is_accepted){
+                        ROS_DEBUG("Received positive response for plan id = " , current_plan.planId);
+                        ROS_DEBUG("Change to CandidateFollower state and notify trajectory failure in order to replan");
+        //                 // Change to candidate follower state and request a new plan to catch up with the front platoon
+                        current_platoon_state = PlatoonState::CANDIDATEFOLLOWER;
+                        targetLeaderId = current_plan.peerId;
+                        
+                    } else{
+                        ROS_DEBUG("Received negative response for plan id = " , current_plan.planId);
+                        // Forget about the previous plan totally
+                            current_plan.valid = false;
+                    }
+                } else{
+                    ROS_DEBUG("Ignore the response message because planID match: " , current_plan.planId == msg.header.plan_id);
+                    ROS_DEBUG("My plan id = " , current_plan.planId , " and response plan Id = " , msg.header.plan_id);
+                    ROS_DEBUG("And peer id match: " , current_plan.peerId == msg.header.sender_id);
+                    ROS_DEBUG("Expected peer id = " , current_plan.peerId , " and response sender Id = " , msg.header.sender_id);
+                }
+            }
+        }
+
+    }
+
+    void PlatooningStateMachine::onMobilityOperationMessageLeader(cav_msgs::MobilityOperation &msg)
+    {
+        std::string strategyParams = msg.strategy_params;
+        std::string senderId = msg.header.sender_id;
+        std::string platoonId = msg.header.plan_id;
+        // In the current state, we care about the INFO heart-beat operation message if we are not currently in
+        // a negotiation, and also we need to care about operation from members in our current platoon
+
+        bool isPlatoonInfoMsg = (strategyParams.find(OPERATION_INFO_TYPE) == 0);// = strategyParams.startsWith(PlatooningPlugin.OPERATION_INFO_TYPE);
+        bool isPlatoonStatusMsg = (strategyParams.find(OPERATION_STATUS_TYPE) == 0);;// = strategyParams.startsWith(PlatooningPlugin.OPERATION_STATUS_TYPE);
+        {
+            std::lock_guard<std::mutex> lock(plan_mutex_);
+
+            bool isNotInNegotiation = (!current_plan.valid);
+            if(isPlatoonInfoMsg && isNotInNegotiation) {
+                // For INFO params, the string format is INFO|REAR:%s,LENGTH:%.2f,SPEED:%.2f,SIZE:%d
+                // TODO In future, we should remove downtrack distance from this string and send XYZ location in ECEF
+                std::vector<std::string> parsed_strategy_params;
+                boost::algorithm::split(parsed_strategy_params, strategyParams, boost::is_any_of(","));
+
+                std::vector<std::string> parsed_BsmId;
+                boost::algorithm::split(parsed_BsmId, parsed_strategy_params[0], boost::is_any_of(":"));
+                std::string rearVehicleBsmId = parsed_BsmId[1];
+
+                std::vector<std::string> parsed_dtd;
+                boost::algorithm::split(parsed_dtd, parsed_strategy_params[4], boost::is_any_of(":"));
+                double rearVehicleDtd = std::stod(parsed_dtd[1]);
+                // We are trying to validate is the platoon rear is right in front of the host vehicle
+                if(isVehicleRightInFront(rearVehicleBsmId, rearVehicleDtd)) {
+                    ROS_DEBUG("Found a platoon with id = " , platoonId , " in front of us.");
+                    cav_msgs::MobilityRequest request;
+                    std::string planId = boost::uuids::to_string(boost::uuids::random_generator()());
+                    long currentTime = ros::Time::now().toSec();
+                    request.header.plan_id = planId;
+                    request.header.recipient_id = senderId;
+                    cav_msgs::LocationECEF location; //from GPS?
+                    request.location = location;
+                    request.plan_type.type = cav_msgs::PlanType::JOIN_PLATOON_AT_REAR;
+                    request.strategy = MOBILITY_STRATEGY;
+
+
+                    double total_platoon_size = pm_.getTotalPlatooningSize();
+                    double current_speed = pm_.current_speed_;
+                    double current_downtrack = pm_.getCurrentDowntrackDistance();
+
+                    boost::format fmter(JOIN_AT_REAR_PARAMS);
+                    fmter %total_platoon_size;
+                    fmter %current_speed;
+                    fmter %current_downtrack;
+ 
+                    std::string strategyParamsString = fmter.str(); 
+                    request.strategy_params = strategyParamsString;
+                    request.urgency = 50;
+                    mob_req_pub_.publish(request);
+                    PlatoonPlan* new_plan = new PlatoonPlan(true, currentTime, planId, senderId);
+                    current_plan = *new_plan;
+
+                    
+                    ROS_DEBUG("Publishing request to leader " , senderId , " with params " , request.strategy_params , " and plan id = " , request.header.plan_id);
+                    // this.potentialNewPlatoonId = platoonId;
+                } else{
+                        ROS_DEBUG("Ignore platoon with platoon id: " , platoonId , " because it is not right in front of us");
+                }
+            }
+            else if(isPlatoonStatusMsg) {
+                // If it is platoon status message, the params string is in format: STATUS|CMDSPEED:xx,DTD:xx,SPEED:xx
+                std::string statusParams = strategyParams.substr(OPERATION_STATUS_TYPE.size()+1);// = strategyParams.substring(PlatooningPlugin.OPERATION_STATUS_TYPE.length() + 1);
+                ROS_DEBUG("Receive operation status message from vehicle: " , senderId , " with params: " , statusParams);
+                std::string SenderBsmId = msg.header.sender_bsm_id;
+                pm_.memberUpdates(senderId, platoonId, SenderBsmId, statusParams);
+            }
+            else {
+                ROS_DEBUG("Receive operation message but ignore it because isPlatoonInfoMsg = " , isPlatoonInfoMsg 
+                        , ", isNotInNegotiation = " , isNotInNegotiation , " and isPlatoonStatusMsg = " , isPlatoonStatusMsg);
+            }
+
+        }
+    }
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessageLeaderWaiting(cav_msgs::MobilityRequest &msg)
+    {
+        bool isTargetVehicle = (msg.header.sender_id == applicantID);
+        bool isCandidateJoin = (msg.plan_type.type == cav_msgs::PlanType::PLATOON_FOLLOWER_JOIN);
+        if(isTargetVehicle && isCandidateJoin) {
+            ROS_DEBUG("Target vehicle " , applicantID , " is actually joining.");
+            ROS_DEBUG("Changing to PlatoonLeaderState and send ACK to target vehicle");
+            current_platoon_state = PlatoonState::LEADER;
+            return MobilityRequestResponse::ACK;
+        }
+        else{
+            ROS_DEBUG("Received platoon request with vehicle id = " , msg.header.sender_id);
+            ROS_DEBUG("The request type is " , msg.plan_type.type,  " and we choose to ignore");
+            return MobilityRequestResponse::NO_RESPONSE;
+        }
+    }
+
+    void PlatooningStateMachine::onMobilityResponseMessageLeaderWaiting(cav_msgs::MobilityResponse &msg) const
+    {
+        // Do Nothing
+    }
+
+    void PlatooningStateMachine::onMobilityOperationMessageLeaderWaiting(cav_msgs::MobilityOperation &msg)
+    {
+        // We still need to handle STATUS operation message from our platoon
+        std::string strategyParams = msg.strategy_params;
+        std::string OPERATION_STATUS_TYPE;
+        bool isPlatoonStatusMsg = (strategyParams.find(OPERATION_STATUS_TYPE) == 0); 
+        if (isPlatoonStatusMsg){
+            std::string vehicleID = msg.header.sender_id;
+            std::string platoonID = msg.header.plan_id;
+            std::string statusParams = strategyParams.substr(OPERATION_STATUS_TYPE.size()+1); 
+            std::string SenderBsmId = msg.header.sender_bsm_id;
+            pm_.memberUpdates(vehicleID, platoonID, SenderBsmId, statusParams);
+            ROS_DEBUG("Received platoon status message from " , msg.header.sender_id);
+        }
+        else
+        {
+            ROS_DEBUG("Received a mobility operation message with params " , msg.strategy_params + " but ignored.");
+        }
+    }
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessageCandidateFollower(cav_msgs::MobilityRequest &msg) const
+    {
+        // No need to response as a follower
+        return MobilityRequestResponse::NO_RESPONSE;
+    }
+    void PlatooningStateMachine::onMobilityResponseMessageCandidateFollower(cav_msgs::MobilityResponse &msg)
+    {
+        // Waiting on response for the current Candidate-Join plan
+        if (current_plan.valid){
+            {
+                std::lock_guard<std::mutex> lock(plan_mutex_);
+                if (current_plan.valid){
+                    bool isForCurrentPlan = (msg.header.plan_id == current_plan.planId);
+                    bool isFromTargetVehicle = (msg.header.sender_id == targetLeaderId);
+                    if(isForCurrentPlan && isFromTargetVehicle) {
+                        if(msg.is_accepted) {
+                        // We change to follower state and start to actually follow that leader
+                        // The platoon manager also need to change the platoon Id to the one that the target leader is using 
+                        ROS_DEBUG("The leader " , msg.header.sender_id , " agreed on our join. Change to follower state.");
+                        pm_.changeFromLeaderToFollower(targetPlatoonId);
+                        current_platoon_state = PlatoonState::FOLLOWER;
+                        // pluginServiceLocator.getArbitratorService().requestNewPlan(this.trajectoryEndLocation);
+                        }
+                        else{
+                            // We change back to normal leader state and try to join other platoons
+                            ROS_DEBUG("The leader " , msg.header.sender_id , " does not agree on our join. Change back to leader state.");
+                            current_platoon_state = PlatoonState::LEADER;
+                        }
+                    }
+                    else{
+                        ROS_DEBUG("Ignore received response message because it is not for the current plan.");
+                    }
+                }
+            }
+        }
+        else{
+            ROS_DEBUG("Ignore received response message because we are not in any negotiation process.");
+        }
+    }
+    void PlatooningStateMachine::onMobilityOperationMessageCandidateFollower(cav_msgs::MobilityOperation &msg)
+    {
+        // We still need to handle STATUS operAtion message from our platoon
+        std::string strategyParams = msg.strategy_params;
+        std::string OPERATION_STATUS_TYPE;
+        bool isPlatoonStatusMsg = (strategyParams.find(OPERATION_STATUS_TYPE) == 0);
+        if (isPlatoonStatusMsg){
+            std::string vehicleId = msg.header.sender_id;
+            std::string platoonId = msg.header.plan_id;
+            std::string statusParams = strategyParams.substr(OPERATION_STATUS_TYPE.size()+1);
+            std::string SenderBsmId = msg.header.sender_bsm_id;
+            pm_.memberUpdates(vehicleId, platoonId, SenderBsmId, statusParams);
+            ROS_DEBUG("Received platoon status message from " , vehicleId);
+        }
+        else {
+            ROS_DEBUG("Received a mobility operation message with params " , msg.strategy_params , " but ignored.");
+        }
+    }
+
+
+    MobilityRequestResponse PlatooningStateMachine::onMobilityRequestMessageStandby(cav_msgs::MobilityRequest &msg) const
+    {
+        // In standby state, the plugin is not responsible for replying to any request messages
+        return MobilityRequestResponse::NO_RESPONSE;
+    }
+    void PlatooningStateMachine::onMobilityResponseMessageStandby(cav_msgs::MobilityResponse &msg) const
+    {
+        // Do Nothing
+    }
+    void PlatooningStateMachine::onMobilityOperationMessageStandby(cav_msgs::MobilityOperation &msg) const
+    {
+        // Do Nothing
+    }
+
+    bool PlatooningStateMachine::isVehicleRightInFront(std::string rearVehicleBsmId, double downtrack) const {
+        double currentDtd = pm_.getCurrentDowntrackDistance();
+        if(downtrack > currentDtd) {
+            std::clog << "Found a platoon in front. We are able to join" << std::endl;
+            return true;
+        } else {
+            std::clog <<"Ignoring platoon from our back." << std::endl;
+            std::clog << "The front platoon dtd is " << downtrack << " and we are current at " << currentDtd << std::endl;
+            return false;
+        }
+    }
+
+        
+}

--- a/platooning_strategic/test/main_test.cpp
+++ b/platooning_strategic/test/main_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+// Run all the tests
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/platooning_strategic/test/mobility_messages.cpp
+++ b/platooning_strategic/test/mobility_messages.cpp
@@ -1,0 +1,260 @@
+ 
+#include <cav_msgs/MobilityRequest.h>
+#include <cav_msgs/MobilityResponse.h>
+#include <cav_msgs/MobilityOperation.h>
+#include <cav_msgs/MobilityHeader.h>
+#include <cav_msgs/PlanType.h>
+#include <cav_msgs/Trajectory.h>
+#include <cav_msgs/LocationOffsetECEF.h>
+using namespace std;
+
+class MobilityMessages{
+    
+    private:
+        cav_msgs::MobilityRequest req1;
+        cav_msgs::MobilityRequest req2;
+        cav_msgs::MobilityRequest req3;
+        cav_msgs::MobilityResponse res1;
+        cav_msgs::MobilityResponse res2;
+        cav_msgs::MobilityResponse res3;
+        cav_msgs::MobilityOperation op1;
+        cav_msgs::MobilityOperation op2;
+        cav_msgs::MobilityOperation op3;
+    
+    public:   
+        MobilityMessages(){
+            cav_msgs::MobilityHeader header;
+            cav_msgs::PlanType plan;
+            cav_msgs::LocationECEF location;
+            cav_msgs::LocationOffsetECEF offset;
+            cav_msgs::Trajectory traject;
+            vector<cav_msgs::LocationOffsetECEF> offsets;
+            //mobility request messages            
+
+            //set up location
+            location.ecef_x = 10000;
+            location.ecef_y = 0;
+            location.ecef_z = 33333;
+            location.timestamp = 99999;
+            
+            
+            //set up trajectory
+            traject.location = location;
+            offset.offset_x = 14;
+            offset.offset_y = 200;
+            offset.offset_z = 150;
+            offsets.push_back(offset);
+            traject.offsets = offsets;
+
+            //set up plan
+            plan.type = 1;
+            
+            //set up header
+            header.sender_id = "sender_id1";
+            header.sender_bsm_id = "sender_bsm_id1";
+            header.recipient_id = "";
+            header.plan_id = "plan_id1";
+            header.timestamp = 55555555555555;
+            
+            //set up mobility request
+            req1.header = header;
+            req1.strategy = "CARMA/platooning";
+            req1.plan_type = plan;
+            req1.urgency = 1000;
+            req1.location = location;
+            req1.strategy_params = "param1 param2";
+            req1.trajectory = traject;
+            req1.expiration = 5555555;
+
+
+            //set up location
+            location.ecef_x = 40;
+            location.ecef_y = 12312321;
+            location.ecef_z = 3177;
+            location.timestamp = 191934;
+            
+            
+            //set up trajectory
+            traject.location = location;
+            offset.offset_x = 189;
+            offset.offset_y = 2123124;
+            offset.offset_z = 14;
+            offsets.push_back(offset);
+            traject.offsets = offsets;
+
+            //set up plan
+            plan.type = 2;
+            
+            //set up header
+            header.sender_id = "11";
+            header.sender_bsm_id = "sender_bsm_id5";
+            header.recipient_id = "recipient_id5";
+            header.plan_id = "plan_id5";
+            header.timestamp = 555555555555;
+            
+            //set up mobility request
+            req2.header = header;
+            req2.strategy = "CARMA/platooning";
+            req2.plan_type.type = cav_msgs::PlanType::PLATOON_FOLLOWER_JOIN;
+            req2.urgency = 1000;
+            req2.location = location;
+            req2.strategy_params = "param1 param2 param3 param4";
+            req2.trajectory = traject;
+            req2.expiration = 98124172;
+
+            
+            //set up location
+            location.ecef_x = 1238123;
+            location.ecef_y = 9875488;
+            location.ecef_z = 3434534;
+            location.timestamp = 88888888;
+            
+            
+            //set up trajectory
+            traject.location = location;
+            offset.offset_x = 987893934;
+            offset.offset_y = 5151;
+            offset.offset_z = 12312;
+            offsets.push_back(offset);
+            traject.offsets = offsets;
+
+            //set up plan
+            plan.type = 3;
+            
+            //set up header
+            header.sender_id = "sender_id6";
+            header.sender_bsm_id = "sender_bsm_id6";
+            header.recipient_id = "recipient_id6";
+            header.plan_id = "plan_id6";
+            header.timestamp = 98745745;
+            
+            //set up mobility request
+            req3.header = header;
+            req3.strategy = "CARMA/platooning3";
+            req3.plan_type = plan;
+            req3.urgency = 156;
+            req3.location = location;
+            req3.strategy_params = "param1 param2";
+            req3.trajectory = traject;
+            req3.expiration = 15132;
+            
+            
+            
+            //mobility response messages
+
+
+            //set up header
+            header.sender_id = "sender_id2";
+            header.sender_bsm_id = "sender_bsm_id2";
+            header.recipient_id = "recipient_id1";
+            header.plan_id = "plan_id2";
+            header.timestamp = 66666666;
+
+            //set up mobility response
+            res1.header = header;
+            res1.is_accepted = true;
+            res1.urgency = 1000;
+
+             //set up header
+            header.sender_id = "sender_id9";
+            header.sender_bsm_id = "sender_bsm_id9";
+            header.recipient_id = "recipient_id9";
+            header.plan_id = "plan_id9";
+            header.timestamp = 1772327;
+
+            //set up mobility response
+            res2.header = header;
+            res2.is_accepted = false;
+            res2.urgency = 50;
+
+             //set up header
+            header.sender_id = "sender_id10";
+            header.sender_bsm_id = "sender_bsm_id10";
+            header.recipient_id = "recipient_id10";
+            header.plan_id = "plan_id10";
+            header.timestamp = 77777777;
+
+            //set up mobility response
+            res3.header = header;
+            res3.is_accepted = true;
+            res3.urgency = 700;
+
+
+
+
+            //mobility operation messages
+
+            //set up header
+            header.sender_id = "sender_id3";
+            header.sender_bsm_id = "sender_bsm_id3";
+            header.recipient_id = "recipient_id3";
+            header.plan_id = "plan_id3";
+            header.timestamp = 44444444;
+
+            op1.header = header;
+            op1.strategy = "STATUS";
+            op1.strategy_params = "CMDSPEED:1.0,DTD:1.0,SPEED:1.0";
+
+            //set up header
+            header.sender_id = "sender_id12";
+            header.sender_bsm_id = "sender_bsm_id12";
+            header.recipient_id = "recipient_id12";
+            header.plan_id = "plan_id12";
+            header.timestamp = 8989898;
+
+            op2.header = header;
+            op2.strategy = "strategy3";
+            op2.strategy_params = "param1 param2 param3 param4 param5";
+
+
+            //set up header
+            header.sender_id = "sender_id23";
+            header.sender_bsm_id = "sender_bsm_id23";
+            header.recipient_id = "recipient_id23";
+            header.plan_id = "plan_id23";
+            header.timestamp = 181818;
+
+            op3.header = header;
+            op3.strategy = "strategy23";
+            op3.strategy_params = "";
+        
+        }
+
+        cav_msgs::MobilityRequest getRequest1(){
+            return req1;
+        }
+
+        cav_msgs::MobilityRequest getRequest2(){
+            return req2;
+        }
+        
+        cav_msgs::MobilityRequest getRequest3(){
+            return req3;
+        }
+
+        
+        cav_msgs::MobilityResponse getResponse1(){
+            return res1;
+        }
+
+        cav_msgs::MobilityResponse getResponse2(){
+            return res2;
+        }
+
+        cav_msgs::MobilityResponse getResponse3(){
+            return res3;
+        }
+
+        cav_msgs::MobilityOperation getOperation1(){
+            return op1;
+        }
+
+        cav_msgs::MobilityOperation getOperation2(){
+            return op2;
+        }
+
+        cav_msgs::MobilityOperation getOperation3(){
+            return op3;
+        }
+
+};

--- a/platooning_strategic/test/test_platoon_manager.cpp
+++ b/platooning_strategic/test/test_platoon_manager.cpp
@@ -1,0 +1,115 @@
+#include "platoon_manager.hpp"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+#include <carma_wm/CARMAWorldModel.h>
+#include <carma_utils/CARMAUtils.h>
+// #include "TestHelpers.h"
+
+
+
+TEST(PlatoonManagerTest, test1)
+{
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+
+
+    platoon_strategic::PlatoonManager pm;
+    pm.platoon = cur_pl;
+
+    
+    pm.isFollower = false;
+    pm.platoonSize = 1;
+    pm.leaderID = "0";
+    pm.currentPlatoonID = "a";
+
+    std::string params = "CMDSPEED:11,DOWNTRACK:01,SPEED:11";
+
+    pm.memberUpdates("1", "1", "1", params);
+
+    EXPECT_EQ(0, pm.platoon.size());
+
+    
+}
+
+TEST(PlatoonManagerTest, test2)
+{
+    platoon_strategic::PlatoonMember* member = new platoon_strategic::PlatoonMember("1", "1", 1.0, 1.1, 0.1, 100);
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+
+    cur_pl.push_back(*member);
+
+    platoon_strategic::PlatoonManager pm;
+    pm.platoon = cur_pl;
+
+    pm.isFollower = true;
+    pm.platoonSize = 1;
+    pm.leaderID = "0";
+    pm.currentPlatoonID = "a";
+
+    std::string params = "CMDSPEED:11,DOWNTRACK:01,SPEED:11";
+
+    ros::Time::init();
+
+    pm.updatesOrAddMemberInfo("2", "2", 2.0, 1.0, 2.5);
+    // updatesOrAddMemberInfo(std::string senderId, std::string senderBsmId, double cmdSpeed, double dtDistance, double curSpeed)
+
+    EXPECT_EQ(2, pm.platoon.size());
+    EXPECT_EQ("1", pm.platoon[0].staticId);
+
+}
+
+
+TEST(PlatoonManagerTest, test3)
+{
+    platoon_strategic::PlatoonMember* member1 = new platoon_strategic::PlatoonMember("1", "1", 1.0, 1.1, 0.1, 100);
+    platoon_strategic::PlatoonMember* member2 = new platoon_strategic::PlatoonMember("2", "2", 2.0, 2.1, 0.2, 200);
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+
+    cur_pl.push_back(*member1);
+    cur_pl.push_back(*member2);
+
+    platoon_strategic::PlatoonManager pm;
+    pm.platoon = cur_pl;
+
+    pm.isFollower = false;
+    pm.platoonSize = 2;
+    pm.leaderID = "0";
+    pm.currentPlatoonID = "a";
+
+
+    ros::Time::init();
+
+    int res = pm.getTotalPlatooningSize();
+
+    EXPECT_EQ(3, res);
+
+}
+
+TEST(PlatoonManagerTest, test4)
+{
+    platoon_strategic::PlatoonMember* member1 = new platoon_strategic::PlatoonMember("1", "1", 1.0, 1.1, 0.1, 100);
+    platoon_strategic::PlatoonMember* member2 = new platoon_strategic::PlatoonMember("2", "2", 2.0, 2.1, 0.2, 200);
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+
+    cur_pl.push_back(*member1);
+    cur_pl.push_back(*member2);
+
+    platoon_strategic::PlatoonManager pm;
+    pm.platoon = cur_pl;
+
+    pm.isFollower = true;
+    pm.platoonSize = 2;
+    pm.leaderID = "0";
+    pm.currentPlatoonID = "a";
+
+
+    ros::Time::init();
+
+    int res = pm.allPredecessorFollowing();
+
+    EXPECT_EQ(0, res);
+
+}
+
+

--- a/platooning_strategic/test/test_state_machine.cpp
+++ b/platooning_strategic/test/test_state_machine.cpp
@@ -1,0 +1,108 @@
+#include "state_machine.hpp"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+#include <carma_wm/CARMAWorldModel.h>
+#include <carma_utils/CARMAUtils.h>
+#include "mobility_messages.cpp"
+// #include "TestHelpers.h"
+
+
+
+TEST(PlatooningStateMachineTest, test1)
+{
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+    
+    platoon_strategic::PlatooningStateMachine psm;
+    platoon_strategic::PlatoonManager pm;
+    
+
+    psm.pm_ = pm;
+
+
+    psm.current_platoon_state = platoon_strategic::PlatoonState::FOLLOWER;
+
+    MobilityMessages mm;
+    cav_msgs::MobilityOperation res1 = mm.getOperation1();
+
+    psm.onMobilityOperationMessage(res1);
+
+
+    
+}
+
+TEST(PlatooningStateMachineTest, test2)
+{
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+    
+    platoon_strategic::PlatooningStateMachine psm;
+    platoon_strategic::PlatoonManager pm;
+
+    psm.pm_ = pm;
+
+
+    psm.current_platoon_state = platoon_strategic::PlatoonState::LEADER;
+
+    MobilityMessages mm;
+    cav_msgs::MobilityRequest r1 = mm.getRequest1();
+
+    platoon_strategic::MobilityRequestResponse out = psm.onMobilityRequestMessage(r1);
+
+
+
+    EXPECT_EQ(2, out);
+
+    
+}
+
+TEST(PlatooningStateMachineTest, test3)
+{
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+    
+    platoon_strategic::PlatooningStateMachine psm;
+    platoon_strategic::PlatoonManager pm;
+
+    psm.pm_ = pm;
+    psm.applicantID = "11";
+
+    psm.current_platoon_state = platoon_strategic::PlatoonState::LEADERWAITING;
+
+    MobilityMessages mm;
+    cav_msgs::MobilityRequest r1 = mm.getRequest2();
+
+    platoon_strategic::MobilityRequestResponse out = psm.onMobilityRequestMessage(r1);
+
+
+    EXPECT_EQ(2, psm.current_platoon_state);
+    EXPECT_EQ(0, out);
+
+    
+}
+
+TEST(PlatooningStateMachineTest, test4)
+{
+    std::vector<platoon_strategic::PlatoonMember> cur_pl;
+    
+    platoon_strategic::PlatooningStateMachine psm;
+    platoon_strategic::PlatoonManager pm;
+
+    psm.pm_ = pm;
+    psm.applicantID = "11";
+
+    psm.current_platoon_state = platoon_strategic::PlatoonState::CANDIDATEFOLLOWER;
+
+    MobilityMessages mm;
+    cav_msgs::MobilityRequest r1 = mm.getRequest1();
+
+    platoon_strategic::MobilityRequestResponse out = psm.onMobilityRequestMessage(r1);
+
+    // cav_msgs::MobilityRequest r1;
+    // psm.onMobilityRequestMessage(r1);
+
+    // cav_msgs::MobilityResponse r1;
+    // psm.onMobilityResponseMessage(r1);
+
+    EXPECT_EQ(2, out);
+}
+

--- a/platooning_tactical_plugin/package.xml
+++ b/platooning_tactical_plugin/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>platooning_tactical_plugin</name>
   <version>1.0.0</version>
   <description>The platooning_tactical_plugin package</description>

--- a/pure_pursuit_wrapper/package.xml
+++ b/pure_pursuit_wrapper/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>pure_pursuit_wrapper</name>
   <version>3.3.0</version>
   <description>The pure_pursuit_wrapper package</description>

--- a/roadway_objects/package.xml
+++ b/roadway_objects/package.xml
@@ -13,7 +13,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>roadway_objects</name>
   <version>0.0.0</version>
   <description>The roadway_objects package</description>

--- a/route/package.xml
+++ b/route/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>route</name>
   <version>3.3.0</version>
   <description>The route package provides capabilities for loading different route files and route state mangement</description>

--- a/trajectory_executor/package.xml
+++ b/trajectory_executor/package.xml
@@ -14,7 +14,7 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<package format="2">
+<package format="3">
   <name>trajectory_executor</name>
   <version>3.3.0</version>
   <description>CARMA Trajectory Executor pacakge</description>

--- a/truck_inspection_client/package.xml
+++ b/truck_inspection_client/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>truck_inspection_client</name>
   <version>1.0.0</version>
   <description>This node works with CARMA Messenger truck inspection plugin to send back requested safety message</description>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
With new definition of geofence spec, carma-msgs, carma-messenger's j2735_converter, cpp_message node, and carma-platform's carma_wm_ctrl needed to be updated.
Also updated controlrequest logic
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/790
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit and integration tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file | No need
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
