### PR TITLE
Fix/health monitor lidar fault

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -43,7 +43,7 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch $BRANCH
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch release/Wanderer
       git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch CARMANovatelGpsDriver_1.2.0
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch release/Wanderer

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -45,6 +45,6 @@ if [[ "$BRANCH" = "develop" ]]; then
 else
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch release/Wanderer
       git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch CARMANovatelGpsDriver_1.2.0
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch release/Wanderer
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch release/Wanderer
 fi

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -91,7 +91,7 @@ namespace health_monitor
         
         for(int i=0;i<lidar_gps_entries_.size();i++)
         {
-            if(lidar_gps_entries_[i]==name)
+            if(lidar_gps_entries_[i].compare(name) == 0)
             {
                 return i;
             }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fixed a defective if test in EntryManager::is_lidar_gps_entry_required().  As it was, the comparison would normally fail and the method would return an unpredictable value.  This may be the primary contributor to the frequently sensed lidar faults.  If it returns a value other than one of the 3 expected (for trucks) then some or all of the lidar/gps sensors will not be evaluated in DriverManager::arec_critical_drivers_operational_*().  Thus, a lidar that was late in coming online at startup may never get evaluated again, thus its not-ready state would never change.  Likewise, a sensor that lost power during a run may never get its status evaluated, thus the fault condition would never be reported.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#953 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
More consistent evaluation & reporting of true lidar & GPS operational status.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am unable to test.  Relying on @lewisid to run tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
