### PR TITLE
Hotfix/end of route

### DIFF
--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -255,7 +255,7 @@ namespace route_following_plugin
             for(auto i=1;i<plan.response.new_plan.maneuvers.size() -1 ;i++){
                 ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value()) ;
             }
-            ASSERT_EQ(plan.response.new_plan.maneuvers.back().type,cav_msgs::Maneuver::STOP_AND_WAIT);
+            
         }
         else{
             EXPECT_TRUE(false);

--- a/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
+++ b/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
@@ -115,7 +115,7 @@ namespace stop_and_wait_plugin
             }
         }
 
-        if(current_downtrack < maneuver_plan[0].stop_and_wait.start_dist){
+        if(current_downtrack < maneuver_plan[0].stop_and_wait_maneuver.start_dist){
             //Do nothing
             return true;
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR  changes planning logic in route_following, such that maneuver plan is only created for a specific duration, maneuver length. 
A change in stop and wait maneuver stops planning of the maneuver, until the current downtrack on the route is atleast the downtrack required for the stop and wait maneuver.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
