### PR TITLE
Fix/detected objects id zero

### DIFF
--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -201,9 +201,9 @@
 
   <!-- naive_motion_predict -->
   <group>
-  <remap to="prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
-  <remap to="prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>
-
+  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
+  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>
+  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/objects_markers" from="/prediction/motion_predictor/objects_markers"/>
   <include file="$(find naive_motion_predict)/launch/naive_motion_predict.launch">
   <arg name="interval_sec" value="0.1"/>
   <arg name="num_prediction" value="10"/>

--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -115,9 +115,9 @@
   
   <!-- lidar_euclidean_cluster_detect -->
   <group>
-  <remap to="detection/lidar_detector/cloud_clusters" from="/detection/lidar_detector/cloud_clusters"/>
-  <remap to="detection/lidar_detector/objects" from="/detection/lidar_detector/objects"/>
-  <remap to="detection/lidar_detector/objects_markers" from="/detection/lidar_detector/objects_markers"/>
+  <remap to="$(optenv CARMA_ENV_NS)/detection/lidar_detector/cloud_clusters" from="/detection/lidar_detector/cloud_clusters"/>
+  <remap to="$(optenv CARMA_ENV_NS)/detection/lidar_detector/objects" from="/detection/lidar_detector/objects"/>
+  <remap to="$(optenv CARMA_ENV_NS)/detection/lidar_detector/objects_markers" from="/detection/lidar_detector/objects_markers"/>
 
   <include file="$(find lidar_euclidean_cluster_detect)/launch/lidar_euclidean_cluster_detect.launch">
   <arg name="points_node" value="ray_ground_filter/points_no_ground" />

--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -55,6 +55,7 @@
 
   <!-- CARMA External Object Node -->
   <group unless="$(arg simulation_mode)">
+    <remap to="prediction/motion_predictor/objects" from="detected_objects"/>
     <include file="$(find object_detection_tracking)/launch/external_object.launch"/>
   </group>
 
@@ -200,16 +201,15 @@
 
   <!-- naive_motion_predict -->
   <group>
-  <remap from="/prediction/motion_predictor/objects" to="detected_objects"/>
-  <remap from="/prediction/motion_predictor/objects_markers" to="prediction/motion_predictor/objects_markers"/>
-  <remap from="/prediction/motion_predictor/path_markers" to="prediction/motion_predictor/path_markers"/>
+  <remap to="prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
+  <remap to="prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>
 
   <include file="$(find naive_motion_predict)/launch/naive_motion_predict.launch">
   <arg name="interval_sec" value="0.1"/>
   <arg name="num_prediction" value="10"/>
   <arg name="sensor_height_calibration_params_file" value="$(arg vehicle_calibration_dir)/naive_motion_predict/calibration.yaml"/>
   <arg name="filter_out_close_object_threshold" value="1.5"/>
-  <arg name="input_topic" value="detection/fusion_tools/objects"/>
+  <arg name="input_topic" value="detected_objects"/>
   </include>
   </group>
   

--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -48,7 +48,7 @@
 
   <!-- CARMA Motion Computation Node -->
   <group>
-    <remap to="$(optenv CARMA_MSG_NS)/incoming_mobility_path" from="/environment/incoming_mobility_path"/>
+    <remap to="$(optenv CARMA_MSG_NS)/incoming_mobility_path" from="incoming_mobility_path"/>
     <include file="$(find motion_computation)/launch/motion_computation.launch"/>
   </group>
 
@@ -103,7 +103,7 @@
   </group>
 
 <!-- vision_beyond_track -->
-  <remap to="detection/image_detector/objects" from="/environment/vision_beyond_track_01/detection/image_detector/objects"/>
+  <remap to="detection/image_detector/objects" from="vision_beyond_track_01/detection/image_detector/objects"/>
   <remap from="/detection/image_tracker/objects" to="detection/image_tracker/objects"/>
   <group>
   <include file="$(find vision_beyond_track)/launch/vision_beyond_track.launch">
