### PR TITLE
Cannot restart same route after getting LEFT ROUTE event 

### DIFF
--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -62,14 +62,7 @@ namespace route {
     {
         boost::filesystem::path route_path_object(this->route_file_path_);
         if(boost::filesystem::exists(route_path_object))
-        {
-            //after route path object is available to select, worker will able to transit state and provide route selection service
-            if(this->rs_worker_.get_route_state() == RouteStateWorker::RouteState::LOADING) 
-            {
-                this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_LOADED);
-                publish_route_event(cav_msgs::RouteEvent::ROUTE_LOADED);
-            }
-            
+        {   
             boost::filesystem::directory_iterator end_point;
             // read all route files in the given directory
             for(boost::filesystem::directory_iterator itr(route_path_object); itr != end_point; ++itr)
@@ -99,6 +92,13 @@ namespace route {
                     route_msg.route_name = dest_name.substr(last_comma + 1);
                     resp.availableRoutes.push_back(route_msg);
                 }
+            }
+            
+            //after route path object is available to select, worker will able to transit state and provide route selection service
+            if(this->rs_worker_.get_route_state() == RouteStateWorker::RouteState::LOADING) 
+            {
+                this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_LOADED);
+                publish_route_event(cav_msgs::RouteEvent::ROUTE_LOADED);
             }
         }
         return true;

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -63,6 +63,13 @@ namespace route {
         boost::filesystem::path route_path_object(this->route_file_path_);
         if(boost::filesystem::exists(route_path_object))
         {
+            //after route path object is available to select, worker will able to transit state and provide route selection service
+            if(this->rs_worker_.get_route_state() == RouteStateWorker::RouteState::LOADING) 
+            {
+                this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_LOADED);
+                publish_route_event(cav_msgs::RouteEvent::ROUTE_LOADED);
+            }
+            
             boost::filesystem::directory_iterator end_point;
             // read all route files in the given directory
             for(boost::filesystem::directory_iterator itr(route_path_object); itr != end_point; ++itr)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Allow users to reselect the same route on the UI after getting a LEFT ROUTE event.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1057
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
release/vanden-plas
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
will be tested in vehicle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
