### PR TITLE
Hotfix/use vehicle pose for routing

### DIFF
--- a/route/include/route_generator_worker.h
+++ b/route/include/route_generator_worker.h
@@ -39,8 +39,10 @@
 #include <geometry_msgs/Transform.h>
 #include <wgs84_utils/wgs84_utils.h>
 #include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 #include <visualization_msgs/MarkerArray.h>
 #include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <unordered_set>
 #include <lanelet2_extension/projection/local_frame_projector.h>
 #include <lanelet2_extension/io/autoware_osm_parser.h>
@@ -266,6 +268,8 @@ namespace route {
         int cte_count_ = 0;
 
         int cte_count_max_;
+
+        boost::optional<geometry_msgs::PoseStamped> vehicle_pose_;
 
     };
 

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -151,7 +151,7 @@ namespace route {
             // convert points in ECEF to map frame
             auto destination_points_in_map = transform_to_map_frame(destination_points, map_in_earth);
             
-            lanelet::BasicPoint2d vehicle_position(vehicle_pose_->pose.x, vehicle_pose_->pose.y);
+            lanelet::BasicPoint2d vehicle_position(vehicle_pose_->pose.position.x, vehicle_pose_->pose.position.y);
             destination_points_in_map.insert(destination_points_in_map.begin(), vehicle_position);
 
             int idx = 0;

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -113,6 +113,15 @@ namespace route {
             // entering to routing state once destinations are picked
             this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_SELECTED);
             publish_route_event(cav_msgs::RouteEvent::ROUTE_SELECTED);
+
+            if (!vehicle_pose_) {
+                ROS_ERROR_STREAM("No vehicle position. Routing cannot be completed.");
+                resp.errorStatus = cav_srvs::SetActiveRouteResponse::ROUTING_FAILURE;
+                this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
+                publish_route_event(cav_msgs::RouteEvent::ROUTE_GEN_FAILED);
+                return true;
+            }
+
             // get transform from ECEF(earth) to local map frame
             tf2::Transform map_in_earth;
             try
@@ -125,22 +134,26 @@ namespace route {
                 resp.errorStatus = cav_srvs::SetActiveRouteResponse::TRANSFORM_ERROR;
                 this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
                 publish_route_event(cav_msgs::RouteEvent::ROUTE_GEN_FAILED);
-                return false;
+                return true;
             }
 
             // load destination points in ECEF frame
             auto destination_points = load_route_destinations_in_ecef(req.routeID);
             // Check if route file are valid with at least one starting points and one destination points
-            if(destination_points.size() < 2)
+            if(destination_points.size() < 1)
             {
-                ROS_ERROR_STREAM("Selected route file contains 1 or less points. Routing cannot be completed.");
+                ROS_ERROR_STREAM("Selected route file contains no points. Routing cannot be completed.");
                 resp.errorStatus = cav_srvs::SetActiveRouteResponse::ROUTE_FILE_ERROR;
                 this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
                 publish_route_event(cav_msgs::RouteEvent::ROUTE_GEN_FAILED);
-                return false;
+                return true;
             }
             // convert points in ECEF to map frame
             auto destination_points_in_map = transform_to_map_frame(destination_points, map_in_earth);
+            
+            lanelet::BasicPoint2d vehicle_position(vehicle_pose_->pose.x, vehicle_pose_->pose.y);
+            destination_points_in_map.insert(destination_points_in_map.begin(), vehicle_position);
+
             int idx = 0;
             // validate if the points are geometrically in the map
             for (auto pt : destination_points_in_map)
@@ -153,7 +166,7 @@ namespace route {
                 resp.errorStatus = cav_srvs::SetActiveRouteResponse::ROUTE_FILE_ERROR;
                 this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
                 publish_route_event(cav_msgs::RouteEvent::ROUTE_GEN_FAILED);
-                return false;
+                return true;
                 }
                 idx ++;
             }
@@ -172,7 +185,7 @@ namespace route {
                 resp.errorStatus = cav_srvs::SetActiveRouteResponse::ROUTING_FAILURE;
                 this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
                 publish_route_event(cav_msgs::RouteEvent::ROUTE_GEN_FAILED);
-                return false;
+                return true;
             }
             // update route message
             route_msg_ = compose_route_msg(route);
@@ -196,7 +209,10 @@ namespace route {
             new_route_msg_generated_ = true;
             return true;
         }
-        return false;
+
+        resp.errorStatus = cav_srvs::SetActiveRouteResponse::ALREADY_FOLLOWING_ROUTE;
+
+        return true;
     }
 
     std::vector<tf2::Vector3> RouteGeneratorWorker::load_route_destinations_in_ecef(const std::string& route_id) const
@@ -337,6 +353,7 @@ namespace route {
 
     void RouteGeneratorWorker::pose_cb(const geometry_msgs::PoseStampedConstPtr& msg)
     {
+        vehicle_pose_ = *msg;
         if(this->rs_worker_.get_route_state() == RouteStateWorker::RouteState::FOLLOWING) {
             // convert from pose stamp into lanelet basic 2D point
             lanelet::BasicPoint2d current_loc(msg->pose.position.x, msg->pose.position.y);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1051 by using the vehicle position as the first point in the routing process. It also makes the service call return True when exceptions are caught so that the UI can properly display the reported error code. 
## Related Issue
See above
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Correct routing functionality for vanden plas
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In blue lexus at TFHRC
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
