### PR TITLE
Add cleaner handling for shutdown case in arbitrator

### DIFF
--- a/arbitrator/src/arbitrator.cpp
+++ b/arbitrator/src/arbitrator.cpp
@@ -48,6 +48,11 @@ namespace arbitrator
                     ROS_INFO("Aribtrator spinning in PAUSED state.");
                     paused_state();
                     break;
+                case SHUTDOWN:
+                    ROS_INFO("Arbitrator shutting down after being commanded to shutdown!");
+                    ros::shutdown();
+                    exit(0);
+                    break;
                 default:
                     throw std::invalid_argument("State machine attempting to process an illegal state value");
             }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

Adds clean shutdown handling logic for Arbitrator node to remove exception thrown in logs as part of normal shutdown procedure.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #509 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Reduces confusion over state machine shutdown exception thrown during normal CARMA shutdown procedure after publication of `cav_msgs/SystemAlert` with value `FATAL`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested to work using local CARMA development docker configuration with manual publication of `SystemAlert` messages to force a shutdown.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
