### PR TITLE
Fix rosbridge issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,6 @@ LABEL org.label-schema.build-date=${BUILD_DATE}
 COPY --from=install --chown=carma /opt/carma /opt/carma
 COPY --from=install --chown=carma /root/.bashrc /home/carma/.bashrc
 
+RUN pip install future
+
 CMD "roslaunch carma carma_docker.launch"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
rosbridge is failing because it cannot find builtin package as rosbridge was updated to require that (when we updated VTK).
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/RobotWebTools/rosbridge_suite/issues/544 (rosbridge issue)
https://github.com/usdot-fhwa-stol/carma-platform/issues/1002


<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
rosbridge crashing at start (1-2m after start)
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
regression tested on pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
