### PR TITLE
Make new message check more robust to GPS noise

### DIFF
--- a/traffic_incident_parser/include/traffic_incident_parser_worker.h
+++ b/traffic_incident_parser/include/traffic_incident_parser_worker.h
@@ -69,8 +69,10 @@ class TrafficIncidentParserWorker
     /*! \fn mobilityMessageParser(std::string mobility_strategy_params)
     \brief mobilityMessageParser helps to parse incoming mobility operation message to required format
     \param  std::string mobility_strategy_params
+
+    \return True if the new message is valid and can be used. False if not new or not valid.
   */
-  void mobilityMessageParser(std::string mobility_strategy_params);
+  bool mobilityMessageParser(std::string mobility_strategy_params);
 
     /*! \fn stringParserHelper(std::string str,int str_index)
     \brief stringParserHelper helps to convert string to double data type.
@@ -90,12 +92,12 @@ class TrafficIncidentParserWorker
   */
   lanelet::BasicPoint2d getIncidentOriginPoint() const;
 
-  double latitude;
-  double longitude;
-  double down_track;
-  double up_track;
-  double min_gap;
-  double speed_advisory;
+  double latitude = 0.0;
+  double longitude = 0.0;
+  double down_track = 0.0;
+  double up_track = 0.0;
+  double min_gap = 0.0;
+  double speed_advisory = 0.0;
   std::string event_reason;
   std::string event_type;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the traffic incident parser node so that it will have a buffer on the position reported by the Tahoe and only forward new messages if there as been an change in the parameters or a position change of greater than 5m. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Message processing is more robust to GPS errors
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in black pacifica at tfhrc
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
