### PR TITLE
Fix transform lookup develop

### DIFF
--- a/motion_computation/include/motion_computation_node.h
+++ b/motion_computation/include/motion_computation_node.h
@@ -53,7 +53,8 @@ class MotionComputationNode
 
   // tf buffer holds the tree of transforms
   tf2_ros::Buffer tf_buffer_;
-
+  std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
+  
   /*!fn initialize()
   \brief lookup ECEF to Map transform from tf2 tree
   \return ECEF to Map transform
@@ -76,7 +77,7 @@ class MotionComputationNode
   \brief General starting point to run this node
   */
   void run();
-  
+
 };
 
 }//object

--- a/motion_computation/src/motion_computation_node.cpp
+++ b/motion_computation/src/motion_computation_node.cpp
@@ -72,16 +72,11 @@ namespace object{
   tf2::Transform MotionComputationNode::lookupECEFtoMapTransform()
   {
     tf2::Transform map_in_earth;
+    tf2_listener_.reset(new tf2_ros::TransformListener(tf_buffer_));
+    tf_buffer_.setUsingDedicatedThread(true);
     try
     {
-      std::string errstr;
-      if (tf_buffer_.canTransform("earth", "map", ros::Time(0), ros::Duration(20), &errstr)) //20 second timeout
-        tf2::convert(tf_buffer_.lookupTransform("earth", "map", ros::Time(0)).transform, map_in_earth); //save to local copy of transform
-      else
-      {
-        tf2::TransformException ex("Look up transform timed out: " + errstr);
-        ros::CARMANodeHandle::handleException(ex);
-      }
+      tf2::convert(tf_buffer_.lookupTransform("earth", "map", ros::Time(0), ros::Duration((double)time_out_time_)).transform, map_in_earth); //save to local copy of transform
     }
     catch (const tf2::TransformException &ex)
     {

--- a/motion_computation/src/motion_computation_node.cpp
+++ b/motion_computation/src/motion_computation_node.cpp
@@ -76,7 +76,7 @@ namespace object{
     tf_buffer_.setUsingDedicatedThread(true);
     try
     {
-      tf2::convert(tf_buffer_.lookupTransform("earth", "map", ros::Time(0), ros::Duration((double)time_out_time_)).transform, map_in_earth); //save to local copy of transform
+      tf2::convert(tf_buffer_.lookupTransform("earth", "map", ros::Time(0), ros::Duration(20.0)).transform, map_in_earth); //save to local copy of transform 20 sec timeout
     }
     catch (const tf2::TransformException &ex)
     {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
See below.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1087
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This PR adds back the tf2_listener missing as well as follow the instructions shown in the tf2 error message regarding lookupTransform
`Do not call canTransform or lookupTransform with a timeout unless you are using another thread for populating data. Without a dedicated thread it will always timeout. If you have a seperate thread servicing tf messages, call setUsingDedicatedThread(true) on your Buffer instance.`

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