@@ -114,6 +114,7 @@
   </group>
   
   <!-- lidar_euclidean_cluster_detect -->
+  <!-- todo: remove CARMA_ENV_NS namespace without the node generating extra unwanted topics-->
   <group>
   <remap to="$(optenv CARMA_ENV_NS)/detection/lidar_detector/cloud_clusters" from="/detection/lidar_detector/cloud_clusters"/>
   <remap to="$(optenv CARMA_ENV_NS)/detection/lidar_detector/objects" from="/detection/lidar_detector/objects"/>
@@ -151,8 +152,8 @@
   <!-- range_vision_fusion -->
   <group>
 
-  <remap to="detection/image_tracker/objects" from="/environment/range_vision_fusion_01/detection/image_detector/objects"/>
-  <remap to="detection/lidar_detector/objects" from="/environment/range_vision_fusion_01/detection/lidar_detector/objects"/>
+  <remap to="detection/image_tracker/objects" from="range_vision_fusion_01/detection/image_detector/objects"/>
+  <remap to="detection/lidar_detector/objects" from="range_vision_fusion_01/detection/lidar_detector/objects"/>
   <remap to="detection/fusion_tools/objects" from="/detection/fusion_tools/objects"/>
   
   <include file="$(find range_vision_fusion)/launch/range_vision_fusion.launch">
@@ -200,6 +201,7 @@
   </group>
 
   <!-- naive_motion_predict -->
+  <!-- todo: remove CARMA_ENV_NS namespace without the node generating extra unwanted topics-->
   <group>
   <remap to="$(optenv CARMA_ENV_NS)/prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
   <remap to="$(optenv CARMA_ENV_NS)/prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>

--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -84,6 +84,7 @@
 
   <!-- vision_darknet_detect -->
   <group>
+  <remap from="/detection/image_detector/objects" to="detection/image_detector/objects"/>
   <include file="$(find vision_darknet_detect)/launch/vision_yolo3_detect.launch">
   <arg name="gpu_device_id" value="0"/>
   <arg name="score_threshold" value="0.30"/>
@@ -101,6 +102,8 @@
   </group>
 
 <!-- vision_beyond_track -->
+  <remap to="detection/image_detector/objects" from="/environment/vision_beyond_track_01/detection/image_detector/objects"/>
+  <remap from="/detection/image_tracker/objects" to="detection/image_tracker/objects"/>
   <group>
   <include file="$(find vision_beyond_track)/launch/vision_beyond_track.launch">
   <arg name="camera_info_src" value="$(optenv CARMA_INTR_NS)/camera/camera_info"/>
@@ -111,6 +114,10 @@
   
   <!-- lidar_euclidean_cluster_detect -->
   <group>
+  <remap to="detection/lidar_detector/cloud_clusters" from="/detection/lidar_detector/cloud_clusters"/>
+  <remap to="detection/lidar_detector/objects" from="/detection/lidar_detector/objects"/>
+  <remap to="detection/lidar_detector/objects_markers" from="/detection/lidar_detector/objects_markers"/>
+
   <include file="$(find lidar_euclidean_cluster_detect)/launch/lidar_euclidean_cluster_detect.launch">
   <arg name="points_node" value="ray_ground_filter/points_no_ground" />
 
@@ -143,9 +150,10 @@
   <!-- range_vision_fusion -->
   <group>
 
-  <remap to="/detection/image_detector/objects" from="/environment/range_vision_fusion_01/detection/image_detector/objects"/>
-  <remap to="/detection/lidar_detector/objects" from="/environment/range_vision_fusion_01/detection/lidar_detector/objects"/>
-	  
+  <remap to="detection/image_tracker/objects" from="/environment/range_vision_fusion_01/detection/image_detector/objects"/>
+  <remap to="detection/lidar_detector/objects" from="/environment/range_vision_fusion_01/detection/lidar_detector/objects"/>
+  <remap to="detection/fusion_tools/objects" from="/detection/fusion_tools/objects"/>
+  
   <include file="$(find range_vision_fusion)/launch/range_vision_fusion.launch">
   <arg name="detected_objects_range" value="detection/lidar_detector/objects"/>
   <arg name="detected_objects_vision" value="detection/image_detector/objects"/>
