### PR TITLE
Add a param_dump script which will dump all the loaded rosparameters …

### DIFF
--- a/carma/launch/carma_src.launch
+++ b/carma/launch/carma_src.launch
@@ -138,5 +138,8 @@
   <group ns="carma_record">
     <include file="$(find carma_record)/launch/carma_record.launch" if="$(arg use_rosbag)" />
   </group>
+
+  <!-- Dump all ros parameters to a file -->
+  <node name="param_dump" pkg="carma_record" type="param_dump.sh"/>
   
 </launch>

--- a/carma_record/CMakeLists.txt
+++ b/carma_record/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(${PROJECT_NAME}_node
 ## in contrast to setup.py, you can choose the destination
 catkin_install_python(PROGRAMS
   scripts/carma_record.sh
+  scripts/param_dump.sh
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/carma_record/scripts/param_dump.sh
+++ b/carma_record/scripts/param_dump.sh
@@ -51,5 +51,9 @@ else # Handle case where latest/ does not exist
 fi
 
 PARAM_DUMP=$(rosparam dump) # Get params
-rostopic pub --once /carma_record/rosparams std_msgs/String "${PARAM_DUMP}" # Try to store in rosbag
+PARAM_DUMP=$(echo ${PARAM_DUMP} | tr ":" '=') # Convert colons to equals to support rostopic pub
+PARAM_DUMP=$(echo ${PARAM_DUMP} | tr "'" '"') # Replace single quotes with double to support rostopic pub
+PARAM_DUMP=\'${PARAM_DUMP}\' # Wrap whole thing in single quotes
+
+rostopic pub --once /carma_record/rosparams std_msgs/String "data: ${PARAM_DUMP}" # Try to store in rosbag
 

--- a/carma_record/scripts/param_dump.sh
+++ b/carma_record/scripts/param_dump.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#  Copyright (C) 2021 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This script is responsable for logging all the ROS Parameters of a running ROS Network
+sleep 10 # Sleep for 10s to allow the network to startup
+
+LOG_FOLDER="/opt/carma/logs"
+if [ -d "${LOG_FOLDER}/latest" ]
+then # If the latest folder exists then log to that
+  
+  echo "param_dump placing rosparams.yaml in ${LOG_FOLDER}/latest/rosparams.yaml"
+
+  rosparam dump > "${LOG_FOLDER}/latest/rosparams.yaml"
+
+else # Handle case where latest/ does not exist
+
+  echo "${LOG_FOLDER}/latest not found! param_dump will direct parameter logs to the most recent folder in ${LOG_FOLDER}"
+
+  #  The rest of this else block implementation is based on Stack Overflow answer: https://stackoverflow.com/a/35757377
+  #  Asked by Jonathan: https://stackoverflow.com/users/19272/jonathan
+  #  Answered by pjh: https://stackoverflow.com/users/4154375/pjh
+  #  Credited in accordance with Stack Overflow's CC-BY license
+  topdir=${LOG_FOLDER}
+  BACKUPDIR=
+
+  # Handle subdirectories beginning with '.', and empty $topdir
+  shopt -s dotglob nullglob
+
+  for file in "$topdir"/* ; do
+      [[ -L $file || ! -d $file ]] && continue
+      [[ -z $BACKUPDIR || $file -nt $BACKUPDIR ]] && BACKUPDIR=$file
+  done
+
+  echo "param_dump placing rosparams.yaml in ${BACKUPDIR}"
+
+  rosparam dump > "${BACKUPDIR}/rosparams.yaml"
+fi

--- a/carma_record/scripts/param_dump.sh
+++ b/carma_record/scripts/param_dump.sh
@@ -18,12 +18,13 @@
 sleep 10 # Sleep for 10s to allow the network to startup
 
 LOG_FOLDER="/opt/carma/logs"
+
 if [ -d "${LOG_FOLDER}/latest" ]
 then # If the latest folder exists then log to that
   
   echo "param_dump placing rosparams.yaml in ${LOG_FOLDER}/latest/rosparams.yaml"
-
-  rosparam dump > "${LOG_FOLDER}/latest/rosparams.yaml"
+  
+  rosparam dump > "${LOG_FOLDER}/latest/rosparams.yaml" # Store in file
 
 else # Handle case where latest/ does not exist
 
@@ -46,5 +47,9 @@ else # Handle case where latest/ does not exist
 
   echo "param_dump placing rosparams.yaml in ${BACKUPDIR}"
 
-  rosparam dump > "${BACKUPDIR}/rosparams.yaml"
+  rosparam dump > "${BACKUPDIR}/rosparams.yaml" # Store in file
 fi
+
+PARAM_DUMP=$(rosparam dump) # Get params
+rostopic pub --once /carma_record/rosparams std_msgs/String "${PARAM_DUMP}" # Try to store in rosbag
+


### PR DESCRIPTION
…to a file after system launch

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds a param_dump.sh script to the carma_record package. 
This script will create a log file that records all the ros parameters of the system as rosparameters.yaml in the ros log folder. 


## Related Issue
Resolves #1128
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This will be helpful with the ensuring duplication of test runs
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local testing of the script
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
