### PR TITLE
Fix #114

### DIFF
--- a/carma_wm/include/carma_wm/CARMAWorldModel.h
+++ b/carma_wm/include/carma_wm/CARMAWorldModel.h
@@ -173,7 +173,7 @@ private:
   std::vector<lanelet::LineString3d> shortest_path_centerlines_;  // List of disjoint centerlines seperated by lane
                                                                   // changes along the shortest path
   IndexedDistanceMap shortest_path_distance_map_;
-  lanelet::LaneletSubmapUPtr shortest_path_filtered_centerline_view_;  // Lanelet map view of shortest path center lines
+  lanelet::LaneletMapUPtr shortest_path_filtered_centerline_view_;  // Lanelet map view of shortest path center lines
                                                                     // only
   std::vector<cav_msgs::RoadwayObstacle> roadway_objects_; // 
 

--- a/carma_wm/include/carma_wm/CARMAWorldModel.h
+++ b/carma_wm/include/carma_wm/CARMAWorldModel.h
@@ -168,12 +168,12 @@ private:
   LaneletRoutePtr route_;
   LaneletRoutingGraphPtr map_routing_graph_;
   
-  lanelet::LaneletMapConstUPtr shortest_path_view_;  // Map containing only lanelets along the shortest path of the
+  lanelet::LaneletSubmapConstUPtr shortest_path_view_;  // Map containing only lanelets along the shortest path of the
                                                      // route
   std::vector<lanelet::LineString3d> shortest_path_centerlines_;  // List of disjoint centerlines seperated by lane
                                                                   // changes along the shortest path
   IndexedDistanceMap shortest_path_distance_map_;
-  lanelet::LaneletMapUPtr shortest_path_filtered_centerline_view_;  // Lanelet map view of shortest path center lines
+  lanelet::LaneletSubmapUPtr shortest_path_filtered_centerline_view_;  // Lanelet map view of shortest path center lines
                                                                     // only
   std::vector<cav_msgs::RoadwayObstacle> roadway_objects_; // 
 

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -307,7 +307,7 @@ void CARMAWorldModel::setRoute(LaneletRoutePtr route)
 {
   route_ = route;
   lanelet::ConstLanelets path_lanelets(route_->shortestPath().begin(), route_->shortestPath().end());
-  shortest_path_view_ = lanelet::utils::createConstMap(path_lanelets, {});
+  shortest_path_view_ = lanelet::utils::createConstSubmap(path_lanelets, {});
   computeDowntrackReferenceLine();
 }
 
@@ -389,7 +389,7 @@ void CARMAWorldModel::computeDowntrackReferenceLine()
     shortest_path_distance_map_.pushBack(lanelet::utils::to2D(lineStrings.back()));  // Record length of last continuous
                                                                                      // segment
   }
-  shortest_path_filtered_centerline_view_ = lanelet::utils::createMap(shortest_path_centerlines_);
+  shortest_path_filtered_centerline_view_ = lanelet::utils::createSubmap(shortest_path_centerlines_);
 }
 
 LaneletRoutingGraphConstPtr CARMAWorldModel::getMapRoutingGraph() const

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -336,7 +336,7 @@ void CARMAWorldModel::computeDowntrackReferenceLine()
       lanelet::routing::RoutingGraph::build(*shortest_path_view_, *traffic_rules);
 
   std::vector<lanelet::LineString3d> lineStrings;  // List of continuos line strings representing segments of the route
-                                                   // reference line
+                                                   // reference line                                       
 
   bool first = true;
   size_t next_index = 0;
@@ -389,7 +389,9 @@ void CARMAWorldModel::computeDowntrackReferenceLine()
     shortest_path_distance_map_.pushBack(lanelet::utils::to2D(lineStrings.back()));  // Record length of last continuous
                                                                                      // segment
   }
-  shortest_path_filtered_centerline_view_ = lanelet::utils::createSubmap(shortest_path_centerlines_);
+
+  // Since our copy constructed linestrings do not contain references to lanelets they can be added to a full map instead of a submap
+  shortest_path_filtered_centerline_view_ = lanelet::utils::createMap(shortest_path_centerlines_); 
 }
 
 LaneletRoutingGraphConstPtr CARMAWorldModel::getMapRoutingGraph() const

--- a/carma_wm/test/TestHelpers.h
+++ b/carma_wm/test/TestHelpers.h
@@ -149,8 +149,8 @@ inline void addStraightRoute(CARMAWorldModel& cmw)
   lanelet::routing::Route route = std::move(*optional_route);
   LaneletRoutePtr route_ptr = std::make_shared<lanelet::routing::Route>(std::move(route));
   // 5. Set route and map
-  cmw.setRoute(route_ptr);
   cmw.setMap(map);
+  cmw.setRoute(route_ptr);
 }
 
 inline void addDisjointRoute(CARMAWorldModel& cmw)
@@ -194,8 +194,8 @@ inline void addDisjointRoute(CARMAWorldModel& cmw)
   lanelet::routing::Route route = std::move(*optional_route);
   LaneletRoutePtr route_ptr = std::make_shared<lanelet::routing::Route>(std::move(route));
   // 5. Set route and map
-  cmw.setRoute(route_ptr);
   cmw.setMap(map);
+  cmw.setRoute(route_ptr);
 }
 
 inline lanelet::LaneletMapPtr getDisjointRouteMap()


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Issue #1114 was caused because the shortest_path_view variable in carma world model was created using the lanelet::createConstMap() call provided with only the lanelets on the shortest path. However, because there was a regulatory element shared by lanelets on the shortest path and other lanelets these non-shortest path lanelets were also added to the map. 
This PR updates the call to use lanelet2's SubMap interface which only adds the elements you provide and not their children's children. 
<!--- Describe your changes in detail -->

## Related Issue
#1114 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Proper route following behavior
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests pass in carma_wm
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
