### PR TITLE
fix/steering_issue

### DIFF
--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -46,7 +46,7 @@ namespace route_following_plugin
         
         pnh_->param<double>("minimal_maneuver_duration", mvr_duration_, 16.0);
         pnh2_->param<double>("config_speed_limit",config_limit);
-        pnh_->param<double>("/guidance/route_end_jerk", jerk_, 1.0);
+        pnh_->param<double>("/guidance/route_end_jerk", jerk_, 0.05);
         wml_.reset(new carma_wm::WMListener());
         // set world model point form wm listener
         wm_ = wml_->getWorldModel();

--- a/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
+++ b/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
@@ -129,12 +129,8 @@ namespace stop_and_wait_plugin
             return true;
         }
 
-        // Update state to correctly reflect current pos
-        auto curr_state = req.vehicle_state;
-        curr_state.X_pos_global = pose_msg_.pose.position.x;
-        curr_state.Y_pos_global = pose_msg_.pose.position.y;
 
-        std::vector<PointSpeedPair> points_and_target_speeds = maneuvers_to_points(maneuver_plan, current_downtrack, wm_, curr_state);
+        std::vector<PointSpeedPair> points_and_target_speeds = maneuvers_to_points(maneuver_plan, current_downtrack, wm_, req.vehicle_state);
 
         auto downsampled_points = 
             carma_utils::containers::downsample_vector(points_and_target_speeds,downsample_ratio_);
@@ -145,7 +141,7 @@ namespace stop_and_wait_plugin
         trajectory.header.stamp = ros::Time::now();
         trajectory.trajectory_id = boost::uuids::to_string(boost::uuids::random_generator()());
       
-        trajectory.trajectory_points = compose_trajectory_from_centerline(downsampled_points,curr_state);
+        trajectory.trajectory_points = compose_trajectory_from_centerline(downsampled_points,req.vehicle_state);
         ROS_DEBUG_STREAM("Trajectory points size:"<<trajectory.trajectory_points.size());
         trajectory.initial_longitudinal_velocity = req.vehicle_state.longitudinal_vel;
         resp.trajectory_plan = trajectory;
@@ -254,11 +250,16 @@ namespace stop_and_wait_plugin
 
                 lanelet::BasicLineString2d route_geometry = carma_wm::geometry::concatenate_lanelets(lanelets_to_add);
                 int nearest_pt_index = getNearestRouteIndex(route_geometry,state);
+                // route end point index
                 auto temp_state = state;
-                temp_state.X_pos_global = wm_->getRoute()->getEndPoint().basicPoint2d().x();
-                temp_state.Y_pos_global =  wm_->getRoute()->getEndPoint().basicPoint2d().y();
-                int nearest_end_pt_index = getNearestRouteIndex(route_geometry,temp_state);
-                lanelet::BasicLineString2d future_route_geometry(route_geometry.begin() + nearest_pt_index, route_geometry.begin()+ nearest_end_pt_index);
+                
+                // maneuver end dist index
+                int ending_downtrack_pt_index = (int)(route_geometry.size() * (ending_downtrack / wm_->getRoute()->length2d()));
+                ROS_DEBUG_STREAM("ending_downtrack: " << ending_downtrack);
+                ROS_DEBUG_STREAM("ending_downtrack_pt_index" << ending_downtrack_pt_index);
+                ROS_DEBUG_STREAM("nearest_pt_index" << nearest_pt_index);
+
+                lanelet::BasicLineString2d future_route_geometry(route_geometry.begin() + nearest_pt_index, route_geometry.begin()+ ending_downtrack_pt_index);
                 
                 int points_count = future_route_geometry.size();
                 delta_time = maneuver_time_/(points_count-1);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
At TFHRC, we initially noticed that there was `bad_alloc` error from stop_and_wait_plugin near the route end. This was because vehicle_state that was passed into stop_and_wait_plugin was not current_state of the vehicle (we were using position as if it was vehicle's position), which made lanelets_between function to fail as we are trying to get a vector starting from an index that is way past the end() index. . 
Therefore, we used vehicle's realtime pose. However, at Summit Point, this created additional random steering event supposedly when inlanecruising stops and stop_and_wait_plugin takes over, most likely due to that inconsistency in which pose to use in planning.
This PR is to revert that change and potentially fix the random steering event

NEW:
This PR also makes the stop_and_wait look at only its ending downtrack not the route-end as the route-end will be provided as ending downtrack anyways 

<!--- Describe your changes in detail -->
The issue below is related to inlanecruising's bad_alloc, and this story is for stop_and_wait but they could be related
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1173
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Not tested yet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
