### PR TITLE
add logic for successing lanelets

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -34,7 +34,6 @@ sonar.sourceEncoding=UTF-8
 
 # Modules starting with Java packages then C++ packages
 sonar.modules= carma_transform_server, \
-  autoware_plugin, \
   bsm_generator, \
   gnss_to_map_convertor, \
   guidance, \
@@ -65,7 +64,6 @@ sonar.modules= carma_transform_server, \
 mock_drivers.sonar.projectBaseDir              = /opt/carma/src/CARMAPlatform/carmajava/mock_drivers
 carma_transform_server.sonar.projectBaseDir    = /opt/carma/src/CARMAPlatform/carma_transform_server
 guidance.sonar.projectBaseDir                  = /opt/carma/src/CARMAPlatform/guidance
-autoware_plugin.sonar.projectBaseDir           = /opt/carma/src/CARMAPlatform/autoware_plugin
 bsm_generator.sonar.projectBaseDir             = /opt/carma/src/CARMAPlatform/bsm_generator
 gnss_to_map_convertor.sonar.projectBaseDir     = /opt/carma/src/CARMAPlatform/gnss_to_map_convertor
 guidance_command_repeater.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/guidance_command_repeater
@@ -97,7 +95,6 @@ rosbag_mock_drivers.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/mock_dri
 # Sources
 carma_transform_server.sonar.sources    = src
 guidance.sonar.sources                  = src
-autoware_plugin.sonar.sources           = src
 bsm_generator.sonar.sources             = src
 gnss_to_map_convertor.sonar.sources     = src
 guidance_command_repeater.sonar.sources = src
@@ -126,7 +123,6 @@ rosbag_mock_drivers.sonar.sources      = src
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
-autoware_plugin.sonar.tests         = test
 bsm_generator.sonar.tests           = test
 gnss_to_map_convertor.sonar.tests   = test
 guidance.sonar.tests                = test

--- a/waypoint_generator/include/waypoint_generator/waypoint_generator.hpp
+++ b/waypoint_generator/include/waypoint_generator/waypoint_generator.hpp
@@ -189,6 +189,13 @@ namespace waypoint_generator
                 const std::vector<double> speeds, 
                 const std::vector<double> speed_limits) const;
 
+            /**!
+             * \brief Lists the successig lanelets from the shortest path
+             * by removing adjacent lanelets.
+             * 
+             */
+            std::vector<lanelet::ConstLanelet> findSuccessingLanelets();
+
             void new_route_callback();
         private:
             carma_wm::WorldModelConstPtr _wm;

--- a/waypoint_generator/include/waypoint_generator/waypoint_generator.hpp
+++ b/waypoint_generator/include/waypoint_generator/waypoint_generator.hpp
@@ -194,7 +194,7 @@ namespace waypoint_generator
              * by removing adjacent lanelets.
              * 
              */
-            std::vector<lanelet::ConstLanelet> findSuccessingLanelets();
+            std::vector<lanelet::ConstLanelet> findSuccessingLanelets() const;
 
             void new_route_callback();
         private:

--- a/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
+++ b/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
@@ -355,13 +355,13 @@ std::vector<double> WaypointGenerator::get_speed_limits(std::vector<lanelet::Con
   return out;
 }
 
