### PR TITLE
Fix/system alert for health monito

### DIFF
--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -82,7 +82,7 @@ namespace health_monitor
                 new_msg.description = header;
                 new_msg.type = cav_msgs::SystemAlert::SHUTDOWN;
 
-                ros::CARMANodeHandle::publishSystemAlert(new_msg);
+                nh_->publishSystemAlert(new_msg);
             }
 
         });
@@ -94,7 +94,7 @@ namespace health_monitor
             new_msg.type = cav_msgs::SystemAlert::SHUTDOWN;
             new_msg.description = exp.what();
 
-            ros::CARMANodeHandle::publishSystemAlert(new_msg);
+            nh_->publishSystemAlert(new_msg);
 
         });
 

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -72,7 +72,7 @@ namespace health_monitor
         start_up_timestamp_ = ros::Time::now().toNSec() / 1e6;
         start_time_flag_=ros::Time::now();
 
-        pnh_->setSystemAlertCallback([&](const cav_msgs::SystemAlertConstPtr& msg) -> void {
+        ros::CARMANodeHandle::setSystemAlertCallback([&](const cav_msgs::SystemAlertConstPtr& msg) -> void {
 
             if (msg->type == cav_msgs::SystemAlert::FATAL)
             { 
@@ -82,19 +82,19 @@ namespace health_monitor
                 new_msg.description = header;
                 new_msg.type = cav_msgs::SystemAlert::SHUTDOWN;
 
-                pnh_->publishSystemAlert(new_msg);
+                ros::CARMANodeHandle::publishSystemAlert(new_msg);
             }
 
         });
         
 
-        pnh_->setExceptionCallback([&](const std::exception& exp) -> void {
+        ros::CARMANodeHandle::setExceptionCallback([&](const std::exception& exp) -> void {
 
-         cav_msgs::SystemAlert new_msg;
-        new_msg.type = cav_msgs::SystemAlert::SHUTDOWN;
-        new_msg.description = exp.what();
+            cav_msgs::SystemAlert new_msg;
+            new_msg.type = cav_msgs::SystemAlert::SHUTDOWN;
+            new_msg.description = exp.what();
 
-        pnh_->publishSystemAlert(new_msg);
+            ros::CARMANodeHandle::publishSystemAlert(new_msg);
 
         });
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Changes health monitor to use the non-private node handle for publishing to system alert and use the static calls for setting up the system alert callbacks. This reduces errors at build time and helps reduce possibilities for the source of the linked error. 

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/963
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
