### PR TITLE
Regex updates for release image auto build process.

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -5,9 +5,11 @@ if [[ "$SOURCE_BRANCH" = "develop" ]]; then
     sed -i "s|checkout.bash|checkout.bash -d|g; s|usdotfhwastol/|usdotfhwastoldev/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:develop|g s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:develop|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:develop|g" \
         Dockerfile
 elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]]; then
-    # swap checkout branch in checkout.bash to release branch
-    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|:develop|:candidate|g" \
+    # Update Dockerfile to point to release images
+    RELEASE_NAME=$(echo $SOURCE_BRANCH | cut -d "/" -f 2)
+    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:develop|:$RELEASE_NAME|g" \
         Dockerfile
+    # swap checkout branch in checkout.bash to release branch
     sed -i "s|--branch .*|--branch $SOURCE_BRANCH|g" \
         docker/checkout.bash
 fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This change includes regex updates in the hooks/pre_build file in order to ensure that necessary release images are pulled and necessary repo release branches are cloned during the release image auto-build process on Docker Hub when a branch beginning with 'release/' is updated. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change ensures that the proper release base image(s) are pulled and the necessary repo release branches are cloned during the release image auto-build process on Docker Hub. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by verifying that the release/autobuild_test branch resulted in a successfully built image within the usdotfhwastolcandidate/carma-platform repository on Docker Hub. The build log associated with the auto build was checked to verify that proper release base images were pulled and necessary repo release branches were cloned during the build process.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
