### PR TITLE
Feature/curve entry lookahead

### DIFF
--- a/inlanecruising_plugin/config/parameters.yaml
+++ b/inlanecruising_plugin/config/parameters.yaml
@@ -3,6 +3,10 @@ trajectory_time_length: 6.0 # Trajectory length in seconds
 curve_resample_step_size: 1.0 # Curve re-sampling step size in m
 downsample_ratio: 8 # Amount to downsample input lanelet centerline data. Value corresponds to saving each nth point.
 minimum_speed: 2.2352 # Minimum allowable speed in m/s
-lookahead_count: 8 # Number of points to look ahead for speed reduction.
+minimum_lookahead_distance: 5.0 # Minimum value for lookahead distance in m
+maximum_lookahead_distance: 25.0 # Maximum value for lookahead distance in m
+minimum_lookahead_speed: 2.8 # Minimum speed value for lookahead calculation in m/s
+maximum_lookahead_speed: 13.9 # Maximum speed value for lookahead calculation in m/s
+lookahead_ratio: 2.0 # ratio to calculate lookahead distance from speed
 moving_average_window_size: 5 # Size of the window used in the moving average filter to smooth both the computed curvature and output speeds
 curvature_calc_lookahead_count: 1 # Number of points to look ahead when calculating the curvature of the lanelet centerline

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_config.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_config.h
@@ -29,7 +29,14 @@ struct InLaneCruisingPluginConfig
                                            // Corresponds to saving each nth point.
   double minimum_speed = 2.2352;           // Minimum allowable speed in m/s
   double max_accel = 1.5;                  // Maximum allowable longitudinal acceleration in m/s^2
-  int lookahead_count = 8;                 // Number of points to look ahead for speed reduction.
+  
+  double minimum_lookahead_distance = 5.0; // Minimum value for lookahead distance in m
+  double maximum_lookahead_distance = 25.0;// Maximum value for lookahead distance in m
+  double minimum_lookahead_speed = 2.8;    // Minimum speed value for lookahead calculation in m/s
+  double maximum_lookahead_speed = 13.9;   // Maximum speed value for lookahead calculation in m/s
+  double lookahead_ratio = 2.0;            // ratio to calculate lookahead distance from speed
+  
+
   double lateral_accel_limit = 1.5;        // Maximum allowable lateral acceleration m/s^2
   int moving_average_window_size = 5;      // Size of the window used in the moving average filter to smooth both the
                                            // computed curvature and output speeds
@@ -44,7 +51,11 @@ struct InLaneCruisingPluginConfig
            << "downsample_ratio: " << c.downsample_ratio << std::endl
            << "minimum_speed: " << c.minimum_speed << std::endl
            << "max_accel: " << c.max_accel << std::endl
-           << "lookahead_count: " << c.lookahead_count << std::endl
+           << "minimum_lookahead_distance: " << c.minimum_lookahead_distance << std::endl
+           << "maximum_lookahead_distance: " << c.maximum_lookahead_distance << std::endl
+           << "minimum_lookahead_speed: " << c.minimum_lookahead_speed << std::endl
+           << "maximum_lookahead_speed: " << c.maximum_lookahead_speed << std::endl
+           << "lookahead_ratio: " << c.lookahead_ratio << std::endl
            << "lateral_accel_limit: " << c.lateral_accel_limit << std::endl
            << "moving_average_window_size: " << c.moving_average_window_size << std::endl
            << "curvature_calc_lookahead_count: " << c.curvature_calc_lookahead_count << std::endl

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
@@ -208,8 +208,25 @@ public:
    */ 
   Eigen::Isometry2d curvePointInMapTF(const Eigen::Isometry2d& curve_in_map, const lanelet::BasicPoint2d& p, double yaw) const;
 
+  /**
+   * \brief Returns the speeds of points closest to the lookahead distance.
+   * 
+   * \param points The points in the map frame that the trajectory will follow. Units m
+   * \param speeds Speeds assigned to points that trajectory will follow. Unit m/s
+   * \param lookahead The lookahead distance to obtain future points' speed. Unit m
+   * 
+   * \return A vector of speed values shifted by the lookahead distance.
+   */ 
+
   std::vector<double> get_lookahead_speed(const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& speeds, const double& lookahead);
 
