### PR TITLE
Fix/ctrl request timer

### DIFF
--- a/carma_wm_ctrl/src/WMBroadcasterNode.cpp
+++ b/carma_wm_ctrl/src/WMBroadcasterNode.cpp
@@ -80,8 +80,11 @@ int WMBroadcasterNode::run()
   pnh2_.getParam("/config_speed_limit", config_limit);
   wmb_.setConfigSpeedLimit(config_limit);
 
-  if(wmb_.getRoute().route_path_lanelet_ids.size() > 0)
-    timer = cnh_.createTimer(ros::Duration(10.0), [this](auto){wmb_.routeCallbackMessage(wmb_.getRoute());}, &wmb_);
+  
+    timer = cnh_.createTimer(ros::Duration(10.0), [this](auto){
+      if(wmb_.getRoute().route_path_lanelet_ids.size() > 0)
+      wmb_.routeCallbackMessage(wmb_.getRoute());
+      }, &wmb_);
  
   // Spin
   cnh_.spin();

--- a/carma_wm_ctrl/src/WMBroadcasterNode.cpp
+++ b/carma_wm_ctrl/src/WMBroadcasterNode.cpp
@@ -80,7 +80,8 @@ int WMBroadcasterNode::run()
   pnh2_.getParam("/config_speed_limit", config_limit);
   wmb_.setConfigSpeedLimit(config_limit);
 
-  timer = cnh_.createTimer(ros::Duration(10.0), [this](auto){wmb_.routeCallbackMessage(wmb_.getRoute());}, &wmb_);
+  if(wmb_.getRoute().route_path_lanelet_ids.size() > 0)
+    timer = cnh_.createTimer(ros::Duration(10.0), [this](auto){wmb_.routeCallbackMessage(wmb_.getRoute());}, &wmb_);
  
   // Spin
   cnh_.spin();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This change fixes an issue with the TrafficControlRequest timer causing carma to crash at startup since the timer is calling routeCallbackMessage() in WMBroadcaster with an empty route (no route exists at startup), and this empty route is then passed to controlRequestFromRoute(). 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/866
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