-std::vector<lanelet::ConstLanelet> WaypointGenerator::findSuccessingLanelets(){
+std::vector<lanelet::ConstLanelet> WaypointGenerator::findSuccessingLanelets() const
+{
   std::vector<lanelet::ConstLanelet> out;
   auto shortest_path = _wm->getRoute()->shortestPath();
   ROS_DEBUG_STREAM("Processing " << shortest_path.size() << " lanelets.");
   
   out.push_back(shortest_path[0]);
-  int prev_index = 0;
   for (size_t i=1; i<shortest_path.size(); i++)
   {
     lanelet::ConstLanelet l = shortest_path[i];

--- a/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
+++ b/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
@@ -355,17 +355,37 @@ std::vector<double> WaypointGenerator::get_speed_limits(std::vector<lanelet::Con
   return out;
 }
 
+std::vector<lanelet::ConstLanelet> WaypointGenerator::findSuccessingLanelets(){
+  std::vector<lanelet::ConstLanelet> out;
+  auto shortest_path = _wm->getRoute()->shortestPath();
+  ROS_DEBUG_STREAM("Processing " << shortest_path.size() << " lanelets.");
+  
+  out.push_back(shortest_path[0]);
+  int prev_index = 0;
+  for (size_t i=1; i<shortest_path.size(); i++)
+  {
+    lanelet::ConstLanelet l = shortest_path[i];
+    auto following = _wm->getRoute()->followingRelations(shortest_path[i-1]);
+    if (following[0].lanelet.id()==l.id() && following[0].relationType == lanelet::routing::RelationType::Successor){
+      out.push_back(l);
+    }
+    else{
+      // TODO: Find an approach for handling transition between non-successing lanelets
+      auto right = _wm->getRoute()->rightRelation(shortest_path[i-1]);
+      auto left = _wm->getRoute()->leftRelation(shortest_path[i-1]);
+      if (right || left) ROS_ERROR_STREAM("skipping adjacent lanelet: " << l.id());
+      else ROS_ERROR_STREAM("unidentified relation to lanelet: " << l.id());
+    }
+  }
+  return out;
+
+}
+
 void WaypointGenerator::new_route_callback()
 {
   ROS_DEBUG_STREAM("Received new route message, processing...");
 
-  auto shortest_path = _wm->getRoute()->shortestPath();
-  ROS_DEBUG_STREAM("Processing " << shortest_path.size() << " lanelets.");
-  std::vector<lanelet::ConstLanelet> tmp;
-  for (lanelet::ConstLanelet l : shortest_path)
-  {
-    tmp.push_back(l);
-  }
+  std::vector<lanelet::ConstLanelet> tmp = findSuccessingLanelets();
 
   lanelet::BasicLineString2d route_geometry = carma_wm::geometry::concatenate_lanelets(tmp);
 

--- a/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
+++ b/waypoint_generator/src/waypoint_generator/waypoint_generator.cpp
@@ -373,8 +373,8 @@ std::vector<lanelet::ConstLanelet> WaypointGenerator::findSuccessingLanelets() c
       // TODO: Find an approach for handling transition between non-successing lanelets
       auto right = _wm->getRoute()->rightRelation(shortest_path[i-1]);
       auto left = _wm->getRoute()->leftRelation(shortest_path[i-1]);
-      if (right || left) ROS_ERROR_STREAM("skipping adjacent lanelet: " << l.id());
-      else ROS_ERROR_STREAM("unidentified relation to lanelet: " << l.id());
+      if (right || left)  throw std::invalid_argument("skipping adjacent lanelet");
+      else throw std::invalid_argument("unidentified relation to lanelet");
     }
   }
   return out;

--- a/waypoint_generator/test/test_route_callback.cpp
+++ b/waypoint_generator/test/test_route_callback.cpp
@@ -233,33 +233,22 @@ TEST(WaypointGeneratorTest, following_lanelet)
    *           START_LINE
    */
 
-  // carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1203 }, wm);
-  carma_wm::test::setRouteByIds({ 1210, 1201, 1212, 1223 }, wm);
+  carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1203 }, wm);
 
   std::vector<lanelet::ConstLanelet> res1 =  wpg.findSuccessingLanelets();
   ASSERT_EQ(res1.size(), 4);
-  ASSERT_EQ(res1[0].id(), 1210);
+  ASSERT_EQ(res1[0].id(), 1200);
   ASSERT_EQ(res1[1].id(), 1201);
-  ASSERT_EQ(res1[2].id(), 1212);
-  ASSERT_EQ(res1[3].id(), 1223);
+  ASSERT_EQ(res1[2].id(), 1202);
+  ASSERT_EQ(res1[3].id(), 1203);
 
   carma_wm::test::setRouteByIds({ 1200, 1211, 1212, 1213 }, wm);
+  ASSERT_THROW( wpg.findSuccessingLanelets(), std::invalid_argument);
 
-  std::vector<lanelet::ConstLanelet> res2 =  wpg.findSuccessingLanelets();
-  ASSERT_EQ(res2.size(), 4);
-  ASSERT_EQ(res2[0].id(), 1200);
-  ASSERT_EQ(res2[1].id(), 1211);
-  ASSERT_EQ(res2[2].id(), 1212);
-  ASSERT_EQ(res2[3].id(), 1213);
 
   carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1223 }, wm);
+  ASSERT_THROW( wpg.findSuccessingLanelets(), std::invalid_argument);
 
-  std::vector<lanelet::ConstLanelet> res3 =  wpg.findSuccessingLanelets();
-  ASSERT_EQ(res3.size(), 4);
-  ASSERT_EQ(res3[0].id(), 1200);
-  ASSERT_EQ(res3[1].id(), 1201);
-  ASSERT_EQ(res3[2].id(), 1202);
-  ASSERT_EQ(res3[3].id(), 1223);
 
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added logic to find and eliminate adjacent lanelets in shortest path.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
