### PR TITLE
Cannot restart same route after getting LEFT ROUTE event

### DIFF
--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -438,7 +438,7 @@ namespace route {
             bool departed = crosstrack_error_check(msg, current_lanelet);
             if (departed)
                 {
-                    this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_GEN_FAILED);
+                    this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_DEPARTED);
                     publish_route_event(cav_msgs::RouteEvent::ROUTE_DEPARTED);
                 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
After the vehicle left route, route package publish left_route event and shall change route_state to loading state
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
vanden-plas release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing and will be tested in vehicle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
