### PR TITLE
Fix state check in guidance state callback

### DIFF
--- a/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
+++ b/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
@@ -79,21 +79,12 @@ namespace trajectory_executor
     void TrajectoryExecutor::guidanceStateMonitor(cav_msgs::GuidanceState msg)
     {
         std::unique_lock<std::mutex> lock(_cur_traj_mutex); // Acquire lock until end of this function scope
-        if(msg.state==cav_msgs::GuidanceState::INACTIVE)
-        {
-        	_cur_traj= nullptr;
-        }
-
-    }
-
-    void TrajectoryExecutor::guidanceStateCb(const cav_msgs::GuidanceStateConstPtr& msg)
-    {
-        std::unique_lock<std::mutex> lock(_cur_traj_mutex);
         // TODO need to handle control handover once alernative planner system is finished
         if(msg->state != cav_msgs::GuidanceState::ENGAGED)
         {
         	_cur_traj= nullptr;
         }
+
     }
 
     void TrajectoryExecutor::onTrajEmitTick(const ros::TimerEvent& te)


### PR DESCRIPTION
Guidance state updates were being checked against == INACTIVE which may miss some cases in which the trajectory should not be consumed. This has been fixed to check against != ENGAGED. A redundant callback (unused) that contained this logic has been removed and the correct callback has been updated with this logic.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Implements a fix in guidance state processing logic inside of the trajectory executor. Previously trajectory processing was stopped only on transition to INACTIVE. Now it is stopped on transition to any state other than ENGAGED to ensure that transitions occurring during the end of route restart process don't trigger trajectory processing (with no data) thus causing an exception to be thrown.

## Related Issue

Potentially closes #1028

## Motivation and Context

Should ensure that trajectories are not consumed outside of ENGAGED state, preventing an exception from being thrown during vehicle operation after a completed route.

## How Has This Been Tested?

Untested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
