### PR TITLE
Change trajectory_plan to mpc_follower/trajectory

### DIFF
--- a/mpc_follower_wrapper/src/mpc_follower_wrapper.cpp
+++ b/mpc_follower_wrapper/src/mpc_follower_wrapper.cpp
@@ -34,7 +34,7 @@ void MPCFollowerWrapper::Initialize() {
 
   // Trajectory Plan Subscriber
   
-  trajectory_plan_sub = nh_.subscribe<cav_msgs::TrajectoryPlan>("trajectory_plan", 1, &MPCFollowerWrapper::TrajectoryPlanPoseHandler, this);
+  trajectory_plan_sub = nh_.subscribe<cav_msgs::TrajectoryPlan>("mpc_follower/trajectory", 1, &MPCFollowerWrapper::TrajectoryPlanPoseHandler, this);
 
   // WayPoints Publisher
   way_points_pub_ = nh_.advertise<autoware_msgs::Lane>("final_waypoints", 10, true);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The topic "trajectory_plan" in the mpc_follower_wrapper has no publisher. The trajectory executor publishes "/guidance/mpc_follower/trajectory".This is a topic mismatch. Changes the subscribed topic from "trajectory_plan" to "mpc_follower/trajectory".
## Related Issue
#820 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The trajectory executor is publishing "mpc_follower/trajectory", not "trajectory_plan". The mismatch causes no vehicle commands.
## How Has This Been Tested?
This is been tested in the CEE simulation.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
