### PR TITLE
lane_change

### DIFF
--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -24,6 +24,7 @@
 #include <carma_wm/WMListener.h>
 #include <carma_wm/WorldModel.h>
 #include <cav_srvs/PlanManeuvers.h>
+#include <cav_msgs/UpcomingLaneChangeStatus.h>
 
 /**
  * \brief Macro definition to enable easier access to fields shared across the maneuver typees
@@ -148,6 +149,12 @@ namespace route_following_plugin
 
         // config limit for vehicle speed limit set as ros parameter
         double config_limit=0.0;
+        /**
+         * \brief Given lane change status
+         * \param 
+         * \return 
+         */
+        cav_msgs::UpcomingLaneChangeStatus ComposeLaneChangeStatus(double lane_change_start_dist,lanelet::ConstLanelet starting_lanelet,lanelet::ConstLanelet ending_lanelet,double current_downtrack);
 
     private:
 
@@ -158,6 +165,7 @@ namespace route_following_plugin
 
         // ROS publishers and subscribers
         ros::Publisher plugin_discovery_pub_;
+        ros::Publisher upcoming_lane_change_status_pub_;
         ros::Subscriber pose_sub_;
         ros::Subscriber twist_sub_;
         ros::Timer discovery_pub_timer_;
@@ -182,6 +190,9 @@ namespace route_following_plugin
 
         // Plugin discovery message
         cav_msgs::Plugin plugin_discovery_msg_;