+  /**
+   * \brief Computes the lookahead distance based on the input velocity
+   * 
+   * \param velocity vehicle velocity in m/s.
+   * 
+   * \return lookahead distance in m.
+   */ 
   double get_adaptive_lookahead(double velocity);
 
 private:

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
@@ -208,7 +208,7 @@ public:
    */ 
   Eigen::Isometry2d curvePointInMapTF(const Eigen::Isometry2d& curve_in_map, const lanelet::BasicPoint2d& p, double yaw) const;
 
-  std::vector<double> get_lookahead_speed(const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& speeds, const cav_msgs::VehicleState& state);
+  std::vector<double> get_lookahead_speed(const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& speeds, const double& lookahead);
 
   double get_adaptive_lookahead(double velocity);
 

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
@@ -208,6 +208,10 @@ public:
    */ 
   Eigen::Isometry2d curvePointInMapTF(const Eigen::Isometry2d& curve_in_map, const lanelet::BasicPoint2d& p, double yaw) const;
 
+  std::vector<double> get_lookahead_speed(const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& speeds, const cav_msgs::VehicleState& state);
+
+  double get_adaptive_lookahead(double velocity);
+
 private:
   carma_wm::WorldModelConstPtr wm_;
   InLaneCruisingPluginConfig config_;

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
@@ -53,11 +53,11 @@ public:
     pnh.param<double>("curve_resample_step_size", config.curve_resample_step_size, config.curve_resample_step_size);
     pnh.param<int>("downsample_ratio", config.downsample_ratio, config.downsample_ratio);
     pnh.param<double>("minimum_speed", config.minimum_speed, config.minimum_speed);
-    pnh.param<int>("minimum_lookahead_distance", config.minimum_lookahead_distance, config.minimum_lookahead_distance);
-    pnh.param<int>("maximum_lookahead_distance", config.maximum_lookahead_distance, config.maximum_lookahead_distance);
-    pnh.param<int>("minimum_lookahead_speed", config.minimum_lookahead_speed, config.minimum_lookahead_speed);
-    pnh.param<int>("maximum_lookahead_speed", config.maximum_lookahead_speed, config.maximum_lookahead_speed);
-    pnh.param<int>("lookahead_ratio", config.lookahead_ratio, config.lookahead_ratio);
+    pnh.param<double>("minimum_lookahead_distance", config.minimum_lookahead_distance, config.minimum_lookahead_distance);
+    pnh.param<double>("maximum_lookahead_distance", config.maximum_lookahead_distance, config.maximum_lookahead_distance);
+    pnh.param<double>("minimum_lookahead_speed", config.minimum_lookahead_speed, config.minimum_lookahead_speed);
+    pnh.param<double>("maximum_lookahead_speed", config.maximum_lookahead_speed, config.maximum_lookahead_speed);
+    pnh.param<double>("lookahead_ratio", config.lookahead_ratio, config.lookahead_ratio);
     pnh.param<int>("moving_average_window_size", config.moving_average_window_size,
                      config.moving_average_window_size);
     pnh.param<double>("/vehicle_acceleration_limit", config.max_accel, config.max_accel);

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
@@ -53,7 +53,11 @@ public:
     pnh.param<double>("curve_resample_step_size", config.curve_resample_step_size, config.curve_resample_step_size);
     pnh.param<int>("downsample_ratio", config.downsample_ratio, config.downsample_ratio);
     pnh.param<double>("minimum_speed", config.minimum_speed, config.minimum_speed);
-    pnh.param<int>("lookahead_count", config.lookahead_count, config.lookahead_count);
+    pnh.param<int>("minimum_lookahead_distance", config.minimum_lookahead_distance, config.minimum_lookahead_distance);
+    pnh.param<int>("maximum_lookahead_distance", config.maximum_lookahead_distance, config.maximum_lookahead_distance);
+    pnh.param<int>("minimum_lookahead_speed", config.minimum_lookahead_speed, config.minimum_lookahead_speed);
+    pnh.param<int>("maximum_lookahead_speed", config.maximum_lookahead_speed, config.maximum_lookahead_speed);
+    pnh.param<int>("lookahead_ratio", config.lookahead_ratio, config.lookahead_ratio);
     pnh.param<int>("moving_average_window_size", config.moving_average_window_size,
                      config.moving_average_window_size);
     pnh.param<double>("/vehicle_acceleration_limit", config.max_accel, config.max_accel);

