### PR TITLE
Commit Unit Test Fixes to WMTestLibForGuidanceTest.cpp

### DIFF
--- a/carma_wm/test/WMTestLibForGuidanceTest.cpp
+++ b/carma_wm/test/WMTestLibForGuidanceTest.cpp
@@ -71,7 +71,9 @@ TEST(WMTestLibForGuidanceTest, getGuidanceTestMap)
 
     mp.speed_limit_ = MapOptions::SpeedLimit::NONE;
     cmw = getGuidanceTestMap(mp);
-    ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 28); // 28 belong to map compliance
+    //ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 28); // 28 belong to map compliance
+    ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 40); // 28 belong to map compliance
+
 }
 
 TEST(WMTestLibForGuidanceTest, buildGuidanceTestMap)
@@ -222,13 +224,11 @@ TEST(WMTestLibForGuidanceTest, setSpeedLimit)
     MapOptions mp(3.7,25,MapOptions::Obstacle::DEFAULT, MapOptions::SpeedLimit::NONE);
     auto cmw = getGuidanceTestMap(mp);
     auto llt = cmw->getMutableMap()->laneletLayer.get(1200);
-    // create existing speed limit to overwrite
-    lanelet::DigitalSpeedLimitPtr sl = std::make_shared<lanelet::DigitalSpeedLimit>(lanelet::DigitalSpeedLimit::buildData(lanelet::utils::getId(), 50_mph, {llt}, {},
-                                                     { lanelet::Participants::VehicleCar }));
-    cmw->getMutableMap()->update(llt, sl);
-    ASSERT_EQ(cmw->getMutableMap()->regulatoryElementLayer.size(), 29); // 28 belong to map compliance
+   
+    ASSERT_EQ(cmw->getMutableMap()->regulatoryElementLayer.size(), 40); // 40 belong to map compliance
+
     setSpeedLimit(25_mph, cmw);
-    ASSERT_EQ(cmw->getMutableMap()->regulatoryElementLayer.size(), 41); // old speed limit exists but is not assigned to any llt
+    ASSERT_EQ(cmw->getMutableMap()->regulatoryElementLayer.size(), 52); // old speed limit exists but is not assigned to any llt
     ASSERT_NEAR(cmw->getMutableMap()->laneletLayer.get(1200).regulatoryElementsAs<lanelet::DigitalSpeedLimit>()[0]->getSpeedLimit().value(), 11.176, 0.0001); 
 }
 }  // namespace test

--- a/carma_wm/test/WMTestLibForGuidanceTest.cpp
+++ b/carma_wm/test/WMTestLibForGuidanceTest.cpp
@@ -71,8 +71,7 @@ TEST(WMTestLibForGuidanceTest, getGuidanceTestMap)
 
     mp.speed_limit_ = MapOptions::SpeedLimit::NONE;
     cmw = getGuidanceTestMap(mp);
-    //ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 28); // 28 belong to map compliance
-    ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 40); // 28 belong to map compliance
+    ASSERT_EQ(cmw->getMap()->regulatoryElementLayer.size(), 40); // 40 belong to map compliance
 
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Two of the test cases from WMTestLibForGuidanceTest.cpp had failed after the feature/validate_speed_limits branch had been merged into develop. Unnecessary logic needed to be removed from the test cases to ensure that all unit tests pass. Specifically,  lines 256 and 279 were to be taken out to account for the changes in MapConformer.cpp
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/902
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required to ensure that there are no failed test cases for any of the files on the develop branch
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested using gtest/gmock.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