+
+        //Upcoming Lane Change message
+        cav_msgs::UpcomingLaneChangeStatus upcoming_lane_change_status_msg_;
 
         /**
          * \brief Initialize ROS publishers, subscribers, service servers and service clients

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -35,6 +35,7 @@ namespace route_following_plugin
         plan_maneuver_srv_ = nh_->advertiseService("plugins/RouteFollowing/plan_maneuvers", &RouteFollowingPlugin::plan_maneuver_cb, this);
                 
         plugin_discovery_pub_ = nh_->advertise<cav_msgs::Plugin>("plugin_discovery", 1);
+        upcoming_lane_change_status_pub_ = nh_->advertise<cav_msgs::UpcomingLaneChangeStatus>("upcoming_lane_change_status", 1);
         plugin_discovery_msg_.name = "RouteFollowing";
         plugin_discovery_msg_.versionId = "v1.0";
         plugin_discovery_msg_.available = true;
@@ -94,6 +95,7 @@ namespace route_following_plugin
             return true;
         }
         double current_progress = wm_->routeTrackPos(current_loc).downtrack;
+        double current_downtrack=current_progress;
         double speed_progress = current_speed_;
         ros::Time time_progress = ros::Time::now();
         double target_speed=findSpeedLimit(current_lanelet);   //get Speed Limit
@@ -169,6 +171,9 @@ namespace route_following_plugin
                 composeLaneChangeManeuverMessage(lane_change_start_dist, end_dist, speed_progress, target_speed, 
                                     starting_lanelet_id, ending_lanelet_id,
                                     time_progress));
+
+               upcoming_lane_change_status_msg_=ComposeLaneChangeStatus(lane_change_start_dist,shortest_path[last_lanelet_index],shortest_path[last_lanelet_index+1],current_downtrack);   
+               
                 
                 ++last_lanelet_index;
             }
@@ -216,9 +221,46 @@ namespace route_following_plugin
         }
         return true;
     }
+
+    cav_msgs::UpcomingLaneChangeStatus RouteFollowingPlugin::ComposeLaneChangeStatus(double lane_change_start_dist,lanelet::ConstLanelet starting_lanelet,lanelet::ConstLanelet ending_lanelet,double current_downtrack)
+    {
+
+        if (current_downtrack <= upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
+        { 
+               return upcoming_lane_change_status_msg_;
+        }
+
+        cav_msgs::UpcomingLaneChangeStatus upcoming_lanechange_status_msg;
+        // default to right lane change
+        upcoming_lanechange_status_msg.lane_change = cav_msgs::UpcomingLaneChangeStatus::RIGHT; 
+        // change to left if detected
+        for (auto &relation : wm_->getRoute()->leftRelations(starting_lanelet))
+        {
+            if (relation.lanelet.id() == ending_lanelet.id())
+            {
+                upcoming_lanechange_status_msg.lane_change = cav_msgs::UpcomingLaneChangeStatus::LEFT;
+                break;
+            }  
+        }
+   
+       upcoming_lanechange_status_msg.last_recorded_lanechange_downtrack=lane_change_start_dist;
+
+       return upcoming_lanechange_status_msg;
+    }
+     
     void RouteFollowingPlugin::pose_cb(const geometry_msgs::PoseStampedConstPtr& msg)
     {
         pose_msg_ = geometry_msgs::PoseStamped(*msg.get());
+        if (!wm_->getRoute())
+        return;
+        lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
+        double current_progress = wm_->routeTrackPos(current_loc).downtrack;
+        if (upcoming_lane_change_msg_.lane_change != cav_msgs::UpcomingLaneChangeStatus::NONE && current_progress < upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
+        {
+            upcoming_lane_change_status_msg_.downtrack_until_lanechange=upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack-current_progress;
+            upcoming_lane_change_status_pub_.publish(upcoming_lane_change_status_msg_); 
+        }
+      
     }
     void RouteFollowingPlugin::twist_cd(const geometry_msgs::TwistStampedConstPtr& msg)
     {

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -255,7 +255,7 @@ namespace route_following_plugin
         return;
         lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
         double current_progress = wm_->routeTrackPos(current_loc).downtrack;
-        if (upcoming_lane_change_msg_.lane_change != cav_msgs::UpcomingLaneChangeStatus::NONE && current_progress < upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
+        if (upcoming_lane_change_status_msg_.lane_change != cav_msgs::UpcomingLaneChangeStatus::NONE && current_progress < upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
         {
             upcoming_lane_change_status_msg_.downtrack_until_lanechange=upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack-current_progress;
             upcoming_lane_change_status_pub_.publish(upcoming_lane_change_status_msg_); 

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -171,7 +171,7 @@ namespace route_following_plugin
                 composeLaneChangeManeuverMessage(lane_change_start_dist, end_dist, speed_progress, target_speed, 
                                     starting_lanelet_id, ending_lanelet_id,
                                     time_progress));
-
+                ROS_DEBUG_STREAM("before composing lane change status msg");
                upcoming_lane_change_status_msg_=ComposeLaneChangeStatus(lane_change_start_dist,shortest_path[last_lanelet_index],shortest_path[last_lanelet_index+1],current_downtrack);   
                
                 
@@ -227,6 +227,7 @@ namespace route_following_plugin
 
         if (current_downtrack <= upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
         { 
+            ROS_DEBUG_STREAM("ComposeLaneChangeStatus First IF: current_downtrack " << current_downtrack << ",upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack " << upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack);
                return upcoming_lane_change_status_msg_;
         }
 
@@ -236,15 +237,17 @@ namespace route_following_plugin
         // change to left if detected
         for (auto &relation : wm_->getRoute()->leftRelations(starting_lanelet))
         {
+            ROS_DEBUG_STREAM("Checking relation.lanelet.id()" < <relation.lanelet.id());
             if (relation.lanelet.id() == ending_lanelet.id())
             {
+                ROS_DEBUG_STREAM("relation.lanelet.id()" << relation.lanelet.id() << " is LEFT");
                 upcoming_lanechange_status_msg.lane_change = cav_msgs::UpcomingLaneChangeStatus::LEFT;
                 break;
             }  
         }
-   
+        ROS_DEBUG_STREAM("lane_change_start_dist <<" << lane_change_start_dist);
        upcoming_lanechange_status_msg.last_recorded_lanechange_downtrack=lane_change_start_dist;
-
+        ROS_DEBUG_STREAM("==== ComposeLaneChangeStatus Exiting now");
        return upcoming_lanechange_status_msg;
     }
      
@@ -255,9 +258,14 @@ namespace route_following_plugin
         return;
         lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
         double current_progress = wm_->routeTrackPos(current_loc).downtrack;
+        ROS_ERROR_STREAM("pose_cb : current_progress" << current_progress);
+        ROS_ERROR_STREAM("upcoming_lane_change_status_msg_.lane_change : " << upcoming_lane_change_status_msg_.lane_change << 
+            ", upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack" << upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack);
+        
         if (upcoming_lane_change_status_msg_.lane_change != cav_msgs::UpcomingLaneChangeStatus::NONE && current_progress < upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack)
         {
             upcoming_lane_change_status_msg_.downtrack_until_lanechange=upcoming_lane_change_status_msg_.last_recorded_lanechange_downtrack-current_progress;
+            ROS_ERROR_STREAM("upcoming_lane_change_status_msg_.downtrack_until_lanechange" << upcoming_lane_change_status_msg_.downtrack_until_lanechange);
             upcoming_lane_change_status_pub_.publish(upcoming_lane_change_status_msg_); 
         }
       

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -273,8 +273,52 @@ namespace route_following_plugin
         else ASSERT_EQ(speed,11.176);                                                                            
     }
 
-    
+     TEST(RouteFollowingPlugin,testComposeLaneChangeStatus)
+    {
+        //Use Guidance Lib to create map
+        carma_wm::test::MapOptions options;
+        options.lane_length_=25;
+        options.lane_width_=3.7;
+        options.speed_limit_=carma_wm::test::MapOptions::SpeedLimit::DEFAULT;
+        options.obstacle_=carma_wm::test::MapOptions::Obstacle::NONE;
+        std::shared_ptr<carma_wm::CARMAWorldModel> cmw=std::make_shared<carma_wm::CARMAWorldModel>();
+        //create the Semantic Map
+        lanelet::LaneletMapPtr map=carma_wm::test::buildGuidanceTestMap(options.lane_width_,options.lane_length_);
 
+        //set the map with default routingGraph
+        cmw->carma_wm::CARMAWorldModel::setMap(map);
+        carma_wm::test::setRouteByIds({1210,1213},cmw);
+
+        lanelet::LaneletMapConstPtr const_map(map);
+        lanelet::traffic_rules::TrafficRulesUPtr traffic_rules=lanelet::traffic_rules::TrafficRulesFactory::create(lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
+        lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
+
+        //Compute and print shortest path
+        lanelet::Lanelet start_lanelet=map->laneletLayer.get(1210);
+        lanelet::Lanelet end_lanelet=map->laneletLayer.get(1223);
+        lanelet::Lanelet end_lanelet_1=map->laneletLayer.get(1220);
+        auto route = map_graph->getRoute(start_lanelet, end_lanelet);
+ 
+        cmw.get()->setConfigSpeedLimit(30.0);
+
+        RouteFollowingPlugin worker;
+        cmw->carma_wm::CARMAWorldModel::setMap(map);
+        worker.wm_=cmw;
+       
+        auto lane_change_status_msg=worker.ComposeLaneChangeStatus(10,start_lanelet,end_lanelet_1,10);
+
+        ASSERT_EQ(lane_change_status_msg.lane_change,cav_msgs::UpcomingLaneChangeStatus::RIGHT);
+        ASSERT_EQ(lane_change_status_msg.downtrack_until_lanechange,0);
+        ASSERT_EQ(lane_change_status_msg.last_recorded_lanechange_downtrack,10);
+
+        lane_change_status_msg=worker.ComposeLaneChangeStatus(10,end_lanelet_1,start_lanelet,10);
+
+        ASSERT_EQ(lane_change_status_msg.lane_change,cav_msgs::UpcomingLaneChangeStatus::LEFT);
+        ASSERT_EQ(lane_change_status_msg.downtrack_until_lanechange,0);
+        ASSERT_EQ(lane_change_status_msg.last_recorded_lanechange_downtrack,10);
+  
+    }
+  
 }
 
 // Run all the tests


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
As identified in CAR-2785: Create High Level Design for Basic TravelDONE, UI needs a simple topic to display what is the next lane change direction is (left/right) and how far it is until an upcoming lane change is required. This story is to develop this logic, which should leverage existing plugins to identify when the lane change will actually occur and to make this information available to the UI. It is understood that the lane change location cannot be known sooner than it is planned by the relevant plugin. Should be published as soon as it is known and updated as actual point of lane change approaches or shifts. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
lane change direction is (left/right) and how far it is until an upcoming lane change
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
