### PR TITLE
fix output order from getLaneletsBetween

### DIFF
--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -280,8 +280,19 @@ std::vector<lanelet::ConstLanelet> CARMAWorldModel::getLaneletsBetween(double st
     prioritized_lanelets.pop();
     output.push_back(pair.lanelet_);
   }
+  
+  //Sort lanelets according to shortest path
+  std::vector<lanelet::ConstLanelet> sorted_output;
+  for(auto llt : route_->shortestPath()){
+    for(int i=0; i < output.size();i++){
+      if(llt.id() == output[i].id()){
+        sorted_output.push_back(llt);
+        break;
+      }
+    }
+  }
 
-  return output;
+  return sorted_output;
 }
 
 std::vector<lanelet::BasicPoint2d> CARMAWorldModel::sampleRoutePoints(double start_downtrack, double end_downtrack,

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -280,8 +280,12 @@ std::vector<lanelet::ConstLanelet> CARMAWorldModel::getLaneletsBetween(double st
     prioritized_lanelets.pop();
     output.push_back(pair.lanelet_);
   }
+
+  if(!shortest_path_only){
+    return output;
+  }
   
-  //Sort lanelets according to shortest path
+  //Sort lanelets according to shortest path if using shortest path
   std::vector<lanelet::ConstLanelet> sorted_output;
   for(auto llt : route_->shortestPath()){
     for(int i=0; i < output.size();i++){


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This pr adds a fix in getLaneletsBetween (carma_wm) which sorts the order of the output from the function, according to the shortest path.
## Description
This fix is required to correctly generate lane change paths.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