@@ -163,10 +171,12 @@
 
   <!-- imm_ukf_pda_track -->
   <group>
+  <remap to="detected_objects" from="/detection/objects"/>
+
   <include file="$(find imm_ukf_pda_track)/launch/imm_ukf_pda_track_lanelet2.launch">
-  	 <arg name="namespace" value="detection/object_tracker"/>
+  <arg name="namespace" value="detection/object_tracker"/>
   <arg name="tracker_input_topic" value="detection/fusion_tools/objects" />
-  	<arg name="tracker_output_topic" value="detection/object_tracker/objects" />
+  <arg name="tracker_output_topic" value="detection/object_tracker/objects" />
 
   <arg name="tracking_frame" value="map" />
   <arg name="gating_threshold" value="9.22" />
@@ -191,12 +201,15 @@
   <!-- naive_motion_predict -->
   <group>
   <remap from="/prediction/motion_predictor/objects" to="detected_objects"/>
+  <remap from="/prediction/motion_predictor/objects_markers" to="prediction/motion_predictor/objects_markers"/>
+  <remap from="/prediction/motion_predictor/path_markers" to="prediction/motion_predictor/path_markers"/>
+
   <include file="$(find naive_motion_predict)/launch/naive_motion_predict.launch">
   <arg name="interval_sec" value="0.1"/>
   <arg name="num_prediction" value="10"/>
   <arg name="sensor_height_calibration_params_file" value="$(arg vehicle_calibration_dir)/naive_motion_predict/calibration.yaml"/>
   <arg name="filter_out_close_object_threshold" value="1.5"/>
-  <arg name="input_topic" value="/detection/fusion_tools/objects"/>
+  <arg name="input_topic" value="detection/fusion_tools/objects"/>
   </include>
   </group>
   

--- a/carma/launch/environment.launch
+++ b/carma/launch/environment.launch
@@ -201,9 +201,9 @@
 
   <!-- naive_motion_predict -->
   <group>
-  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
-  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>
-  <remap to="$(optenv CARMA_ENV_NS)prediction/motion_predictor/objects_markers" from="/prediction/motion_predictor/objects_markers"/>
+  <remap to="$(optenv CARMA_ENV_NS)/prediction/motion_predictor/objects" from="/prediction/motion_predictor/objects"/>
+  <remap to="$(optenv CARMA_ENV_NS)/prediction/motion_predictor/path_markers" from="/prediction/motion_predictor/path_markers"/>
+  <remap to="$(optenv CARMA_ENV_NS)/prediction/motion_predictor/objects_markers" from="/prediction/motion_predictor/objects_markers"/>
   <include file="$(find naive_motion_predict)/launch/naive_motion_predict.launch">
   <arg name="interval_sec" value="0.1"/>
   <arg name="num_prediction" value="10"/>

--- a/carma/rviz/carma_default.rviz
+++ b/carma/rviz/carma_default.rviz
@@ -557,12 +557,12 @@ Visualization Manager:
       width: 128
     - Class: rviz/MarkerArray
       Enabled: true
-      Marker Topic: /detection/lidar_detector/objects_markers
+      Marker Topic: /environment/detection/lidar_detector/objects_markers
       Name: MarkerArray
       Namespaces:
-        /detection/lidar_detector/centroid_markers: true
-        /detection/lidar_detector/hull_markers: true
-        /detection/lidar_detector/label_markers: true
+        /environment/detection/lidar_detector/centroid_markers: true
+        /environment/detection/lidar_detector/hull_markers: true
+        /environment/detection/lidar_detector/label_markers: true
       Queue Size: 100
       Value: true
     - Alpha: 1


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR remaps the topic to strictly follow the object detection stack in the picture attached. This fixes ids and speed being 0 on roadway objects.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1164
https://github.com/usdot-fhwa-stol/carma-platform/issues/1160
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Fusion.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
