### PR TITLE
Add incoming MobilityOperation message processing to Port Drayage Plugin

### DIFF
--- a/carma/launch/guidance.launch
+++ b/carma/launch/guidance.launch
@@ -196,6 +196,8 @@
 
   <!-- Port Drayage Plugin -->
   <group>
+    <remap from="outgoing_mobility_operation" to="$(optenv CARMA_MSG_NS)/outgoing_mobility_operation"/>
+    <remap from="incoming_mobility_operation" to="$(optenv CARMA_MSG_NS)/incoming_mobility_operation"/>
     <include file="$(find port_drayage_plugin)/launch/port_drayage_plugin.launch" />
   </group>
 

--- a/carma/launch/guidance.launch
+++ b/carma/launch/guidance.launch
@@ -194,6 +194,11 @@
     <include file = "$(find yield_plugin)/launch/yield_plugin.launch"/>
   </group>
 
+  <!-- Port Drayage Plugin -->
+  <group>
+    <include file="$(find port_drayage_plugin)/launch/port_drayage_plugin.launch" />
+  </group>
+
 
 </launch>
 

--- a/port_drayage_plugin/CMakeLists.txt
+++ b/port_drayage_plugin/CMakeLists.txt
@@ -108,9 +108,9 @@ install(TARGETS ${PROJECT_NAME}_node
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(FILES
-  config/params.yml
-  launch/port_drayage_plugin.launch
+install(DIRECTORY
+  launch
+  config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/port_drayage_plugin/CMakeLists.txt
+++ b/port_drayage_plugin/CMakeLists.txt
@@ -50,7 +50,7 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(${PROJECT_NAME}_lib
+add_library(port_drayage_plugin_library
   src/port_drayage_plugin.cpp
   src/port_drayage_state_machine.cpp
   src/port_drayage_worker.cpp
@@ -59,27 +59,28 @@ add_library(${PROJECT_NAME}_lib
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-add_dependencies(${PROJECT_NAME}_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(port_drayage_plugin_library ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-add_executable(${PROJECT_NAME}_node src/port_drayage_plugin_main.cpp)
+add_executable(${PROJECT_NAME} src/port_drayage_plugin_main.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
 ## target back to the shorter version for ease of user use
 ## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME port_drayage_plugin PREFIX "")
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME port_drayage_plugin PREFIX "")
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
-add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}_node
-  port_drayage_plugin_lib
+target_link_libraries(${PROJECT_NAME}
+  port_drayage_plugin_library
   ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 #############
@@ -88,20 +89,20 @@ target_link_libraries(${PROJECT_NAME}_node
 
 ## Mark executables for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-install(TARGETS ${PROJECT_NAME}_node
+install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 ## Mark libraries for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-install(TARGETS ${PROJECT_NAME}_node
+install(TARGETS ${PROJECT_NAME} port_drayage_plugin_library
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
 
 ## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
+# install(DIRECTORY include
 #   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 #   FILES_MATCHING PATTERN "*.h"
 #   PATTERN ".svn" EXCLUDE
@@ -122,7 +123,7 @@ install(DIRECTORY
 catkin_add_gtest(${PROJECT_NAME}-test test/test_port_drayage_plugin.cpp)
 if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test 
-  port_drayage_plugin_lib 
+  port_drayage_plugin_library 
   ${catkin_LIBRARIES})
 endif()
 

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_plugin.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_plugin.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2018-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_plugin.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_plugin.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <cav_srvs/PlanManeuvers.h>
 #include <cav_msgs/ManeuverPlan.h>
+#include <cav_msgs/MobilityOperation.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <carma_wm/WorldModel.h>
 #include <carma_wm/WMListener.h>
@@ -44,6 +45,7 @@ namespace port_drayage_plugin
             std::shared_ptr<ros::Subscriber> _maneuver_plan_subscriber = nullptr;
             std::shared_ptr<ros::Subscriber> _pose_subscriber = nullptr;
             std::shared_ptr<ros::Subscriber> _cur_speed_subscriber = nullptr;
+            std::shared_ptr<ros::Subscriber> _inbound_mobility_operation_subscriber = nullptr;
             std::shared_ptr<ros::Publisher> _outbound_mobility_operations_publisher = nullptr;
             
             // ROS service servers

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -20,11 +20,30 @@
 #include <cav_msgs/MobilityOperation.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <boost/optional.hpp>
 
 #include "port_drayage_plugin/port_drayage_state_machine.h"
 
 namespace port_drayage_plugin
 {
+    /**
+     * Convenience struct for storing all data contained in a received MobilityOperation message's
+     * strategy_params field with strategy "carma/port_drayage"
+     */
+    struct PortDrayageMobilityOperationMsg
+    {
+        std::string cargo_id;
+        std::string operation;
+        PortDrayageEvent port_drayage_event_type; // PortDrayageEvent associated with this message
+        bool has_cargo; // Flag to indicate whether vehicle has cargo during this action
+        std::string current_action_id;
+        std::string next_action_id;
+        boost::optional<double> dest_longitude;
+        boost::optional<double> dest_latitude;
+        boost::optional<double> start_longitude; // Starting longitude of the carma vehicle
+        boost::optional<double> start_latitude; // Starting latitude of the carma vehicle
+    };
+
     /**
      * Implementation class for all the business logic of the PortDrayagePlugin
      * 
@@ -125,7 +144,7 @@ namespace port_drayage_plugin
             /**
              * \brief Function to help parse the text included in an inbound MobilityOperation message's 
              *  strategy_params field according to the JSON schema intended for MobilityOperation messages
-             *  with strategy type 'carma/port_drayage'
+             *  with strategy type 'carma/port_drayage'. Stores the parsed information in _latest_mobility_operation_msg.
              * \param mobility_operation_strategy_params the strategy_params field of a MobilityOperation message
              */
             void mobility_operation_message_parser(std::string mobility_operation_strategy_params);
@@ -146,16 +165,8 @@ namespace port_drayage_plugin
              */
             bool check_for_stop(const cav_msgs::ManeuverPlanConstPtr& plan, const geometry_msgs::TwistStampedConstPtr& speed) const;
 
-            // Data members for storing the data located in the strategy_params field of a received port drayage MobilityOperation message intended for this vehicle's cmv_id
-            std::string _received_cargo_id;
-            std::string _received_operation;
-            bool _received_cargo_flag;
-            double _received_start_long;
-            double _received_start_lat;
-            double _received_dest_long;
-            double _received_dest_lat;
-            std::string _received_curr_action_id;
-            std::string _received_next_action_id;
+            // PortDrayageMobilityOperationMsg object for storing strategy_params data of a received port drayage MobilityOperation message intended for this vehicle's cmv_id
+            PortDrayageMobilityOperationMsg _latest_mobility_operation_msg;
 
     };
 } // namespace port_drayage_plugin

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -45,17 +45,9 @@ namespace port_drayage_plugin
             std::string _cmv_id;
             std::string _cargo_id;
             std::function<void(cav_msgs::MobilityOperation)> _publish_mobility_operation;
-            
+
+            // Data member for storing the strategy_params field of the last processed port drayage MobilityOperation message intended for this vehicle's cmv_id
             std::string _previous_strategy_params;
-            std::string _received_cargo_id;
-            std::string _received_operation;
-            bool _received_cargo_flag;
-            double _received_start_long;
-            double _received_start_lat;
-            double _received_dest_long;
-            double _received_dest_lat;
-            std::string _received_curr_action_id;
-            std::string _received_next_action_id;
 
             // Constants
             const std::string PORT_DRAYAGE_PLUGIN_ID = "Port Drayage Plugin";
@@ -126,9 +118,9 @@ namespace port_drayage_plugin
 
             /**
              * \brief Callback to process a received MobilityOperation message
-             * \param mobility_msg a received MobilityOperation message
+             * \param mobility_operation_msg a received MobilityOperation message
              */
-            void on_inbound_mobility_operation(const cav_msgs::MobilityOperationConstPtr& mobility_msg);
+            void on_inbound_mobility_operation(const cav_msgs::MobilityOperationConstPtr& mobility_operation_msg);
 
             /**
              * \brief Function to help parse the text included in an inbound MobilityOperation message's 
@@ -137,22 +129,6 @@ namespace port_drayage_plugin
              * \param mobility_operation_strategy_params the strategy_params field of a MobilityOperation message
              */
             void mobility_operation_message_parser(std::string mobility_operation_strategy_params);
-
-            /**
-             * \brief Getter function that returns the destination longitude associated with the last processed MobilityOperation message
-             */
-            double get_received_destination_long();
-
-            /**
-             * \brief Getter function that returns the destination latitude associated with the last processed MobilityOperation message
-             */
-            double get_received_destination_lat();
-
-            /**
-             * \brief Getter function that returns the cargo ID associated with the last processed MobilityOperation message
-             */
-            std::string get_received_cargo_id();
-
 
             /**
              * \brief Spin and process data
@@ -170,6 +146,16 @@ namespace port_drayage_plugin
              */
             bool check_for_stop(const cav_msgs::ManeuverPlanConstPtr& plan, const geometry_msgs::TwistStampedConstPtr& speed) const;
 
+            // Data members for storing the data located in the strategy_params field of a received port drayage MobilityOperation message intended for this vehicle's cmv_id
+            std::string _received_cargo_id;
+            std::string _received_operation;
+            bool _received_cargo_flag;
+            double _received_start_long;
+            double _received_start_lat;
+            double _received_dest_long;
+            double _received_dest_lat;
+            std::string _received_curr_action_id;
+            std::string _received_next_action_id;
 
     };
 } // namespace port_drayage_plugin

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2018-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -45,6 +45,17 @@ namespace port_drayage_plugin
             std::string _cmv_id;
             std::string _cargo_id;
             std::function<void(cav_msgs::MobilityOperation)> _publish_mobility_operation;
+            
+            std::string _previous_strategy_params;
+            std::string _received_cargo_id;
+            std::string _received_operation;
+            bool _received_cargo_flag;
+            double _received_start_long;
+            double _received_start_lat;
+            double _received_dest_long;
+            double _received_dest_lat;
+            std::string _received_curr_action_id;
+            std::string _received_next_action_id;
 
             // Constants
             const std::string PORT_DRAYAGE_PLUGIN_ID = "Port Drayage Plugin";
@@ -112,6 +123,36 @@ namespace port_drayage_plugin
              * \brief Set the current speed as measured by the vehicle's sensors
              */
             void set_current_speed(const geometry_msgs::TwistStampedConstPtr& speed);
+
+            /**
+             * \brief Callback to process a received MobilityOperation message
+             * \param mobility_msg a received MobilityOperation message
+             */
+            void on_inbound_mobility_operation(const cav_msgs::MobilityOperationConstPtr& mobility_msg);
+
+            /**
+             * \brief Function to help parse the text included in an inbound MobilityOperation message's 
+             *  strategy_params field according to the JSON schema intended for MobilityOperation messages
+             *  with strategy type 'carma/port_drayage'
+             * \param mobility_operation_strategy_params the strategy_params field of a MobilityOperation message
+             */
+            void mobility_operation_message_parser(std::string mobility_operation_strategy_params);
+
+            /**
+             * \brief Getter function that returns the destination longitude associated with the last processed MobilityOperation message
+             */
+            double get_received_destination_long();
+
+            /**
+             * \brief Getter function that returns the destination latitude associated with the last processed MobilityOperation message
+             */
+            double get_received_destination_lat();
+
+            /**
+             * \brief Getter function that returns the cargo ID associated with the last processed MobilityOperation message
+             */
+            std::string get_received_cargo_id();
+
 
             /**
              * \brief Spin and process data

--- a/port_drayage_plugin/launch/port_drayage_plugin.launch
+++ b/port_drayage_plugin/launch/port_drayage_plugin.launch
@@ -1,6 +1,6 @@
 <!--
 
-  Copyright (C) 2018-2020 LEIDOS.
+  Copyright (C) 2018-2021 LEIDOS.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2018-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -67,6 +67,13 @@ namespace port_drayage_plugin
         });
 
         _pose_subscriber = std::make_shared<ros::Subscriber>(pose_sub);
+
+        ros::Subscriber inbound_mobility_operation_sub = _nh->subscribe<cav_msgs::MobilityOperation>("incoming_mobility_operation", 5,
+            [&](const cav_msgs::MobilityOperationConstPtr& mobility_msg){
+            pdw.on_inbound_mobility_operation(mobility_msg);
+        });
+
+        _inbound_mobility_operation_subscriber = std::make_shared<ros::Subscriber>(inbound_mobility_operation_sub);
         
         ros::Timer discovery_pub_timer_ = _nh->createTimer(
             ros::Duration(ros::Rate(10.0)),

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -34,7 +34,7 @@ namespace port_drayage_plugin
         std::string cargo_id;
         _pnh->param<std::string>("cargo_id", cargo_id, "");
 
-        ros::Publisher outbound_mob_op = _nh->advertise<cav_msgs::MobilityOperation>("outbound_mobility_operation", 5);
+        ros::Publisher outbound_mob_op = _nh->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
         _outbound_mobility_operations_publisher = std::make_shared<ros::Publisher>(outbound_mob_op);
         PortDrayageWorker pdw{
             cmv_id,
@@ -46,13 +46,13 @@ namespace port_drayage_plugin
             speed_epsilon
         };
         
-        ros::Subscriber maneuver_sub = _nh->subscribe<cav_msgs::ManeuverPlan>("final_Maneuver_plan", 5, 
+        ros::Subscriber maneuver_sub = _nh->subscribe<cav_msgs::ManeuverPlan>("final_maneuver_plan", 5, 
             [&](const cav_msgs::ManeuverPlanConstPtr& plan) {
                 pdw.set_maneuver_plan(plan);
         });
         _maneuver_plan_subscriber = std::make_shared<ros::Subscriber>(maneuver_sub);
 
-        ros::Subscriber twist_sub = _nh->subscribe<geometry_msgs::TwistStamped>("localization/ekf_twist", 5, 
+        ros::Subscriber twist_sub = _nh->subscribe<geometry_msgs::TwistStamped>("/localization/ekf_twist", 5, 
             [&](const geometry_msgs::TwistStampedConstPtr& speed) {
                 pdw.set_current_speed(speed);
                 _cur_speed = speed->twist;

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 LEIDOS.
+ * Copyright (C) 2018-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -91,61 +91,83 @@ namespace port_drayage_plugin
         return msg;
     }
 
-    void PortDrayageWorker::on_inbound_mobility_operation(const cav_msgs::MobilityOperationConstPtr& mobility_operation_msg)
-    {
+    void PortDrayageWorker::on_inbound_mobility_operation(const cav_msgs::MobilityOperationConstPtr& msg) {
         // Check if the received message is a new message for port drayage
-        if((mobility_operation_msg->strategy == PORT_DRAYAGE_STRATEGY_ID) && (mobility_operation_msg->strategy_params != _previous_strategy_params))
-        {
+        if((msg->strategy == PORT_DRAYAGE_STRATEGY_ID) && (msg->strategy_params != _previous_strategy_params)) {
             // Use Boost Property Tree to parse JSON-encoded strategy_params field in MobilityOperations message
             using boost::property_tree::ptree;
             ptree pt;
-            std::istringstream strategy_params_ss(mobility_operation_msg->strategy_params);
+            std::istringstream strategy_params_ss(msg->strategy_params);
             boost::property_tree::json_parser::read_json(strategy_params_ss, pt);
-            std::string received_cmv_id = pt.get<std::string>("cmv_id");
+            std::string mobility_operation_cmv_id = pt.get<std::string>("cmv_id");
 
             // Check if the received MobilityOperation message is intended for this vehicle's cmv_id   
-            if(received_cmv_id == _cmv_id)
-            {
-                ROS_DEBUG_STREAM("Processing new port drayage MobilityOperation message for cmv_id " << received_cmv_id);
-                _pdsm.process_event(PortDrayageEvent::RECEIVED_NEW_DESTINATION);
-                mobility_operation_message_parser(mobility_operation_msg->strategy_params);  
-                _previous_strategy_params = mobility_operation_msg->strategy_params;
+            if(mobility_operation_cmv_id == _cmv_id) {
+                ROS_DEBUG_STREAM("Processing new port drayage MobilityOperation message for cmv_id " << mobility_operation_cmv_id);
+                mobility_operation_message_parser(msg->strategy_params);  
+                _previous_strategy_params = msg->strategy_params;
+                
+                // Process event based on the PortDrayageEvent associated with the received MobilityOperation message
+                switch(_latest_mobility_operation_msg.port_drayage_event_type) {
+                    case PortDrayageEvent::RECEIVED_NEW_DESTINATION:
+                        _pdsm.process_event(PortDrayageEvent::RECEIVED_NEW_DESTINATION);
+                        break;
+                    default:
+                        break;
+                }
             }
-            else
-            {
-                ROS_DEBUG_STREAM("Ignoring received port drayage MobilityOperation message intended for cmv_id " << received_cmv_id);
+            else {
+                ROS_DEBUG_STREAM("Ignoring received port drayage MobilityOperation message intended for cmv_id " << mobility_operation_cmv_id);
             }
-
         }
     }
 
-    void PortDrayageWorker::mobility_operation_message_parser(std::string mobility_operation_strategy_params)
-    {
+    void PortDrayageWorker::mobility_operation_message_parser(std::string mobility_operation_strategy_params) {
         // Use Boost Property Tree to parse JSON-encoded strategy_params field in MobilityOperations message
         using boost::property_tree::ptree;
         ptree pt;
         std::istringstream mobility_operation_strategy_params_ss(mobility_operation_strategy_params);
         boost::property_tree::json_parser::read_json(mobility_operation_strategy_params_ss, pt);
 
-        _received_cargo_id = pt.get<std::string>("cargo_id");
-        _received_operation = pt.get<std::string>("operation");
-        _received_cargo_flag = pt.get<bool>("cargo");
-        _received_start_long = pt.get<double>("location.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
-        _received_start_lat = pt.get<double>("location.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
-        _received_dest_long = pt.get<double>("destination.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
-        _received_dest_lat = pt.get<double>("destination.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
-        _received_curr_action_id = pt.get<std::string>("action_id");
-        _received_next_action_id = pt.get<std::string>("next_action");
+        _latest_mobility_operation_msg.cargo_id = pt.get<std::string>("cargo_id");
+        _latest_mobility_operation_msg.has_cargo = pt.get<bool>("cargo");
+        _latest_mobility_operation_msg.current_action_id = pt.get<std::string>("action_id");
+        _latest_mobility_operation_msg.next_action_id = pt.get<std::string>("next_action");
+        _latest_mobility_operation_msg.operation = pt.get<std::string>("operation");
 
-        ROS_DEBUG_STREAM("cargo id: " << _received_cargo_id);
-        ROS_DEBUG_STREAM("operation: " << _received_operation);
-        ROS_DEBUG_STREAM("cargo flag: " << _received_cargo_flag);
-        ROS_DEBUG_STREAM("start long: " << _received_start_long);
-        ROS_DEBUG_STREAM("start lat: " << _received_start_lat);
-        ROS_DEBUG_STREAM("dest long: " << _received_dest_long);
-        ROS_DEBUG_STREAM("dest lat: " << _received_dest_lat);
-        ROS_DEBUG_STREAM("current action id: " << _received_curr_action_id);
-        ROS_DEBUG_STREAM("next action id: " << _received_next_action_id);
+        if(_latest_mobility_operation_msg.operation == "MOVING_TO_LOADING_AREA") {
+            _latest_mobility_operation_msg.port_drayage_event_type = PortDrayageEvent::RECEIVED_NEW_DESTINATION;
+        }
+
+        // Parse starting longitude/latitude fields if they exist:
+        if((pt.count("location.longitude") != 0) && (pt.count("location.latitude") != 0)) {
+            _latest_mobility_operation_msg.start_longitude = pt.get<double>("location.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
+            _latest_mobility_operation_msg.start_latitude = pt.get<double>("location.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
+            ROS_DEBUG_STREAM("start long: " << *_latest_mobility_operation_msg.start_longitude);
+            ROS_DEBUG_STREAM("start lat: " << *_latest_mobility_operation_msg.start_latitude);
+        }
+        else {
+            _latest_mobility_operation_msg.start_longitude = boost::optional<double>();
+            _latest_mobility_operation_msg.start_latitude = boost::optional<double>();
+        }
+
+        // Parse destination longitude/latitude fields if they exist:
+        if((pt.count("destination.longitude") != 0) && (pt.count("destination.latitude") != 0)) {
+            _latest_mobility_operation_msg.dest_longitude = pt.get<double>("destination.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
+            _latest_mobility_operation_msg.dest_latitude = pt.get<double>("destination.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
+            ROS_DEBUG_STREAM("dest long: " << *_latest_mobility_operation_msg.dest_longitude);
+            ROS_DEBUG_STREAM("dest lat: " << *_latest_mobility_operation_msg.dest_latitude);
+        }
+        else {
+            _latest_mobility_operation_msg.dest_longitude = boost::optional<double>();
+            _latest_mobility_operation_msg.dest_latitude = boost::optional<double>();
+        }
+
+        ROS_DEBUG_STREAM("cargo id: " << _latest_mobility_operation_msg.cargo_id);
+        ROS_DEBUG_STREAM("operation: " << _latest_mobility_operation_msg.operation);
+        ROS_DEBUG_STREAM("cargo flag: " << _latest_mobility_operation_msg.has_cargo);
+        ROS_DEBUG_STREAM("current action id: " << _latest_mobility_operation_msg.current_action_id);
+        ROS_DEBUG_STREAM("next action id: " << _latest_mobility_operation_msg.next_action_id);
     }
 
 } // namespace port_drayage_plugin

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -130,10 +130,10 @@ namespace port_drayage_plugin
         _received_cargo_id = pt.get<std::string>("cargo_id");
         _received_operation = pt.get<std::string>("operation");
         _received_cargo_flag = pt.get<bool>("cargo");
-        _received_start_long = pt.get<double>("location.longitude");
-        _received_start_lat = pt.get<double>("location.latitude");
-        _received_dest_long = pt.get<double>("destination.longitude");
-        _received_dest_lat = pt.get<double>("destination.latitude");
+        _received_start_long = pt.get<double>("location.longitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
+        _received_start_lat = pt.get<double>("location.latitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
+        _received_dest_long = pt.get<double>("destination.longitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
+        _received_dest_lat = pt.get<double>("destination.latitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
         _received_curr_action_id = pt.get<std::string>("action_id");
         _received_next_action_id = pt.get<std::string>("next_action");
 

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -103,7 +103,7 @@ namespace port_drayage_plugin
             boost::property_tree::json_parser::read_json(strategy_params_ss, pt);
             std::string received_cmv_id = pt.get<std::string>("cmv_id");
 
-            // Check if the received MobilityOperation message is intended for this specific vehicle   
+            // Check if the received MobilityOperation message is intended for this vehicle's cmv_id   
             if(received_cmv_id == _cmv_id)
             {
                 ROS_DEBUG_STREAM("Processing new port drayage MobilityOperation message for cmv_id " << received_cmv_id);
@@ -130,10 +130,10 @@ namespace port_drayage_plugin
         _received_cargo_id = pt.get<std::string>("cargo_id");
         _received_operation = pt.get<std::string>("operation");
         _received_cargo_flag = pt.get<bool>("cargo");
-        _received_start_long = pt.get<double>("location.longitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
-        _received_start_lat = pt.get<double>("location.latitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
-        _received_dest_long = pt.get<double>("destination.longitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
-        _received_dest_lat = pt.get<double>("destination.latitude") * 0.0000001; // Convert 1/10 microdegrees to degrees
+        _received_start_long = pt.get<double>("location.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
+        _received_start_lat = pt.get<double>("location.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
+        _received_dest_long = pt.get<double>("destination.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
+        _received_dest_lat = pt.get<double>("destination.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
         _received_curr_action_id = pt.get<std::string>("action_id");
         _received_next_action_id = pt.get<std::string>("next_action");
 
@@ -146,21 +146,6 @@ namespace port_drayage_plugin
         ROS_DEBUG_STREAM("dest lat: " << _received_dest_lat);
         ROS_DEBUG_STREAM("current action id: " << _received_curr_action_id);
         ROS_DEBUG_STREAM("next action id: " << _received_next_action_id);
-    }
-
-    double PortDrayageWorker::get_received_destination_long()
-    {
-        return _received_dest_long;
-    }
-
-    double PortDrayageWorker::get_received_destination_lat()
-    {
-        return _received_dest_lat;
-    }
-
-    std::string PortDrayageWorker::get_received_cargo_id()
-    {
-        return _received_cargo_id;
     }
 
 } // namespace port_drayage_plugin

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -110,9 +110,11 @@ namespace port_drayage_plugin
                 // Process event based on the PortDrayageEvent associated with the received MobilityOperation message
                 switch(_latest_mobility_operation_msg.port_drayage_event_type) {
                     case PortDrayageEvent::RECEIVED_NEW_DESTINATION:
+                        ROS_DEBUG_STREAM("Processing RECEIVED_NEW_DESTINATION event for operation type " << _latest_mobility_operation_msg.operation);
                         _pdsm.process_event(PortDrayageEvent::RECEIVED_NEW_DESTINATION);
                         break;
                     default:
+                        ROS_DEBUG_STREAM("Not processing an event for operation type " << _latest_mobility_operation_msg.operation);
                         break;
                 }
             }
@@ -139,8 +141,8 @@ namespace port_drayage_plugin
             _latest_mobility_operation_msg.port_drayage_event_type = PortDrayageEvent::RECEIVED_NEW_DESTINATION;
         }
 
-        // Parse starting longitude/latitude fields if they exist:
-        if((pt.count("location.longitude") != 0) && (pt.count("location.latitude") != 0)) {
+        // Parse starting longitude/latitude fields if 'location' field exists in strategy_params:
+        if (pt.count("location") != 0){
             _latest_mobility_operation_msg.start_longitude = pt.get<double>("location.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
             _latest_mobility_operation_msg.start_latitude = pt.get<double>("location.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
             ROS_DEBUG_STREAM("start long: " << *_latest_mobility_operation_msg.start_longitude);
@@ -151,8 +153,8 @@ namespace port_drayage_plugin
             _latest_mobility_operation_msg.start_latitude = boost::optional<double>();
         }
 
-        // Parse destination longitude/latitude fields if they exist:
-        if((pt.count("destination.longitude") != 0) && (pt.count("destination.latitude") != 0)) {
+        // Parse destination longitude/latitude fields if 'destination' field exists in strategy_params:
+        if(pt.count("destination") != 0) {
             _latest_mobility_operation_msg.dest_longitude = pt.get<double>("destination.longitude") / 10000000; // Convert 1/10 microdegrees to degrees
             _latest_mobility_operation_msg.dest_latitude = pt.get<double>("destination.latitude") / 10000000; // Convert 1/10 microdegrees to degrees
             ROS_DEBUG_STREAM("dest long: " << *_latest_mobility_operation_msg.dest_longitude);

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 LEIDOS.
+ * Copyright (C) 2019-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -341,24 +341,24 @@ TEST(PortDrayageTest, testInboundMobilityOperation)
     // Note: The strategy_params using the schema for messages of this type that have strategy "carma/port_drayage"
     cav_msgs::MobilityOperation mobility_operation_msg;
     mobility_operation_msg.strategy = "carma/port_drayage";
-    mobility_operation_msg.strategy_params = "{ \"cmv_id\": 123, \"cargo_id\": 321, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": 1.2, \"latitude\": 2.2 }, \"destination\": { \"longitude\": 3.2, \"latitude\": 4.2 }, \"action_id\": 32, \"next_action\": 33 }";
+    mobility_operation_msg.strategy_params = "{ \"cmv_id\": 123, \"cargo_id\": 321, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": -77150342, \"latitude\": 389554370 }, \"destination\": { \"longitude\": -771481980, \"latitude\": 389550030 }, \"action_id\": 32, \"next_action\": 33 }";
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr(new cav_msgs::MobilityOperation(mobility_operation_msg));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr);
 
-    ASSERT_EQ(3.2, pdw.get_received_destination_long());
-    ASSERT_EQ(4.2, pdw.get_received_destination_lat());
+    ASSERT_EQ(-77.1481980, pdw.get_received_destination_long());
+    ASSERT_EQ(38.9550030, pdw.get_received_destination_lat());
     ASSERT_EQ("321", pdw.get_received_cargo_id());
 
     // Create a MobilityOperationConstPtr with a cmv_id that is not intended for this specific vehicle
     // Note: The strategy_params using the schema for messages of this type that have strategy "carma/port_drayage"
     cav_msgs::MobilityOperation mobility_operation_msg2;
     mobility_operation_msg2.strategy = "carma/port_drayage";
-    mobility_operation_msg2.strategy_params = "{ \"cmv_id\": 444, \"cargo_id\": 567, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": 8.2, \"latitude\": 9.2 }, \"destination\": { \"longitude\": 10.2, \"latitude\": 11.2 }, \"action_id\": 44, \"next_action\": 45 }";
+    mobility_operation_msg2.strategy_params = "{ \"cmv_id\": 444, \"cargo_id\": 567, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": -88150342, \"latitude\": 429554370 }, \"destination\": { \"longitude\": -771481980, \"latitude\": 389550030 }, \"action_id\": 44, \"next_action\": 45 }";
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr2(new cav_msgs::MobilityOperation(mobility_operation_msg2));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr2);
 
-    ASSERT_EQ(3.2, pdw.get_received_destination_long());
-    ASSERT_EQ(4.2, pdw.get_received_destination_lat());
+    ASSERT_EQ(-77.1481980, pdw.get_received_destination_long());
+    ASSERT_EQ(38.9550030, pdw.get_received_destination_lat());
     ASSERT_EQ("321", pdw.get_received_cargo_id());
 }
 

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -348,15 +348,16 @@ TEST(PortDrayageTest, testInboundMobilityOperation)
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr(new cav_msgs::MobilityOperation(mobility_operation_msg));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr);
 
-    ASSERT_EQ("321", pdw._received_cargo_id);
-    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._received_operation);
-    ASSERT_EQ(false, pdw._received_cargo_flag);
-    ASSERT_EQ(-77.1503421, pdw._received_start_long);
-    ASSERT_EQ(38.9554377, pdw._received_start_lat);
-    ASSERT_EQ(-77.1481983, pdw._received_dest_long);
-    ASSERT_EQ(38.9550038, pdw._received_dest_lat);
-    ASSERT_EQ("32", pdw._received_curr_action_id);
-    ASSERT_EQ("33", pdw._received_next_action_id);
+    ASSERT_EQ("321", pdw._latest_mobility_operation_msg.cargo_id);
+    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._latest_mobility_operation_msg.operation);
+    ASSERT_EQ(port_drayage_plugin::PortDrayageEvent::RECEIVED_NEW_DESTINATION, pdw._latest_mobility_operation_msg.port_drayage_event_type);
+    ASSERT_EQ(false, pdw._latest_mobility_operation_msg.has_cargo);
+    ASSERT_EQ(-77.1503421, *pdw._latest_mobility_operation_msg.start_longitude);
+    ASSERT_EQ(38.9554377, *pdw._latest_mobility_operation_msg.start_latitude);
+    ASSERT_EQ(-77.1481983, *pdw._latest_mobility_operation_msg.dest_longitude);
+    ASSERT_EQ(38.9550038, *pdw._latest_mobility_operation_msg.dest_latitude);
+    ASSERT_EQ("32", pdw._latest_mobility_operation_msg.current_action_id);
+    ASSERT_EQ("33", pdw._latest_mobility_operation_msg.next_action_id);
 
     // Create a MobilityOperationConstPtr with a cmv_id that is not intended for this specific vehicle
     // Note: The strategy_params using the schema for messages of this type that have strategy "carma/port_drayage"
@@ -369,15 +370,16 @@ TEST(PortDrayageTest, testInboundMobilityOperation)
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr2(new cav_msgs::MobilityOperation(mobility_operation_msg2));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr2);
 
-    ASSERT_EQ("321", pdw._received_cargo_id);
-    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._received_operation);
-    ASSERT_EQ(false, pdw._received_cargo_flag);
-    ASSERT_EQ(-77.1503421, pdw._received_start_long);
-    ASSERT_EQ(38.9554377, pdw._received_start_lat);
-    ASSERT_EQ(-77.1481983, pdw._received_dest_long);
-    ASSERT_EQ(38.9550038, pdw._received_dest_lat);
-    ASSERT_EQ("32", pdw._received_curr_action_id);
-    ASSERT_EQ("33", pdw._received_next_action_id);
+    ASSERT_EQ("321", pdw._latest_mobility_operation_msg.cargo_id);
+    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._latest_mobility_operation_msg.operation);
+    ASSERT_EQ(port_drayage_plugin::PortDrayageEvent::RECEIVED_NEW_DESTINATION, pdw._latest_mobility_operation_msg.port_drayage_event_type);
+    ASSERT_EQ(false, pdw._latest_mobility_operation_msg.has_cargo);
+    ASSERT_EQ(-77.1503421, *pdw._latest_mobility_operation_msg.start_longitude);
+    ASSERT_EQ(38.9554377, *pdw._latest_mobility_operation_msg.start_latitude);
+    ASSERT_EQ(-77.1481983, *pdw._latest_mobility_operation_msg.dest_longitude);
+    ASSERT_EQ(38.9550038, *pdw._latest_mobility_operation_msg.dest_latitude);
+    ASSERT_EQ("32", pdw._latest_mobility_operation_msg.current_action_id);
+    ASSERT_EQ("33", pdw._latest_mobility_operation_msg.next_action_id);
 }
 
 // Run all the tests

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -341,25 +341,43 @@ TEST(PortDrayageTest, testInboundMobilityOperation)
     // Note: The strategy_params using the schema for messages of this type that have strategy "carma/port_drayage"
     cav_msgs::MobilityOperation mobility_operation_msg;
     mobility_operation_msg.strategy = "carma/port_drayage";
-    mobility_operation_msg.strategy_params = "{ \"cmv_id\": 123, \"cargo_id\": 321, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": -77150342, \"latitude\": 389554370 }, \"destination\": { \"longitude\": -771481980, \"latitude\": 389550030 }, \"action_id\": 32, \"next_action\": 33 }";
+    mobility_operation_msg.strategy_params = "{ \"cmv_id\": \"123\", \"cargo_id\": \"321\", \"cargo\": \"false\", \"location\"\
+        : { \"latitude\": \"389554377\", \"longitude\": \"-771503421\" }, \"destination\": { \"latitude\"\
+        : \"389550038\", \"longitude\": \"-771481983\" }, \"operation\": \"MOVING_TO_LOADING_AREA\", \"action_id\"\
+        : \"32\", \"next_action\": \"33\" }";
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr(new cav_msgs::MobilityOperation(mobility_operation_msg));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr);
 
-    ASSERT_EQ(-77.1481980, pdw.get_received_destination_long());
-    ASSERT_EQ(38.9550030, pdw.get_received_destination_lat());
-    ASSERT_EQ("321", pdw.get_received_cargo_id());
+    ASSERT_EQ("321", pdw._received_cargo_id);
+    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._received_operation);
+    ASSERT_EQ(false, pdw._received_cargo_flag);
+    ASSERT_EQ(-77.1503421, pdw._received_start_long);
+    ASSERT_EQ(38.9554377, pdw._received_start_lat);
+    ASSERT_EQ(-77.1481983, pdw._received_dest_long);
+    ASSERT_EQ(38.9550038, pdw._received_dest_lat);
+    ASSERT_EQ("32", pdw._received_curr_action_id);
+    ASSERT_EQ("33", pdw._received_next_action_id);
 
     // Create a MobilityOperationConstPtr with a cmv_id that is not intended for this specific vehicle
     // Note: The strategy_params using the schema for messages of this type that have strategy "carma/port_drayage"
     cav_msgs::MobilityOperation mobility_operation_msg2;
     mobility_operation_msg2.strategy = "carma/port_drayage";
-    mobility_operation_msg2.strategy_params = "{ \"cmv_id\": 444, \"cargo_id\": 567, \"operation\": \"MOVING_TO_LOADING_AREA\", \"cargo\": \"false\", \"location\": { \"longitude\": -88150342, \"latitude\": 429554370 }, \"destination\": { \"longitude\": -771481980, \"latitude\": 389550030 }, \"action_id\": 44, \"next_action\": 45 }";
+    mobility_operation_msg2.strategy_params = "{ \"cmv_id\": \"444\", \"cargo_id\": \"567\", \"cargo\": \"true\", \"location\"\
+        : { \"latitude\": \"489554377\", \"longitude\": \"-671503421\" }, \"destination\": { \"latitude\"\
+        : \"489550038\", \"longitude\": \"-571481983\" }, \"operation\": \"MOVING_FROM_LOADING_AREA\", \"action_id\"\
+        : \"44\", \"next_action\": \"45\" }";
     cav_msgs::MobilityOperationConstPtr mobility_operation_msg_ptr2(new cav_msgs::MobilityOperation(mobility_operation_msg2));
     pdw.on_inbound_mobility_operation(mobility_operation_msg_ptr2);
 
-    ASSERT_EQ(-77.1481980, pdw.get_received_destination_long());
-    ASSERT_EQ(38.9550030, pdw.get_received_destination_lat());
-    ASSERT_EQ("321", pdw.get_received_cargo_id());
+    ASSERT_EQ("321", pdw._received_cargo_id);
+    ASSERT_EQ("MOVING_TO_LOADING_AREA", pdw._received_operation);
+    ASSERT_EQ(false, pdw._received_cargo_flag);
+    ASSERT_EQ(-77.1503421, pdw._received_start_long);
+    ASSERT_EQ(38.9554377, pdw._received_start_lat);
+    ASSERT_EQ(-77.1481983, pdw._received_dest_long);
+    ASSERT_EQ(38.9550038, pdw._received_dest_lat);
+    ASSERT_EQ("32", pdw._received_curr_action_id);
+    ASSERT_EQ("33", pdw._received_next_action_id);
 }
 
 // Run all the tests


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds logic to port_drayage_plugin to enable it to process incoming MobilityOperation messages with strategy "carma/port_drayage". When a new MobilityOperation message of this type is received by a carma vehicle, PortDrayageWorker will check that the cmv_id within the message matches the ego vehicle's cmv_id. If the cmv_id values match, the contents of the MobilityOperation message's strategy_params field are stored in PortDrayageWorker.

This PR also applies fixes to enable the port_drayage_plugin node to launch properly and fixes some topic remapping issues.

Related PR in carma-messenger repository: [Replace encoded quotation marks in received MobilityOperation message's strategy_params field](https://github.com/usdot-fhwa-stol/carma-messenger/pull/91)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This step (receiving and storing MobilityOperation messages related to port drayage) is required in the process flow associated with the Port Drayage scenarios.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tested and integration with White Pacifica and V2XHub.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
