### PR TITLE
add unit test for lane_array, getspeedlimits

### DIFF
--- a/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
+++ b/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
@@ -17,7 +17,7 @@
 #include <waypoint_generator/waypoint_generator.hpp>
 #include <waypoint_generator/waypoint_generator_config.hpp>
 #include <carma_wm/Geometry.h>
-
+#include <lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h>
 namespace waypoint_generator
 {
 WaypointGenerator::WaypointGenerator(carma_wm::WorldModelConstPtr wm, WaypointGeneratorConfig config, PublishWaypointsCallback waypoint_publisher) 
@@ -268,21 +268,26 @@ autoware_msgs::LaneArray WaypointGenerator::generate_lane_array_message(
     header.seq = 0;
     header.stamp = ros::Time::now();
     lane.header = header;
-
+    ROS_ERROR_STREAM("hey");
     std::vector<autoware_msgs::Waypoint> waypoints;
-    for (int j = 0; j < lanelets[j].centerline3d().size(); j++)
+    for (int j = 0; j < lanelets[i].centerline3d().size(); j++)
     {
+      
+      
       autoware_msgs::Waypoint wp;
       wp.lane_id = i;
-
+      
+      ROS_ERROR_STREAM("hey1");
       geometry_msgs::Pose p;
       p.position.x = lanelets[i].centerline3d()[j].x();
       p.position.y = lanelets[i].centerline3d()[j].y();
       p.position.z = lanelets[i].centerline3d()[j].z();
       p.orientation = orientations[centerline_point_idx];
-
+      wp.pose.pose = p;
+      ROS_ERROR_STREAM("hey2");
       geometry_msgs::Twist t;
       t.linear.x = speeds[centerline_point_idx];  // Vehicle's forward velocity corresponds to x
+      wp.twist.twist = t;
 
       wp.change_flag = 0;
       wp.direction = 0;
@@ -305,35 +310,36 @@ autoware_msgs::LaneArray WaypointGenerator::generate_lane_array_message(
     }
 
     lane.waypoints = waypoints;
+    out.lanes.push_back(lane);
   }
+
   return out;
 }
 std::vector<double> WaypointGenerator::get_speed_limits(std::vector<lanelet::ConstLanelet> lanelets) const
 {
   std::vector<double> out;
+  if (!_wm)
+  {
+    ROS_ERROR_STREAM("get_speed_limit: Invalid WM");
+    throw std::invalid_argument("get_speed_limit: Inavlid WM");
+  }
+  if (lanelets.size() == 0)
+  {
+    ROS_ERROR_STREAM("get_speed_limit: Invalid lanelets");
+    throw std::invalid_argument("get_speed_limit: Empty lanelets passed!");
+  }
   for (int i = 0; i < lanelets.size(); i++)
   {
-    if (!_wm)
+    auto slis = lanelets[i].regulatoryElementsAs<lanelet::DigitalSpeedLimit>();
+    if (slis.size() == 0)
     {
-      ROS_ERROR_STREAM("Invalid WM");
-      throw std::invalid_argument("Inavlid WM");
+      std::string err_msg = "get_speed_limit: Lanalet Id:" + std::to_string(lanelets[i].id()) + " has no Digital Speed Limit Regulatory Element!";
+      ROS_ERROR_STREAM(err_msg);
+      throw std::invalid_argument(err_msg);
     }
-
-    if (!(_wm->getTrafficRules()))
-    {
-      ROS_ERROR_STREAM("Invalid TrafficRules");
-      throw std::invalid_argument("Inavlid TrafficRules");
-    }
-    if (!(_wm->getTrafficRules()->get()))
-    {
-      ROS_ERROR_STREAM("Invalid TrafficRules Ptr");
-      throw std::invalid_argument("Inavlid TrafficRules Ptr");
-    }
-    lanelet::traffic_rules::SpeedLimitInformation sli = _wm->getTrafficRules()->get()->speedLimit(lanelets[i]);
-
     for (int j = 0; j < lanelets[i].centerline2d().size(); j++)
     {
-      out.push_back(sli.speedLimit.value());
+      out.push_back(slis[0]->getSpeedLimit().value());
     }
   }
 

--- a/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
+++ b/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
@@ -268,23 +268,18 @@ autoware_msgs::LaneArray WaypointGenerator::generate_lane_array_message(
     header.seq = 0;
     header.stamp = ros::Time::now();
     lane.header = header;
-    ROS_ERROR_STREAM("hey");
     std::vector<autoware_msgs::Waypoint> waypoints;
     for (int j = 0; j < lanelets[i].centerline3d().size(); j++)
     {
-      
-      
       autoware_msgs::Waypoint wp;
       wp.lane_id = i;
       
-      ROS_ERROR_STREAM("hey1");
       geometry_msgs::Pose p;
       p.position.x = lanelets[i].centerline3d()[j].x();
       p.position.y = lanelets[i].centerline3d()[j].y();
       p.position.z = lanelets[i].centerline3d()[j].z();
       p.orientation = orientations[centerline_point_idx];
       wp.pose.pose = p;
-      ROS_ERROR_STREAM("hey2");
       geometry_msgs::Twist t;
       t.linear.x = speeds[centerline_point_idx];  // Vehicle's forward velocity corresponds to x
       wp.twist.twist = t;

--- a/waypoint_generator/test/test_waypoint_generator.cpp
+++ b/waypoint_generator/test/test_waypoint_generator.cpp
@@ -30,7 +30,7 @@
 using namespace waypoint_generator;
 
 
-TEST(WaypointGeneratorTest, DISABLED_TestComputeConstantCurvatureRegions)
+TEST(WaypointGeneratorTest, TestComputeConstantCurvatureRegions)
 {   
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -81,7 +81,7 @@ TEST(WaypointGeneratorTest, DISABLED_TestComputeConstantCurvatureRegions)
     ASSERT_EQ(9, out_e[0]);
 }
 
-TEST(WaypointGeneratorTest, DISABLED_TestComputeIdealSpeeds)
+TEST(WaypointGeneratorTest, TestComputeIdealSpeeds)
 {
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -120,7 +120,7 @@ TEST(WaypointGeneratorTest, DISABLED_TestComputeIdealSpeeds)
     ASSERT_NEAR(std::sqrt(10.0), out_2[9], 0.005);
 }
 
-TEST(WaypointGeneratorTest, DISABLED_TestComputeSpeedForCurvature)
+TEST(WaypointGeneratorTest, TestComputeSpeedForCurvature)
 {
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -142,7 +142,7 @@ TEST(WaypointGeneratorTest, DISABLED_TestComputeSpeedForCurvature)
     ASSERT_NEAR(0.0, speed5, 0.005);
 }
 
-TEST(WaypointGeneratorTest, DISABLED_TestNormalizeCurvatureRegions) {
+TEST(WaypointGeneratorTest, TestNormalizeCurvatureRegions) {
 
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -184,7 +184,7 @@ TEST(WaypointGeneratorTest, DISABLED_TestNormalizeCurvatureRegions) {
     ASSERT_NEAR(2.0, out_b[9], 0.001);
 }
 
-TEST(WaypointGeneratorTest, DISABLED_TestApplyAccelLimits) {
+TEST(WaypointGeneratorTest, TestApplyAccelLimits) {
 
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -245,7 +245,7 @@ TEST(WaypointGeneratorTest, DISABLED_TestApplyAccelLimits) {
     ASSERT_NEAR(0.0, limited_b[9], 0.01);
 }
 
-TEST(WaypointGeneratorTest, DISABLED_TestApplySpeedLimits) {
+TEST(WaypointGeneratorTest, TestApplySpeedLimits) {
 
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -296,7 +296,7 @@ TEST(WaypointGeneratorTest, TestGetSpeedLimits)
 
 TEST(WaypointGeneratorTest, TestGenerateLaneArray) 
 {
-    ros::Time::init();
+    ros::Time::init(); // required here by ros::Time::now() in the function
     WaypointGeneratorConfig config;
     std::shared_ptr<carma_wm::WorldModel> wm = carma_wm::test::getGuidanceTestMap();
     WaypointGenerator wpg(wm, config, [&](auto msg){});

--- a/waypoint_generator/test/test_waypoint_generator.cpp
+++ b/waypoint_generator/test/test_waypoint_generator.cpp
@@ -328,7 +328,7 @@ TEST(WaypointGeneratorTest, TestGenerateLaneArray)
     ASSERT_EQ(msg.lanes[0].waypoints[0].pose.pose.orientation.x, no_rot1.x); //just checking one random side of 4 possible
     ASSERT_EQ(msg.lanes[0].waypoints[1].pose.pose.orientation.y, no_rot2.y);
     ASSERT_EQ(msg.lanes[0].waypoints[2].pose.pose.orientation.z, no_rot3.z);
-    ASSERT_EQ(msg.lanes[1].waypoints[0].pose.pose.orientation.x, no_rot4.x);
+    ASSERT_EQ(msg.lanes[1].waypoints[0].pose.pose.orientation.w, no_rot4.w);
     ASSERT_EQ(msg.lanes[1].waypoints[1].pose.pose.orientation.x, no_rot5.x);
     ASSERT_EQ(msg.lanes[1].waypoints[2].pose.pose.orientation.x, no_rot6.x);
     // check twist (speeds)

--- a/waypoint_generator/test/test_waypoint_generator.cpp
+++ b/waypoint_generator/test/test_waypoint_generator.cpp
@@ -23,21 +23,17 @@
 #include <lanelet2_core/Attribute.h>
 #include <carma_wm/Geometry.h>
 #include <carma_wm/CARMAWorldModel.h>
+#include <carma_wm/WMTestLibForGuidance.h>
+#include <math.h>
 #include "TestHelpers.h"
-
-using ::testing::_;
-using ::testing::A;
-using ::testing::DoAll;
-using ::testing::InSequence;
-using ::testing::Return;
-using ::testing::ReturnArg;
 
 using namespace waypoint_generator;
 
-TEST(WaypointGeneratorTest, TestComputeConstantCurvatureRegions)
+
+TEST(WaypointGeneratorTest, DISABLED_TestComputeConstantCurvatureRegions)
 {   
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     std::vector<double> case_a = {0.0, 0.0, 0.0, 0.0, 0.0, 
@@ -85,10 +81,10 @@ TEST(WaypointGeneratorTest, TestComputeConstantCurvatureRegions)
     ASSERT_EQ(9, out_e[0]);
 }
 
-TEST(WaypointGeneratorTest, TestComputeIdealSpeeds)
+TEST(WaypointGeneratorTest, DISABLED_TestComputeIdealSpeeds)
 {
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     std::vector<double> curvatures_1 = {1.0, 1.0, 1.0, 1.0, 1.0, 
@@ -124,10 +120,10 @@ TEST(WaypointGeneratorTest, TestComputeIdealSpeeds)
     ASSERT_NEAR(std::sqrt(10.0), out_2[9], 0.005);
 }
 
-TEST(WaypointGeneratorTest, TestComputeSpeedForCurvature)
+TEST(WaypointGeneratorTest, DISABLED_TestComputeSpeedForCurvature)
 {
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     double speed1 = wpg.compute_speed_for_curvature(1.0, 1.0);
@@ -146,10 +142,10 @@ TEST(WaypointGeneratorTest, TestComputeSpeedForCurvature)
     ASSERT_NEAR(0.0, speed5, 0.005);
 }
 
-TEST(WaypointGeneratorTest, TestNormalizeCurvatureRegions) {
+TEST(WaypointGeneratorTest, DISABLED_TestNormalizeCurvatureRegions) {
 
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     std::vector<double> case_a = {0.0, 1.0, 0.0, 1.0, 0.0, 
@@ -188,10 +184,10 @@ TEST(WaypointGeneratorTest, TestNormalizeCurvatureRegions) {
     ASSERT_NEAR(2.0, out_b[9], 0.001);
 }
 
-TEST(WaypointGeneratorTest, TestApplyAccelLimits) {
+TEST(WaypointGeneratorTest, DISABLED_TestApplyAccelLimits) {
 
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     std::vector<double> speeds_a = {0.0, 0.0, 0.0, 0.0, 0.0, 
@@ -249,10 +245,10 @@ TEST(WaypointGeneratorTest, TestApplyAccelLimits) {
     ASSERT_NEAR(0.0, limited_b[9], 0.01);
 }
 
-TEST(WaypointGeneratorTest, TestApplySpeedLimits) {
+TEST(WaypointGeneratorTest, DISABLED_TestApplySpeedLimits) {
 
     WaypointGeneratorConfig config;
-    std::shared_ptr<WorldModel> wm = std::make_shared<CARMAWorldModel>();
+    std::shared_ptr<carma_wm::WorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
     WaypointGenerator wpg(wm, config, [&](auto msg){});
 
     std::vector<double> speeds_a = {0.0, 0.0, 0.0, 0.0, 0.0, 
@@ -266,4 +262,89 @@ TEST(WaypointGeneratorTest, TestApplySpeedLimits) {
         ASSERT_LE(out_a[i], limits_a[i]);
     }
 }
+
+TEST(WaypointGeneratorTest, TestGetSpeedLimits) 
+{
+    
+    WaypointGeneratorConfig config;
+    std::shared_ptr<carma_wm::WorldModel> wm;
+    WaypointGenerator wpg(wm, config, [&](auto msg){});
+
+    std::shared_ptr<carma_wm::CARMAWorldModel> cmw = carma_wm::test::getGuidanceTestMap();
+    std::shared_ptr<carma_wm::WorldModel> wm1 = cmw;
+    std::vector<lanelet::ConstLanelet> input;
+    input.push_back(cmw->getMap()->laneletLayer.get(1200));
+    
+    ROS_INFO_STREAM("Following get_speed_limit: Invalid WM error is expected");
+    ASSERT_THROW(wpg.get_speed_limits(input), std::invalid_argument);
+    
+    WaypointGenerator wpg1(cmw, config, [&](auto msg){});
+    std::vector<lanelet::ConstLanelet> input_err;
+    ROS_INFO_STREAM("Following get_speed_limit: Invalid lanelets error is expected");
+    ASSERT_THROW(wpg1.get_speed_limits(input_err), std::invalid_argument);
+
+    // create a copy lanelet with no regems inside it
+    lanelet::ConstLanelet llt = carma_wm::test::getLanelet(1200, cmw->getMutableMap()->laneletLayer.get(1200).leftBound3d(), cmw->getMutableMap()->laneletLayer.get(1200).rightBound3d());
+    input_err.push_back(llt);
+    ROS_INFO_STREAM("Following get_speed_limit: error is expected");
+    ASSERT_THROW(wpg1.get_speed_limits(input_err), std::invalid_argument);
+    
+    std::vector<double> result = wpg1.get_speed_limits(input);
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_NE(result[0], 0);
 }
+
+TEST(WaypointGeneratorTest, TestGenerateLaneArray) 
+{
+    ros::Time::init();
+    WaypointGeneratorConfig config;
+    std::shared_ptr<carma_wm::WorldModel> wm = carma_wm::test::getGuidanceTestMap();
+    WaypointGenerator wpg(wm, config, [&](auto msg){});
+    
+    std::vector<double> speeds = {1,2,3,4,5,6};
+    
+    geometry_msgs::Quaternion no_rot1 = tf::createQuaternionMsgFromYaw(1);
+    geometry_msgs::Quaternion no_rot2 = tf::createQuaternionMsgFromYaw(2);
+    geometry_msgs::Quaternion no_rot3 = tf::createQuaternionMsgFromYaw(3);
+    geometry_msgs::Quaternion no_rot4 = tf::createQuaternionMsgFromYaw(4);
+    geometry_msgs::Quaternion no_rot5 = tf::createQuaternionMsgFromYaw(5);
+    geometry_msgs::Quaternion no_rot6 = tf::createQuaternionMsgFromYaw(6);
+
+    std::vector<geometry_msgs::Quaternion> orientations = {no_rot1, no_rot2, no_rot3, no_rot4, no_rot5, no_rot6};
+    std::vector<lanelet::ConstLanelet> lanelets;
+    lanelets.push_back(wm->getMap()->laneletLayer.get(1200));
+    lanelets.push_back(wm->getMap()->laneletLayer.get(1201));
+
+    autoware_msgs::LaneArray msg = wpg.generate_lane_array_message(
+                speeds, 
+                orientations, 
+                lanelets);
+    ASSERT_EQ(msg.lanes.size(), 2);
+    // check lane_id of lane
+    ASSERT_EQ(msg.lanes[0].lane_id, 0);
+    // check lane_id of waypoint
+    ASSERT_EQ(msg.lanes[0].waypoints[0].lane_id, 0);
+    // check orientation of waypoint
+    ASSERT_EQ(msg.lanes[0].waypoints[0].pose.pose.orientation.x, no_rot1.x); //just checking one random side of 4 possible
+    ASSERT_EQ(msg.lanes[0].waypoints[1].pose.pose.orientation.y, no_rot2.y);
+    ASSERT_EQ(msg.lanes[0].waypoints[2].pose.pose.orientation.z, no_rot3.z);
+    ASSERT_EQ(msg.lanes[1].waypoints[0].pose.pose.orientation.x, no_rot4.x);
+    ASSERT_EQ(msg.lanes[1].waypoints[1].pose.pose.orientation.x, no_rot5.x);
+    ASSERT_EQ(msg.lanes[1].waypoints[2].pose.pose.orientation.x, no_rot6.x);
+    // check twist (speeds)
+    ASSERT_EQ(msg.lanes[0].waypoints[0].twist.twist.linear.x, 1);
+    ASSERT_EQ(msg.lanes[0].waypoints[1].twist.twist.linear.x, 2);
+    ASSERT_EQ(msg.lanes[0].waypoints[2].twist.twist.linear.x, 3);
+    ASSERT_EQ(msg.lanes[1].waypoints[0].twist.twist.linear.x, 4);
+    ASSERT_EQ(msg.lanes[1].waypoints[1].twist.twist.linear.x, 5);
+    ASSERT_EQ(msg.lanes[1].waypoints[2].twist.twist.linear.x, 6);
+
+}
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fixes errors in lane_array and get speed limt function errors in waypoint generator
and added unit tests
the main testing branch is expected to be merged into integration/routing
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/859
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
during integration testing, there were numerous errors that could be caught by unit tests
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests pass
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file | No need
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
