### PR TITLE
Default operation mode is NDT only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/autoware.ai:carma-system-3.4.0
+      - image: usdotfhwastol/autoware.ai:3.9.0
         user: carma
         environment:
           TERM: xterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 # /////////////////////////////////////////////////////////////////////////////
 
 
-FROM usdotfhwastol/autoware.ai:carma-system-3.4.0 AS source-code
+FROM usdotfhwastol/autoware.ai:3.9.0 AS source-code
 
 
 RUN mkdir ~/src
@@ -46,7 +46,7 @@ RUN ~/src/carma-platform/docker/checkout.bash
 # /////////////////////////////////////////////////////////////////////////////
 
 
-FROM usdotfhwastol/autoware.ai:carma-system-3.4.0 AS install
+FROM usdotfhwastol/autoware.ai:3.9.0 AS install
 
 
 # Copy the source files from the previous stage and build/install
@@ -61,7 +61,7 @@ RUN ~/carma_ws/src/carma-platform/docker/install.sh
 # /////////////////////////////////////////////////////////////////////////////
 
 
-FROM usdotfhwastol/autoware.ai:carma-system-3.4.0
+FROM usdotfhwastol/autoware.ai:3.9.0
 
 ARG BUILD_DATE="NULL"
 ARG VCS_REF="NULL"

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -43,8 +43,8 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch $BRANCH
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch carma-system-3.4.0
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch carma-system-3.4.0
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch carma-system-3.4.0
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch carma-system-3.4.0
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch carma-msgs-1.4.0
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch novatel_gps_driver-1.4.0
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch carma-utils-1.4.0
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch carma-messenger-1.0.1
 fi

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,15 @@
 CARMA Platform Release Notes
 ----------------------------
 
+Version 3.4.1, released December 11th, 2020
+--------------------------------------------------------
+
+**Summary:**
+carma-platform release version 3.4.1 is a hotfix release to address the issue of unexpected switching between NDT and GPS localization. This hotfix ensures that switching between NDT and GPS will only occur in the event of a timeout.
+
+Fixes in this release:
+-   Issue 1005: The gnss_ndt_selector would cause lidar to gps failover in the event of an ndt timeout and vice versa regardless of the    operational mode (NDT only, GNSS only, AUTO score based switch).
+
 Version 3.4.0, released December 9th, 2020
 --------------------------------------------------------
 
@@ -16,7 +25,7 @@ Enhancements in this release:
 -	Issue 640: Updated the health_monitor to better handle lidar failures.
 -	Issue 766: Improved localization computation speed.
 -	Issue 838: Added support for PCD map file generation.
-- Issue 986: Added ability for gnss_ndt_selector to operate with a degraded sensor.
+-   Issue 986: Added ability for gnss_ndt_selector to operate with a degraded sensor.
 
 Fixes in this release:
 -	Issue 460: carma-platform does not fully shutdown when a fatal system alert occurs.

--- a/gnss_ndt_selector/config/parameters.yaml
+++ b/gnss_ndt_selector/config/parameters.yaml
@@ -19,6 +19,6 @@ ndt_pose_timeout: 1500
 # 0 - ndt only
 # 1 - GNSS only
 # 2 - auto select between ndt and GNSS
-localization_mode: 2
+localization_mode: 1
 
 

--- a/gnss_ndt_selector/config/parameters.yaml
+++ b/gnss_ndt_selector/config/parameters.yaml
@@ -19,6 +19,6 @@ ndt_pose_timeout: 1500
 # 0 - ndt only
 # 1 - GNSS only
 # 2 - auto select between ndt and GNSS
-localization_mode: 1
+localization_mode: 0
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Addresses issue https://github.com/usdot-fhwa-stol/carma-platform/issues/1005 by setting the default localization mode to NDT instead of AUTO
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1005
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
More predictable localization behavior and a stable ACE demo
## How Has This Been Tested?
Mapping the parameter using docker-compose
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