--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -427,6 +427,10 @@ std::vector<double> InLaneCruisingPlugin::get_lookahead_speed(const std::vector<
     throw std::invalid_argument("Invalid lookahead value");
   }
 
+  if (speeds.size() < 1)
+  {
+    throw std::invalid_argument("Invalid speeds vector");
+  }
 
   if (speeds.size() != points.size())
   {

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
@@ -231,13 +231,8 @@ TEST(InLaneCruisingPluginTest, get_lookahead_speed)
   std::vector<lanelet::BasicPoint2d> points = { p1, p2, p3, p4 };
   std::vector<double> speeds = {8, 9, 10, 11};
 
-  cav_msgs::VehicleState state;
-  state.X_pos_global = 1.0;
-  state.Y_pos_global = 0.0;
-  state.longitudinal_vel = 5.0;
-
   std::vector<double> out;
-  out = plugin.get_lookahead_speed(points, speeds, state);
+  out = plugin.get_lookahead_speed(points, speeds, 10);
   ASSERT_EQ(4, out.size());
   ASSERT_EQ(9, out[0]);
   ASSERT_EQ(10, out[1]);

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
@@ -216,6 +216,52 @@ TEST(InLaneCruisingPluginTest, getNearestPointIndex)
   ASSERT_EQ(3, plugin.getNearestPointIndex(points, state));
 }
 
+TEST(InLaneCruisingPluginTest, get_lookahead_speed)
+{
+  InLaneCruisingPluginConfig config;
+  config.downsample_ratio = 1;
+  std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
+  InLaneCruisingPlugin plugin(wm, config, [&](auto msg) {});
+
+  lanelet::BasicPoint2d p1(10.0, 0.0);
+  lanelet::BasicPoint2d p2(20.0, 0.0);
+  lanelet::BasicPoint2d p3(30, 0.0);
+  lanelet::BasicPoint2d p4(40, 0.0);
+
+  std::vector<lanelet::BasicPoint2d> points = { p1, p2, p3, p4 };
+  std::vector<double> speeds = {8, 9, 10, 11};
+
+  cav_msgs::VehicleState state;
+  state.X_pos_global = 1.0;
+  state.Y_pos_global = 0.0;
+  state.longitudinal_vel = 5.0;
+
+  std::vector<double> out;
+  out = plugin.get_lookahead_speed(points, speeds, state);
+  ASSERT_EQ(4, out.size());
+  ASSERT_EQ(9, out[0]);
+  ASSERT_EQ(10, out[1]);
+  ASSERT_EQ(11, out[2]);
+  ASSERT_EQ(11, out[3]);
+
+  // ASSERT_EQ(3, plugin.getNearestPointIndex(points, state));
+}
+
+TEST(InLaneCruisingPluginTest, get_adaptive_lookahead)
+{
+  InLaneCruisingPluginConfig config;
+  config.downsample_ratio = 1;
+  std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
+  InLaneCruisingPlugin plugin(wm, config, [&](auto msg) {});
+
+  
+  ASSERT_EQ(5.0, plugin.get_adaptive_lookahead(2.0));
+  ASSERT_EQ(2.0*6.0, plugin.get_adaptive_lookahead(6.0));
+  ASSERT_EQ(25.0, plugin.get_adaptive_lookahead(22.0));
+
+
+}
+
 TEST(InLaneCruisingPluginTest, splitPointSpeedPairs)
 {
   InLaneCruisingPluginConfig config;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
In this feature, an adaptive lookahead distance based on the vehicle's velocity is implemented that allows the in-lane cruising plugin to know about upcoming speed increases or decreases (such as curves and turns) in advance, to generate trajectories with smooth speeds.

## Related Issue
#988 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This feature helps in-lane cruising plugin to generate smooth trajectories.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested and integration tested on Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
