### PR TITLE
refactor route following

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -43,8 +43,8 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch release/zephyr
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch release/zephyr
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch release/zephyr
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch release/zephyr
 fi

--- a/route_following_plugin/CMakeLists.txt
+++ b/route_following_plugin/CMakeLists.txt
@@ -91,7 +91,7 @@ install(DIRECTORY launch config
 #############
 ## Testing ##
 #############
-# catkin_add_gmock(${PROJECT_NAME}-test
-# test/test_route_following_plugin.cpp
-#  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
-# target_link_libraries(${PROJECT_NAME}-test route_following_plugin_lib ${catkin_LIBRARIES})
+catkin_add_gmock(${PROJECT_NAME}-test
+test/test_route_following_plugin.cpp
+ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
+target_link_libraries(${PROJECT_NAME}-test route_following_plugin_lib ${catkin_LIBRARIES})

--- a/route_following_plugin/CMakeLists.txt
+++ b/route_following_plugin/CMakeLists.txt
@@ -91,7 +91,7 @@ install(DIRECTORY launch config
 #############
 ## Testing ##
 #############
-catkin_add_gmock(${PROJECT_NAME}-test
-test/test_route_following_plugin.cpp
- WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
-target_link_libraries(${PROJECT_NAME}-test route_following_plugin_lib ${catkin_LIBRARIES})
+# catkin_add_gmock(${PROJECT_NAME}-test
+# test/test_route_following_plugin.cpp
+#  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
+# target_link_libraries(${PROJECT_NAME}-test route_following_plugin_lib ${catkin_LIBRARIES})

--- a/route_following_plugin/config/parameters.yaml
+++ b/route_following_plugin/config/parameters.yaml
@@ -1,5 +1,5 @@
 # The minimum duration of a maneuver plan, in seconds
-minimal_maneuver_duration: 15
+minimal_plan_duration: 15
 
 #Double : The jerk used to bring vehicle to a halt at end of route
 #Unit : m/s3

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -66,7 +66,7 @@ namespace route_following_plugin
          * \param path A list of lanelet with different lanelet IDs
          * \return Index of the target lanelet in the list
          */
-        int findLaneletIndexFromPath(int target_id,const lanelet::routing::LaneletPath& path);
+        int findLaneletIndexFromPath(int target_id,const lanelet::routing::LaneletPath& path) const;
 
         /**
          * \brief Compose a lane keeping maneuver message based on input params
@@ -78,7 +78,7 @@ namespace route_following_plugin
          * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id, ros::Time start_time);
+        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id, ros::Time start_time) const;
 
         /**
          * \brief Compose a lane change maneuver message based on input params
@@ -91,7 +91,7 @@ namespace route_following_plugin
          * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id, ros::Time start_time);
+        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id, ros::Time start_time) const;
         
         /**
          * \brief Given a LaneletRelations and ID of the next lanelet in the shortest path
@@ -106,20 +106,20 @@ namespace route_following_plugin
          * \param maneuver A maneuver (non-specific to type) to be performed
          * \param start_dist the starting distance that the maneuver need to be updated to
          */
-        void setManeuverStartDist(cav_msgs::Maneuver& maneuver, double start_dist);
+        void setManeuverStartDist(cav_msgs::Maneuver& maneuver, double start_dist) const;
 
         /**
          * \brief Given an array of maneuvers update the starting time for each
          * \param maneuvers An array of maneuvers (non-specific to type) 
          * \param start_time The starting time for the first maneuver in the sequence, each consequent maneuver is pushed ahead by same amount
          */
-        void updateTimeProgress(std::vector<cav_msgs::Maneuver>& maneuvers, ros::Time start_time);
+        void updateTimeProgress(std::vector<cav_msgs::Maneuver>& maneuvers, ros::Time start_time) const;
         /**
          * \brief Given an maneuver update the starting speed
          * \param maneuver maneuver to update the starting speed for
          * \param start_time The starting speed for the maneuver passed as argument
          */
-        void updateStartingSpeed(cav_msgs::Maneuver& maneuver, double start_speed);
+        void updateStartingSpeed(cav_msgs::Maneuver& maneuver, double start_speed) const;
         /**
          * \brief Service callback for arbitrator maneuver planning
          * \param req Plan maneuver request

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -99,7 +99,7 @@ namespace route_following_plugin
          * \param target_id ID of the next lanelet in the shortest path
          * \return Whether we need a lanechange to reach to the next lanelet in the shortest path
          */
-        bool identifyLaneChange(lanelet::routing::LaneletRelations relations, int target_id);
+        bool isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, int target_id);
         
         /**
          * \brief Set the start distance of a maneuver based on the progress along the route
@@ -124,9 +124,9 @@ namespace route_following_plugin
         bool plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp);
 
         /**
-         * \brief Given a Lanelet, find it's associated Speed Limit from the vector map
+         * \brief Given a Lanelet, find it's associated Speed Limit
          * \param llt Constant Lanelet object
-         * \return value of speed limit as a double, returns default value of 25 mph
+         * \return value of speed limit in mps
          */
         double findSpeedLimit(const lanelet::ConstLanelet& llt);
         /**
@@ -170,7 +170,7 @@ namespace route_following_plugin
 
 
         // Minimal duration of maneuver, loaded from config file
-        double mvr_duration_;
+        double min_mvr_duration_;
 
 
         // Plugin discovery message
@@ -192,7 +192,7 @@ namespace route_following_plugin
          * \brief Callback for the twist subscriber, which will store latest twist locally
          * \param msg Latest twist message
          */
-        void twist_cd(const geometry_msgs::TwistStampedConstPtr& msg);
+        void twist_cb(const geometry_msgs::TwistStampedConstPtr& msg);
 
     };
 }

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -97,7 +97,7 @@ namespace route_following_plugin
          * \param target_id ID of the next lanelet in the shortest path
          * \return Whether we need a lanechange to reach to the next lanelet in the shortest path.
          */
-        bool isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, int target_id);
+        bool isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, lanelet::Id target_id) const;
         
         /**
          * \brief Set the start distance of a maneuver based on the progress along the route

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -176,7 +176,7 @@ namespace route_following_plugin
 
 
         // Minimal duration of maneuver, loaded from config file
-        double min_mvr_duration_;
+        double min_plan_duration_;
 
 
         // Plugin discovery message

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -186,6 +186,9 @@ namespace route_following_plugin
         std::string planning_strategic_plugin_ = "RouteFollowingPlugin";
         std::string lanefollow_planning_tactical_plugin_ = "InLaneCruisingPlugin"; 
 
+        //Small constant to compare doubles against
+        double epsilon_ = 0.0001;
+
         /**
          * \brief Callback for the pose subscriber, which will store latest pose locally
          * \param msg Latest pose message

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -114,7 +114,12 @@ namespace route_following_plugin
          * \param start_time The starting time for the first maneuver in the sequence, each consequent maneuver is pushed ahead by same amount
          */
         void updateTimeProgress(std::vector<cav_msgs::Maneuver>& maneuvers, ros::Time start_time);
-
+        /**
+         * \brief Given an maneuver update the starting speed
+         * \param maneuver maneuver to update the starting speed for
+         * \param start_time The starting speed for the maneuver passed as argument
+         */
+        void updateStartingSpeed(cav_msgs::Maneuver& maneuver, double start_speed);
         /**
          * \brief Service callback for arbitrator maneuver planning
          * \param req Plan maneuver request
@@ -133,7 +138,7 @@ namespace route_following_plugin
          * \brief Calculate maneuver plan for remaining route. This callback is triggered when a new route has been received and processed by the world model
          *
          */
-        std::vector<cav_msgs::Maneuver> route_cb(lanelet::routing::LaneletPath route_shortest_path, lanelet::BasicPoint2d& current_loc);
+        std::vector<cav_msgs::Maneuver> route_cb(lanelet::routing::LaneletPath route_shortest_path);
 
         //Internal Variables used in unit tests
         // Current vehicle forward speed
@@ -141,6 +146,7 @@ namespace route_following_plugin
 
         // Current vehicle pose in map
         geometry_msgs::PoseStamped pose_msg_;
+        lanelet::BasicPoint2d current_loc_;
 
         // wm listener pointer and pointer to the actual wm object
         std::shared_ptr<carma_wm::WMListener> wml_;

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -73,10 +73,9 @@ namespace route_following_plugin
          * \param start_speed Start speed of the current maneuver
          * \param target_speed Target speed pf the current maneuver, usually it is the lanelet speed limit
          * \param lane_id Lanelet ID of the current maneuver
-         * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id, ros::Time start_time) const;
+        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id) const;
 
         /**
          * \brief Compose a lane change maneuver message based on input params
@@ -86,10 +85,9 @@ namespace route_following_plugin
          * \param start_lane_id Starting Lanelet ID of the current maneuver
          * \param ending_lane_id Ending Lanelet ID of the current maneuver
          * \param target_speed Target speed of the current maneuver
-         * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id, ros::Time start_time) const;
+        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id) const;
         
         /**
          * \brief Given a LaneletRelations and ID of the next lanelet in the shortest path
@@ -124,7 +122,7 @@ namespace route_following_plugin
          * \param resp Plan maneuver response with a list of maneuver plan
          * \return If service call successed
          */
-        bool plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp);
+        bool planManeuverCb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp);
 
         /**
          * \brief Given a Lanelet, find it's associated Speed Limit
@@ -136,7 +134,7 @@ namespace route_following_plugin
          * \brief Calculate maneuver plan for remaining route. This callback is triggered when a new route has been received and processed by the world model
          * \param route_shortest_path A list of lanelets along the shortest path of the route using which the maneuver plan is calculated.
          */
-        std::vector<cav_msgs::Maneuver> route_cb(const lanelet::routing::LaneletPath& route_shortest_path);
+        std::vector<cav_msgs::Maneuver> routeCb(const lanelet::routing::LaneletPath& route_shortest_path);
 
         //Internal Variables used in unit tests
         // Current vehicle forward speed
@@ -201,6 +199,12 @@ namespace route_following_plugin
          * \param msg Latest twist message
          */
         void twist_cb(const geometry_msgs::TwistStampedConstPtr& msg);
+
+        /**
+         * \brief returns duration as ros::Duration required to complete maneuver given its start dist, end dist, start speed and end speed
+         * \param maneuver The maneuver message to calculate duration for
+         */
+        ros::Duration maneuverDuration(cav_msgs::Maneuver &maneuver) const;
 
     };
 }

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -24,6 +24,7 @@
 #include <carma_wm/WMListener.h>
 #include <carma_wm/WorldModel.h>
 #include <cav_srvs/PlanManeuvers.h>
+#include <gtest/gtest_prod.h>
 
 /**
  * \brief Macro definition to enable easier access to fields shared across the maneuver types
@@ -136,24 +137,6 @@ namespace route_following_plugin
          */
         std::vector<cav_msgs::Maneuver> routeCb(const lanelet::routing::LaneletPath& route_shortest_path);
 
-        //Internal Variables used in unit tests
-        // Current vehicle forward speed
-        double current_speed_;
-
-        // Current vehicle pose in map
-        geometry_msgs::PoseStampedConstPtr pose_msg_;
-        lanelet::BasicPoint2d current_loc_;
-
-        // wm listener pointer and pointer to the actual wm object
-        std::shared_ptr<carma_wm::WMListener> wml_;
-        carma_wm::WorldModelConstPtr wm_;
-
-        //Queue of maneuver plans
-        std::vector<cav_msgs::Maneuver> latest_maneuver_plan_;
-
-        //Tactical plugin being used for planning lane change
-        std::string lane_change_plugin_ = "CooperativeLaneChangePlugin";
-
         private:
 
         // CARMA ROS node handles
@@ -178,10 +161,29 @@ namespace route_following_plugin
         // Plugin discovery message
         cav_msgs::Plugin plugin_discovery_msg_;
 
+        // Current vehicle forward speed
+        double current_speed_;
+
+        // Current vehicle pose in map
+        geometry_msgs::PoseStampedConstPtr pose_msg_;
+        lanelet::BasicPoint2d current_loc_;
+
+        // wm listener pointer and pointer to the actual wm object
+        std::shared_ptr<carma_wm::WMListener> wml_;
+        carma_wm::WorldModelConstPtr wm_;
+
+        //Queue of maneuver plans
+        std::vector<cav_msgs::Maneuver> latest_maneuver_plan_;
+
+        //Tactical plugin being used for planning lane change
+        std::string lane_change_plugin_ = "CooperativeLaneChangePlugin";
+
         std::string planning_strategic_plugin_ = "RouteFollowingPlugin";
         std::string lanefollow_planning_tactical_plugin_ = "InLaneCruisingPlugin"; 
         //lane change tactical plugin declared as a public member
 
+        //constant small value to compare doubles approaching zero value
+        const double epsilon_ = 0.00001;
 
         /**
          * \brief Initialize ROS publishers, subscribers, service servers and service clients
@@ -205,6 +207,14 @@ namespace route_following_plugin
          * \param maneuver The maneuver message to calculate duration for
          */
         ros::Duration maneuverDuration(cav_msgs::Maneuver &maneuver) const;
+
+        //Unit Tests
+        FRIEND_TEST(RouteFollowingPluginTest, testFindLaneletIndexFromPath);
+        FRIEND_TEST(RouteFollowingPluginTest, testComposeManeuverMessage);
+        FRIEND_TEST(RouteFollowingPluginTest, testIdentifyLaneChange);
+        FRIEND_TEST(RouteFollowingPlugin, TestAssociateSpeedLimit);
+        FRIEND_TEST(RouteFollowingPlugin, TestAssociateSpeedLimitusingosm);
+        FRIEND_TEST(RouteFollowingPlugin, TestHelperfunctions);
 
     };
 }

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -60,6 +60,13 @@ namespace route_following_plugin
         void run();
 
         /**
+         * \brief Initialize ROS publishers, subscribers, service servers and service clients
+         */
+        void initialize();
+
+        private:
+
+        /**
          * \brief Given a LaneletPath object, find index of the lanelet which has target_id as its lanelet ID
          * \param target_id The laenlet ID this function is looking for
          * \param path A list of lanelet with different lanelet IDs
@@ -137,8 +144,6 @@ namespace route_following_plugin
          */
         std::vector<cav_msgs::Maneuver> routeCb(const lanelet::routing::LaneletPath& route_shortest_path);
 
-        private:
-
         // CARMA ROS node handles
         std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
 
@@ -180,15 +185,6 @@ namespace route_following_plugin
 
         std::string planning_strategic_plugin_ = "RouteFollowingPlugin";
         std::string lanefollow_planning_tactical_plugin_ = "InLaneCruisingPlugin"; 
-        //lane change tactical plugin declared as a public member
-
-        //constant small value to compare doubles approaching zero value
-        const double epsilon_ = 0.00001;
-
-        /**
-         * \brief Initialize ROS publishers, subscribers, service servers and service clients
-         */
-        void initialize();
 
         /**
          * \brief Callback for the pose subscriber, which will store latest pose locally
@@ -205,8 +201,10 @@ namespace route_following_plugin
         /**
          * \brief returns duration as ros::Duration required to complete maneuver given its start dist, end dist, start speed and end speed
          * \param maneuver The maneuver message to calculate duration for
+         * \param epsilon The acceptable min start_speed + target_speed in the maneuver message, under which the maneuver is treated as faulty.
+         * Throws exception if sum of start and target speed of maneuver is below limit defined by parameter epsilon
          */
-        ros::Duration maneuverDuration(cav_msgs::Maneuver &maneuver) const;
+        ros::Duration getManeuverDuration(cav_msgs::Maneuver &maneuver, double epsilon) const;
 
         //Unit Tests
         FRIEND_TEST(RouteFollowingPluginTest, testFindLaneletIndexFromPath);

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -47,8 +47,6 @@ namespace route_following_plugin
     {
         public:
 
-        // constant speed limit for test
-
         /**
          * \brief Default constructor for RouteFollowingPlugin class
          */
@@ -136,7 +134,7 @@ namespace route_following_plugin
         double findSpeedLimit(const lanelet::ConstLanelet& llt);
         /**
          * \brief Calculate maneuver plan for remaining route. This callback is triggered when a new route has been received and processed by the world model
-         *
+         * \param route_shortest_path A list of lanelets along the shortest path of the route using which the maneuver plan is calculated.
          */
         std::vector<cav_msgs::Maneuver> route_cb(const lanelet::routing::LaneletPath& route_shortest_path);
 
@@ -145,7 +143,7 @@ namespace route_following_plugin
         double current_speed_;
 
         // Current vehicle pose in map
-        geometry_msgs::PoseStamped pose_msg_;
+        geometry_msgs::PoseStampedConstPtr pose_msg_;
         lanelet::BasicPoint2d current_loc_;
 
         // wm listener pointer and pointer to the actual wm object

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -66,7 +66,7 @@ namespace route_following_plugin
          * \param path A list of lanelet with different lanelet IDs
          * \return Index of the target lanelet in the list
          */
-        int findLaneletIndexFromPath(int target_id, lanelet::routing::LaneletPath& path);
+        int findLaneletIndexFromPath(int target_id,const lanelet::routing::LaneletPath& path);
 
         /**
          * \brief Compose a lane keeping maneuver message based on input params
@@ -78,7 +78,7 @@ namespace route_following_plugin
          * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int lane_id, ros::Time start_time);
+        cav_msgs::Maneuver composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id, ros::Time start_time);
 
         /**
          * \brief Compose a lane change maneuver message based on input params
@@ -91,13 +91,13 @@ namespace route_following_plugin
          * \param start_time Start time of the current maneuver passed as reference
          * \return A lane keeping maneuver message which is ready to be published
          */
-        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int starting_lane_id,int ending_lane_id, ros::Time start_time);
+        cav_msgs::Maneuver composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id, ros::Time start_time);
         
         /**
          * \brief Given a LaneletRelations and ID of the next lanelet in the shortest path
          * \param relations LaneletRelations relative to the previous lanelet
          * \param target_id ID of the next lanelet in the shortest path
-         * \return Whether we need a lanechange to reach to the next lanelet in the shortest path
+         * \return Whether we need a lanechange to reach to the next lanelet in the shortest path.
          */
         bool isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, int target_id);
         
@@ -138,7 +138,7 @@ namespace route_following_plugin
          * \brief Calculate maneuver plan for remaining route. This callback is triggered when a new route has been received and processed by the world model
          *
          */
-        std::vector<cav_msgs::Maneuver> route_cb(lanelet::routing::LaneletPath route_shortest_path);
+        std::vector<cav_msgs::Maneuver> route_cb(const lanelet::routing::LaneletPath& route_shortest_path);
 
         //Internal Variables used in unit tests
         // Current vehicle forward speed
@@ -181,6 +181,10 @@ namespace route_following_plugin
 
         // Plugin discovery message
         cav_msgs::Plugin plugin_discovery_msg_;
+
+        std::string planning_strategic_plugin_ = "RouteFollowingPlugin";
+        std::string lanefollow_planning_tactical_plugin_ = "InLaneCruisingPlugin"; 
+        //lane change tactical plugin declared as a public member
 
 
         /**

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -24,7 +24,7 @@
 
 namespace route_following_plugin
 {
-    RouteFollowingPlugin::RouteFollowingPlugin() : current_speed_(0.0) , min_plan_duration_(16.0) { }
+    RouteFollowingPlugin::RouteFollowingPlugin() : current_speed_(0.0), min_plan_duration_(16.0) {}
 
     void RouteFollowingPlugin::initialize()
     {
@@ -32,8 +32,8 @@ namespace route_following_plugin
         pnh_.reset(new ros::CARMANodeHandle("~"));
         pnh2_.reset(new ros::CARMANodeHandle("/"));
 
-        plan_maneuver_srv_ = nh_->advertiseService("plugins/RouteFollowing/plan_maneuvers", &RouteFollowingPlugin::plan_maneuver_cb, this);
-                
+        plan_maneuver_srv_ = nh_->advertiseService("plugins/RouteFollowing/plan_maneuvers", &RouteFollowingPlugin::planManeuverCb, this);
+
         plugin_discovery_pub_ = nh_->advertise<cav_msgs::Plugin>("plugin_discovery", 1);
         plugin_discovery_msg_.name = "RouteFollowing";
         plugin_discovery_msg_.versionId = "v1.0";
@@ -54,13 +54,13 @@ namespace route_following_plugin
         wm_ = wml_->getWorldModel();
 
         //set a route callback to update route and calculate maneuver
-        wml_->setRouteCallback([this]() { 
-            this->latest_maneuver_plan_ = route_cb(wm_->getRoute()->shortestPath());
+        wml_->setRouteCallback([this]() {
+            this->latest_maneuver_plan_ = routeCb(wm_->getRoute()->shortestPath());
         });
-        
+
         discovery_pub_timer_ = pnh_->createTimer(
             ros::Duration(ros::Rate(10.0)),
-            [this](const auto&) { plugin_discovery_pub_.publish(plugin_discovery_msg_); });
+            [this](const auto &) { plugin_discovery_pub_.publish(plugin_discovery_msg_); });
     }
 
     void RouteFollowingPlugin::run()
@@ -69,29 +69,31 @@ namespace route_following_plugin
         ros::CARMANodeHandle::spin();
     }
 
-    void RouteFollowingPlugin::pose_cb(const geometry_msgs::PoseStampedConstPtr& msg)
+    void RouteFollowingPlugin::pose_cb(const geometry_msgs::PoseStampedConstPtr &msg)
     {
         pose_msg_ = msg;
         lanelet::BasicPoint2d curr_loc(pose_msg_->pose.position.x, pose_msg_->pose.position.y);
         current_loc_ = curr_loc;
     }
-    void RouteFollowingPlugin::twist_cb(const geometry_msgs::TwistStampedConstPtr& msg)
+    void RouteFollowingPlugin::twist_cb(const geometry_msgs::TwistStampedConstPtr &msg)
     {
         current_speed_ = msg->twist.linear.x;
     }
 
-    std::vector<cav_msgs::Maneuver> RouteFollowingPlugin::route_cb(const lanelet::routing::LaneletPath& route_shortest_path){
-        std::vector <cav_msgs::Maneuver> maneuvers;
-        maneuvers.reserve(route_shortest_path.size());
+    std::vector<cav_msgs::Maneuver> RouteFollowingPlugin::routeCb(const lanelet::routing::LaneletPath &route_shortest_path)
+    {
+        std::vector<cav_msgs::Maneuver> maneuvers;
         //This function calculates the maneuver plan every time the route is set
         ROS_DEBUG_STREAM("New route created");
         //Go through entire route - identify lane changes and fill in the spaces with lane following
-        auto nearest_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, current_loc_, 10);   //Return 10 nearest lanelets
-        if(nearest_lanelets.empty())
+        auto nearest_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, current_loc_, 10); //Return 10 nearest lanelets
+        if (nearest_lanelets.empty())
         {
             ROS_WARN_STREAM("Cannot find any lanelet in map!");
-            return maneuvers; 
+            return maneuvers;
         }
+
+        maneuvers.reserve(route_shortest_path.size());
 
         double route_length = wm_->getRouteEndTrackPos().downtrack;
         double start_dist = 0.0;
@@ -100,74 +102,80 @@ namespace route_following_plugin
 
         size_t shortest_path_index;
         //Find lane changes in path - up to the second to last lanelet in path (till lane change is possible)
-        for(shortest_path_index = 0; shortest_path_index < route_shortest_path.size() - 1; ++shortest_path_index){
+        for (shortest_path_index = 0; shortest_path_index < route_shortest_path.size() - 1; ++shortest_path_index)
+        {
             auto following_lanelets = wm_->getRoute()->followingRelations(route_shortest_path[shortest_path_index]);
             double target_speed_in_lanelet = findSpeedLimit(route_shortest_path[shortest_path_index]);
 
             //update start distance and start speed from previous maneuver if it exists
-            start_dist = (maneuvers.empty()) ?  wm_->routeTrackPos(route_shortest_path[shortest_path_index].centerline2d().front()).downtrack :
-                                                        GET_MANEUVER_PROPERTY(maneuvers.back(), end_dist);
+            start_dist = (maneuvers.empty()) ? wm_->routeTrackPos(route_shortest_path[shortest_path_index].centerline2d().front()).downtrack : GET_MANEUVER_PROPERTY(maneuvers.back(), end_dist);
             start_speed = (maneuvers.empty()) ? 0.0 : GET_MANEUVER_PROPERTY(maneuvers.back(), end_speed);
 
-            end_dist = wm_->routeTrackPos(route_shortest_path[shortest_path_index].centerline2d().back()).downtrack; 
+            end_dist = wm_->routeTrackPos(route_shortest_path[shortest_path_index].centerline2d().back()).downtrack;
             end_dist = std::min(end_dist, route_length);
 
-            if(isLaneChangeNeeded(following_lanelets, route_shortest_path[shortest_path_index + 1].id())){
-                maneuvers.push_back(composeLaneChangeManeuverMessage(start_dist, end_dist, start_speed , target_speed_in_lanelet, route_shortest_path[shortest_path_index].id(), route_shortest_path[shortest_path_index+1].id(), ros::Time::now()));
+            if (isLaneChangeNeeded(following_lanelets, route_shortest_path[shortest_path_index + 1].id()))
+            {
+                maneuvers.push_back(composeLaneChangeManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path[shortest_path_index].id(), route_shortest_path[shortest_path_index + 1].id()));
                 ++shortest_path_index; //Since lane change covers 2 lanelets - skip planning for the next lanelet
             }
-            else{
-                maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path[shortest_path_index].id(),ros::Time::now()));
+            else
+            {
+                maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path[shortest_path_index].id()));
             }
-            
         }
-        //TO DO  - Update this block so that Stop and wait is the last maneuver ---- 
+        //TO DO  - Update this block so that Stop and wait is the last maneuver ----
         //add lane follow as last maneuver if there is a lanelet unplanned for in path
-        if(shortest_path_index < route_shortest_path.size() -1){
+        if (shortest_path_index < route_shortest_path.size() - 1)
+        {
             double target_speed_in_lanelet = findSpeedLimit(route_shortest_path.back());
             start_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().front()).downtrack;
-            end_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().back()).downtrack; 
-            maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path.back().id(),ros::Time::now()));
+            end_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().back()).downtrack;
+            maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path.back().id()));
         }
         ////------------------
         ROS_DEBUG_STREAM("Maneuver plan along route successfully generated");
         return maneuvers;
     }
 
-    bool RouteFollowingPlugin::plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp)
-    { 
-        if(latest_maneuver_plan_.empty()){
+    bool RouteFollowingPlugin::planManeuverCb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp)
+    {
+        if (latest_maneuver_plan_.empty())
+        {
             ROS_ERROR_STREAM("A maneuver plan has not been generated");
             return false;
         }
-        
+
         double current_downtrack = wm_->routeTrackPos(current_loc_).downtrack;
-        
+
         //Return the set of maneuvers which intersect with min_plan_duration
-        int i=0;
+        int i = 0;
         double planned_time = 0.0;
-        while(planned_time < min_plan_duration_ && i < latest_maneuver_plan_.size()){
+
+        while (planned_time < min_plan_duration_ && i < latest_maneuver_plan_.size())
+        {
             //Ignore plans for distance already covered
-            if(GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i], end_dist) < current_downtrack){
+            if (GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i], end_dist) < current_downtrack)
+            {
                 ++i;
                 continue;
             }
-            double maneuver_start_time = GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i], start_time).toSec();
-            double maneuver_end_time = GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i],end_time).toSec();
-            planned_time += maneuver_end_time - maneuver_start_time;
-            
+            if(planned_time == 0.0){
+                //update start distance of first maneuver
+                setManeuverStartDist(latest_maneuver_plan_[i], current_downtrack);
+            }
+            planned_time += maneuverDuration(latest_maneuver_plan_[i]).toSec();
+
             resp.new_plan.maneuvers.push_back(latest_maneuver_plan_[i]);
             ++i;
         }
-        
-        if(resp.new_plan.maneuvers.size() == 0)
+
+        if (resp.new_plan.maneuvers.size() == 0)
         {
             ROS_WARN_STREAM("Cannot plan maneuver because no route is found");
         }
         //update plan
 
-        //update start distance of first maneuver and time for all maneuvers
-        setManeuverStartDist(resp.new_plan.maneuvers.front(), current_downtrack);
         //Update time progress for maneuvers
         updateTimeProgress(resp.new_plan.maneuvers, ros::Time::now());
         //update starting speed of first maneuver
@@ -176,117 +184,128 @@ namespace route_following_plugin
         return true;
     }
 
-    void RouteFollowingPlugin::updateTimeProgress(std::vector<cav_msgs::Maneuver>& maneuvers, ros::Time start_time) const {
+    ros::Duration RouteFollowingPlugin::maneuverDuration(cav_msgs::Maneuver &maneuver) const
+    {
+        double maneuver_start_speed = GET_MANEUVER_PROPERTY(maneuver, start_speed);
+        double manever_end_speed = GET_MANEUVER_PROPERTY(maneuver, end_speed);
+        double cur_plus_target = maneuver_start_speed + manever_end_speed;
+        ros::Duration duration;
+        double maneuver_start_dist = GET_MANEUVER_PROPERTY(maneuver, start_dist);
+        double maneuver_end_dist = GET_MANEUVER_PROPERTY(maneuver, end_dist);
+        duration = ros::Duration((maneuver_end_dist - maneuver_start_dist) / (0.5 * cur_plus_target));
+
+        return duration;
+    }
+
+    void RouteFollowingPlugin::updateTimeProgress(std::vector<cav_msgs::Maneuver> &maneuvers, ros::Time start_time) const
+    {
         ros::Time time_progress = start_time;
         ros::Time prev_time = time_progress;
 
-        for(auto& maneuver : maneuvers){
-            double maneuver_start_speed = GET_MANEUVER_PROPERTY(maneuver,start_speed);
-            double manever_end_speed = GET_MANEUVER_PROPERTY(maneuver,end_speed);
-            double cur_plus_target = maneuver_start_speed + manever_end_speed;
-            ros::Duration maneuver_duration;
-            double maneuver_start_dist = GET_MANEUVER_PROPERTY(maneuver,start_dist);
-            double maneuver_end_dist = GET_MANEUVER_PROPERTY(maneuver,end_dist);
-            maneuver_duration = ros::Duration((maneuver_end_dist - maneuver_start_dist) / (0.5 * cur_plus_target));
-
-            time_progress += maneuver_duration;
-            switch(maneuver.type){
-                case cav_msgs::Maneuver::LANE_FOLLOWING :
+        for (auto &maneuver : maneuvers)
+        {
+            time_progress += maneuverDuration(maneuver);
+            switch (maneuver.type)
+            {
+            case cav_msgs::Maneuver::LANE_FOLLOWING:
                 maneuver.lane_following_maneuver.start_time = prev_time;
                 maneuver.lane_following_maneuver.end_time = time_progress;
                 break;
-            case cav_msgs::Maneuver::LANE_CHANGE :
+            case cav_msgs::Maneuver::LANE_CHANGE:
                 maneuver.lane_change_maneuver.start_time = prev_time;
                 maneuver.lane_change_maneuver.end_time = time_progress;
                 break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT :
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT:
                 maneuver.intersection_transit_straight_maneuver.start_time = prev_time;
                 maneuver.intersection_transit_straight_maneuver.end_time = time_progress;
                 break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN :
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN:
                 maneuver.intersection_transit_left_turn_maneuver.start_time = prev_time;
                 maneuver.intersection_transit_left_turn_maneuver.end_time = time_progress;
                 break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN :
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN:
                 maneuver.intersection_transit_right_turn_maneuver.start_time = prev_time;
                 maneuver.intersection_transit_right_turn_maneuver.end_time = time_progress;
                 break;
-            case cav_msgs::Maneuver::STOP_AND_WAIT :
+            case cav_msgs::Maneuver::STOP_AND_WAIT:
                 maneuver.stop_and_wait_maneuver.start_time = prev_time;
                 maneuver.stop_and_wait_maneuver.start_time = time_progress;
                 break;
-            default :
+            default:
                 throw std::invalid_argument("Invalid maneuver type, cannot update time progress for maneuver");
             }
             prev_time = time_progress;
         }
     }
 
-    void RouteFollowingPlugin::updateStartingSpeed(cav_msgs::Maneuver& maneuver, double start_speed) const {
-                switch(maneuver.type){
-                case cav_msgs::Maneuver::LANE_FOLLOWING :
-                maneuver.lane_following_maneuver.start_speed = start_speed;
-                break;
-            case cav_msgs::Maneuver::LANE_CHANGE :
-                maneuver.lane_change_maneuver.start_speed = start_speed;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT :
-                maneuver.intersection_transit_straight_maneuver.start_speed = start_speed;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN :
-                maneuver.intersection_transit_left_turn_maneuver.start_speed = start_speed;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN :
-                maneuver.intersection_transit_right_turn_maneuver.start_speed = start_speed;
-                break;
-            case cav_msgs::Maneuver::STOP_AND_WAIT :
-                maneuver.stop_and_wait_maneuver.start_speed = start_speed;
-                break;
-            default :
-                throw std::invalid_argument("Invalid maneuver type, cannot update starting speed for maneuver");
-            }
-    }
-
-    void RouteFollowingPlugin::setManeuverStartDist(cav_msgs::Maneuver& maneuver, double start_dist) const { 
-        switch(maneuver.type){
-            case cav_msgs::Maneuver::LANE_FOLLOWING :
-                maneuver.lane_following_maneuver.start_dist = start_dist;
-                break;
-            case cav_msgs::Maneuver::LANE_CHANGE :
-                maneuver.lane_change_maneuver.start_dist = start_dist;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT :
-                maneuver.intersection_transit_straight_maneuver.start_dist = start_dist;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN :
-                maneuver.intersection_transit_left_turn_maneuver.start_dist = start_dist;
-                break;
-            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN :
-                maneuver.intersection_transit_right_turn_maneuver.start_dist = start_dist;
-                break;
-            case cav_msgs::Maneuver::STOP_AND_WAIT :
-                maneuver.stop_and_wait_maneuver.start_dist = start_dist;
-                break;
-            default :
-                throw std::invalid_argument("Invalid maneuver type");
-        }
-
-    }
-    
-
-    int RouteFollowingPlugin::findLaneletIndexFromPath(int target_id,const lanelet::routing::LaneletPath& path) const
+    void RouteFollowingPlugin::updateStartingSpeed(cav_msgs::Maneuver &maneuver, double start_speed) const
     {
-        for(size_t i = 0; i < path.size(); ++i)
+        switch (maneuver.type)
         {
-            if(path[i].id() == target_id)
+        case cav_msgs::Maneuver::LANE_FOLLOWING:
+            maneuver.lane_following_maneuver.start_speed = start_speed;
+            break;
+        case cav_msgs::Maneuver::LANE_CHANGE:
+            maneuver.lane_change_maneuver.start_speed = start_speed;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT:
+            maneuver.intersection_transit_straight_maneuver.start_speed = start_speed;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN:
+            maneuver.intersection_transit_left_turn_maneuver.start_speed = start_speed;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN:
+            maneuver.intersection_transit_right_turn_maneuver.start_speed = start_speed;
+            break;
+        case cav_msgs::Maneuver::STOP_AND_WAIT:
+            maneuver.stop_and_wait_maneuver.start_speed = start_speed;
+            break;
+        default:
+            throw std::invalid_argument("Invalid maneuver type, cannot update starting speed for maneuver");
+        }
+    }
+
+    void RouteFollowingPlugin::setManeuverStartDist(cav_msgs::Maneuver &maneuver, double start_dist) const
+    {
+        switch (maneuver.type)
+        {
+        case cav_msgs::Maneuver::LANE_FOLLOWING:
+            maneuver.lane_following_maneuver.start_dist = start_dist;
+            break;
+        case cav_msgs::Maneuver::LANE_CHANGE:
+            maneuver.lane_change_maneuver.start_dist = start_dist;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT:
+            maneuver.intersection_transit_straight_maneuver.start_dist = start_dist;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN:
+            maneuver.intersection_transit_left_turn_maneuver.start_dist = start_dist;
+            break;
+        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN:
+            maneuver.intersection_transit_right_turn_maneuver.start_dist = start_dist;
+            break;
+        case cav_msgs::Maneuver::STOP_AND_WAIT:
+            maneuver.stop_and_wait_maneuver.start_dist = start_dist;
+            break;
+        default:
+            throw std::invalid_argument("Invalid maneuver type");
+        }
+    }
+
+    int RouteFollowingPlugin::findLaneletIndexFromPath(int target_id, const lanelet::routing::LaneletPath &path) const
+    {
+        for (size_t i = 0; i < path.size(); ++i)
+        {
+            if (path[i].id() == target_id)
             {
                 return i;
             }
         }
         return -1;
     }
-    
-    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id, ros::Time start_time) const {
+
+    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id) const
+    {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
         maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
@@ -295,24 +314,18 @@ namespace route_following_plugin
         maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = planning_strategic_plugin_;
         maneuver_msg.lane_following_maneuver.start_dist = start_dist;
         maneuver_msg.lane_following_maneuver.start_speed = start_speed;
-        maneuver_msg.lane_following_maneuver.start_time = start_time;
         maneuver_msg.lane_following_maneuver.end_dist = end_dist;
         maneuver_msg.lane_following_maneuver.end_speed = target_speed;
-        
-        // because it is a rough plan, assume vehicle can always reach to the target speed in a lanelet
-        double cur_plus_target = start_speed + target_speed;
-        if (cur_plus_target < 0.00001) {
-            throw std::invalid_argument("Requested zero speed lane following.");
-        } else {
-            maneuver_msg.lane_following_maneuver.end_time = start_time + ros::Duration((end_dist - start_dist) / (0.5 * cur_plus_target));
-        }
         maneuver_msg.lane_following_maneuver.lane_id = std::to_string(lane_id);
-        ROS_INFO_STREAM("Creating lane follow start dist: "<<start_dist<<" end dist: "<<end_dist);
-        ROS_INFO_STREAM("Duration: "<<maneuver_msg.lane_following_maneuver.end_time.toSec() - maneuver_msg.lane_following_maneuver.start_time.toSec());
+        //Start time and end time for maneuver are assigned in updateTimeProgress
+
+        ROS_INFO_STREAM("Creating lane follow start dist: " << start_dist << " end dist: " << end_dist);
+        
         return maneuver_msg;
     }
 
-    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id,lanelet::Id ending_lane_id, ros::Time start_time) const{
+    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id starting_lane_id, lanelet::Id ending_lane_id) const
+    {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_CHANGE;
         maneuver_msg.lane_change_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
@@ -321,30 +334,23 @@ namespace route_following_plugin
         maneuver_msg.lane_change_maneuver.parameters.planning_strategic_plugin = planning_strategic_plugin_;
         maneuver_msg.lane_change_maneuver.start_dist = start_dist;
         maneuver_msg.lane_change_maneuver.start_speed = start_speed;
-        maneuver_msg.lane_change_maneuver.start_time = start_time;
         maneuver_msg.lane_change_maneuver.end_dist = end_dist;
         maneuver_msg.lane_change_maneuver.end_speed = target_speed;
-        // because it is a rough plan, assume vehicle can always reach to the target speed in a lanelet
-        double cur_plus_target = start_speed + target_speed;
-        if (cur_plus_target < 0.00001) {
-            throw std::invalid_argument("Requested zero speed lane change.");
-        } else {
-            maneuver_msg.lane_change_maneuver.end_time = start_time + ros::Duration((end_dist - start_dist) / (0.5 * cur_plus_target));
-        }
         maneuver_msg.lane_change_maneuver.starting_lane_id = std::to_string(starting_lane_id);
         maneuver_msg.lane_change_maneuver.ending_lane_id = std::to_string(ending_lane_id);
-        
-        ROS_INFO_STREAM("Creating lane change start dist: "<<start_dist<<" end dist: "<<end_dist<<" Starting llt: "<<starting_lane_id<<" Ending llt: "<<ending_lane_id);
-        ROS_INFO_STREAM("Duration: "<<maneuver_msg.lane_change_maneuver.end_time.toSec() - maneuver_msg.lane_change_maneuver.start_time.toSec());
+        //Start time and end time for maneuver are assigned in updateTimeProgress
+
+        ROS_INFO_STREAM("Creating lane change start dist: " << start_dist << " end dist: " << end_dist << " Starting llt: " << starting_lane_id << " Ending llt: " << ending_lane_id);
+
         return maneuver_msg;
     }
 
     bool RouteFollowingPlugin::isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, lanelet::Id target_id) const
     {
         //This method is constrained to the lanelet being checked against being accessible. A non-accessible target lanelet would result in unspecified behavior
-        for(auto& relation : relations)
+        for (auto &relation : relations)
         {
-            if(relation.lanelet.id() == target_id && relation.relationType == lanelet::routing::RelationType::Successor)
+            if (relation.lanelet.id() == target_id && relation.relationType == lanelet::routing::RelationType::Successor)
             {
                 return false;
             }
@@ -352,16 +358,16 @@ namespace route_following_plugin
         return true;
     }
 
-    double RouteFollowingPlugin::findSpeedLimit(const lanelet::ConstLanelet& llt)
+    double RouteFollowingPlugin::findSpeedLimit(const lanelet::ConstLanelet &llt)
     {
-        if(lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules())
+        lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules();
+        if (traffic_rules)
         {
-           return (*traffic_rules)->speedLimit(llt).speedLimit.value();
-        } 
+            return (*traffic_rules)->speedLimit(llt).speedLimit.value();
+        }
         else
         {
             throw std::invalid_argument("Valid traffic rules object could not be built");
         }
-        
     }
 }

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -164,7 +164,7 @@ namespace route_following_plugin
                 //update start distance of first maneuver
                 setManeuverStartDist(latest_maneuver_plan_[i], current_downtrack);
             }
-            planned_time += maneuverDuration(latest_maneuver_plan_[i]).toSec();
+            planned_time += getManeuverDuration(latest_maneuver_plan_[i], 0.0001).toSec();
 
             resp.new_plan.maneuvers.push_back(latest_maneuver_plan_[i]);
             ++i;
@@ -184,12 +184,12 @@ namespace route_following_plugin
         return true;
     }
 
-    ros::Duration RouteFollowingPlugin::maneuverDuration(cav_msgs::Maneuver &maneuver) const
+    ros::Duration RouteFollowingPlugin::getManeuverDuration(cav_msgs::Maneuver &maneuver, double epsilon) const
     {
         double maneuver_start_speed = GET_MANEUVER_PROPERTY(maneuver, start_speed);
         double manever_end_speed = GET_MANEUVER_PROPERTY(maneuver, end_speed);
         double cur_plus_target = maneuver_start_speed + manever_end_speed;
-        if(cur_plus_target < epsilon_){
+        if(cur_plus_target < epsilon){
             throw std::invalid_argument("Maneuver start and ending speed is zero");
         }
         ros::Duration duration;
@@ -207,7 +207,7 @@ namespace route_following_plugin
 
         for (auto &maneuver : maneuvers)
         {
-            time_progress += maneuverDuration(maneuver);
+            time_progress += getManeuverDuration(maneuver, 0.001);
             switch (maneuver.type)
             {
             case cav_msgs::Maneuver::LANE_FOLLOWING:

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -171,7 +171,7 @@ namespace route_following_plugin
                 //update start distance of first maneuver
                 setManeuverStartDist(latest_maneuver_plan_[i], current_downtrack);
             }
-            planned_time += getManeuverDuration(latest_maneuver_plan_[i], 0.0001).toSec();
+            planned_time += getManeuverDuration(latest_maneuver_plan_[i], epsilon_).toSec();
 
             resp.new_plan.maneuvers.push_back(latest_maneuver_plan_[i]);
             ++i;
@@ -180,7 +180,7 @@ namespace route_following_plugin
         if (resp.new_plan.maneuvers.size() == 0)
         {
             ROS_WARN_STREAM("Cannot plan maneuver because no route is found");
-            return true;
+            return false;
         }
         //update plan
 
@@ -215,7 +215,7 @@ namespace route_following_plugin
 
         for (auto &maneuver : maneuvers)
         {
-            time_progress += getManeuverDuration(maneuver, 0.001);
+            time_progress += getManeuverDuration(maneuver, epsilon_);
             switch (maneuver.type)
             {
             case cav_msgs::Maneuver::LANE_FOLLOWING:

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -189,6 +189,9 @@ namespace route_following_plugin
         double maneuver_start_speed = GET_MANEUVER_PROPERTY(maneuver, start_speed);
         double manever_end_speed = GET_MANEUVER_PROPERTY(maneuver, end_speed);
         double cur_plus_target = maneuver_start_speed + manever_end_speed;
+        if(cur_plus_target < epsilon_){
+            throw std::invalid_argument("Maneuver start and ending speed is zero");
+        }
         ros::Duration duration;
         double maneuver_start_dist = GET_MANEUVER_PROPERTY(maneuver, start_dist);
         double maneuver_end_dist = GET_MANEUVER_PROPERTY(maneuver, end_dist);

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -43,15 +43,15 @@ namespace route_following_plugin
         pose_sub_ = nh_->subscribe("current_pose", 1, &RouteFollowingPlugin::pose_cb, this);
         twist_sub_ = nh_->subscribe("current_velocity", 1, &RouteFollowingPlugin::twist_cd, this);
 
+        pnh_->param<double>("minimal_maneuver_duration", mvr_duration_, 16.0);
+        pnh_->param<std::string>("lane_change_plugin", lane_change_plugin_);
+
         wml_.reset(new carma_wm::WMListener());
         // set world model point form wm listener
         wm_ = wml_->getWorldModel();
         //set a route callback to update route and calculate maneuver
-        wml_->setRouteCallback(route_set);
-        if(route_set)    
-        {
-            route_cb();
-        }
+        lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
+        wml_->setRouteCallback([this, &current_loc]() { this->latest_maneuver_plan_ = route_cb(wm_->getRoute()->shortestPath(), current_loc);});
         
         discovery_pub_timer_ = pnh_->createTimer(
         ros::Duration(ros::Rate(10.0)),
@@ -73,92 +73,93 @@ namespace route_following_plugin
         current_speed_ = msg->twist.linear.x;
     }
 
-    void RouteFollowingPlugin::route_cb(){
-        //This function calculates the maneuver every time a route is set
+    std::vector<cav_msgs::Maneuver> RouteFollowingPlugin::route_cb(lanelet::routing::LaneletPath route_shortest_path, lanelet::BasicPoint2d& current_loc){
+        std::vector <cav_msgs::Maneuver> maneuvers;
         //Go through route - identify lane changes and fill in the spaces with lane following
-        lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
-        auto current_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, current_loc, 10); 
-        if(current_lanelets.size() == 0)
+        
+        auto nearest_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, current_loc, 10); 
+        if(nearest_lanelets.size() == 0)
         {
             ROS_WARN_STREAM("Cannot find any lanelet in map!");
         }
 
-        auto shortest_path = wm_->getRoute()->shortestPath();
+        //auto shortest_path = wm_->getRoute()->shortestPath();
 
-        lanelet::ConstLanelet current_lanelet;
-        int last_lanelet_index = -1;
-        for (auto llt : current_lanelets)
+        //Check if current position is on shortest path, if not on shortest path return empty maneuver  
+        int current_lanelet_index = -1;
+        for (auto llt : nearest_lanelets)
         {
             if (boost::geometry::within(current_loc, llt.second.polygon2d()))
             {
-                int potential_index = findLaneletIndexFromPath(llt.second.id(), shortest_path);
+                int potential_index = findLaneletIndexFromPath(llt.second.id(), route_shortest_path);
                 if (potential_index != -1)
                 {
-                    last_lanelet_index = potential_index;
-                    current_lanelet = shortest_path[last_lanelet_index];
+                    current_lanelet_index = potential_index;
                     break;
                 }
             }
         }
-        if(last_lanelet_index == -1)
+        if(current_lanelet_index == -1)
         {
             ROS_ERROR_STREAM("Current position is not on the shortest path! Returning an empty maneuver");
         }
 
-        double route_length = wm_->getRouteEndTrackPos().downtrack;;
-
+        double route_length = wm_->getRouteEndTrackPos().downtrack;
+        double prev_mvr_end_speed = 0.0;
         //Find lane changes in path - up to the second to last lanelet in path (till lane change is possible)
-        for(int i = 0;i < shortest_path.size() - 2; i++){
-            auto following_lanelets = wm_->getRoute()->followingRelations(shortest_path[i]);
-            double target_speed_in_lanelet = findSpeedLimit(shortest_path[i]);
-            double start_dist = wm_->routeTrackPos(shortest_path[i].centerline2d().front()).downtrack;
-            double end_dist = wm_->routeTrackPos(shortest_path[i].centerline2d().back()).downtrack; 
+        for(int i = 0;i < route_shortest_path.size() - 2; i++){
+            auto following_lanelets = wm_->getRoute()->followingRelations(route_shortest_path[i]);
+            double target_speed_in_lanelet = findSpeedLimit(route_shortest_path[i]);
+            double start_dist = wm_->routeTrackPos(route_shortest_path[i].centerline2d().front()).downtrack;
+            double end_dist = wm_->routeTrackPos(route_shortest_path[i].centerline2d().back()).downtrack; 
 
-            if(end_dist > route_length){
-                end_dist = route_length;
-            }
+            end_dist = std::min(end_dist, route_length);
 
-            if(identifyLaneChange(following_lanelets, shortest_path[i].id())){
-                maneuvers.push_back(composeLaneChangeManeuverMessage(start_dist, end_dist, 0.0 , target_speed_in_lanelet, shortest_path[i].id(), shortest_path[i+1].id(), ros::Time::now()));
+            if(identifyLaneChange(following_lanelets, route_shortest_path[i + 1].id())){
+                maneuvers.push_back(composeLaneChangeManeuverMessage(start_dist, end_dist, prev_mvr_end_speed , target_speed_in_lanelet, route_shortest_path[i].id(), route_shortest_path[i+1].id(), ros::Time::now()));
             }
             else{
-                maneuvers.push_back(composeManeuverMessage(start_dist, end_dist, 0.0, target_speed_in_lanelet, shortest_path[i].id(),ros::Time::now()));
+                maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, prev_mvr_end_speed, target_speed_in_lanelet, route_shortest_path[i].id(),ros::Time::now()));
             }
+            prev_mvr_end_speed = target_speed_in_lanelet;
         }
         //add lane follow as last maneuver
-        if(maneuvers.size() < shortest_path.size()){
-            double target_speed_in_lanelet = findSpeedLimit(shortest_path.back());
-            double start_dist = wm_->routeTrackPos(shortest_path.back().centerline2d().front()).downtrack;
-            double end_dist = wm_->routeTrackPos(shortest_path.back().centerline2d().back()).downtrack; 
-            maneuvers.push_back(composeManeuverMessage(start_dist, end_dist, 0.0, target_speed_in_lanelet, shortest_path.back().id(),ros::Time::now()));
+        if(maneuvers.size() < route_shortest_path.size()){
+            double target_speed_in_lanelet = findSpeedLimit(route_shortest_path.back());
+            double start_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().front()).downtrack;
+            double end_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().back()).downtrack; 
+            maneuvers.push_back(composeLaneFollowingManeuverMessage(start_dist, end_dist, prev_mvr_end_speed, target_speed_in_lanelet, route_shortest_path.back().id(),ros::Time::now()));
         }
         
-
+        return maneuvers;
     }
 
     bool RouteFollowingPlugin::plan_maneuver_cb(cav_srvs::PlanManeuversRequest &req, cav_srvs::PlanManeuversResponse &resp)
     { 
+        if(latest_maneuver_plan_.empty()){
+            ROS_ERROR_STREAM("A maneuver plan has not been generated");
+            return true;
+        }
+
         lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
-        double current_progress = wm_->routeTrackPos(current_loc).downtrack;
+        
+        double current_downtrack = wm_->routeTrackPos(current_loc).downtrack;
         double speed_progress = current_speed_;
         
-        //Estimate 15s downtrack distance from end_speed of current maneuver
-        double maneuver_target_speed = get_final_speed(maneuvers.front());
-        double total_maneuver_length = current_progress + maneuver_target_speed * mvr_duration_;
-        double route_length=  wm_->getRouteEndTrackPos().downtrack; 
-        total_maneuver_length = std::min(total_maneuver_length, route_length);
-
         //update start distance of first maneuver and time for all maneuvers
-           set_maneuver_start_dist(maneuvers.front(), current_progress);
-
+        setManeuverStartDist(latest_maneuver_plan_.front(), current_downtrack);
+        //Update time progress for maneuvers
+        updateTimeProgress(latest_maneuver_plan_, ros::Time::now());
         //Return the set of maneuvers which intersect those 15s
         int i=0;
-        while(current_progress < total_maneuver_length && i < maneuvers.size()){
-           double maneuver_end_dist = GET_MANEUVER_PROPERTY(maneuvers[i],end_dist);
-           current_progress += maneuver_end_dist;
-           //Update time progress for maneuvers
-           resp.new_plan.maneuvers.push_back(maneuvers[i]);
-           i++;
+        double planned_time = 0.0;
+        while(planned_time < mvr_duration_ && i < latest_maneuver_plan_.size()){
+            double maneuver_start_time = GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i], start_time).toSec();
+            double maneuver_end_time = GET_MANEUVER_PROPERTY(latest_maneuver_plan_[i],end_time).toSec();
+            planned_time += maneuver_end_time - maneuver_start_time;
+
+            resp.new_plan.maneuvers.push_back(latest_maneuver_plan_[i]);
+            i++;
         }
         
         if(resp.new_plan.maneuvers.size() == 0)
@@ -168,7 +169,41 @@ namespace route_following_plugin
         return true;
     }
 
-    void RouteFollowingPlugin::set_maneuver_start_dist(cav_msgs::Maneuver& maneuver, double start_dist){
+    void RouteFollowingPlugin::updateTimeProgress(std::vector<cav_msgs::Maneuver>& maneuvers, ros::Time start_time){
+        ros::Time time_progress = start_time;
+        ros::Time prev_time = time_progress;
+
+        for(auto maneuver : maneuvers){
+            ros::Duration maneuver_duration =GET_MANEUVER_PROPERTY(maneuver,end_time) - GET_MANEUVER_PROPERTY(maneuver, start_time);
+            time_progress += maneuver_duration;
+            switch(maneuver.type){
+                case cav_msgs::Maneuver::LANE_FOLLOWING :
+                std::cout<<"Time progress in update Time progress:"<<prev_time.toSec() - GET_MANEUVER_PROPERTY(maneuver, start_time).toSec() <<std::endl;
+                maneuver.lane_following_maneuver.start_time = prev_time;
+                maneuver.lane_following_maneuver.end_time = time_progress;
+            case cav_msgs::Maneuver::LANE_CHANGE :
+                maneuver.lane_change_maneuver.start_time = prev_time;
+                maneuver.lane_change_maneuver.end_time = time_progress;
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT :
+                maneuver.intersection_transit_straight_maneuver.start_time = prev_time;
+                maneuver.intersection_transit_straight_maneuver.end_time = time_progress;
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN :
+                maneuver.intersection_transit_left_turn_maneuver.start_time = prev_time;
+                maneuver.intersection_transit_left_turn_maneuver.end_time = time_progress;
+            case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN :
+                maneuver.intersection_transit_right_turn_maneuver.start_time = prev_time;
+                maneuver.intersection_transit_right_turn_maneuver.end_time = time_progress;
+            case cav_msgs::Maneuver::STOP_AND_WAIT :
+                maneuver.stop_and_wait_maneuver.start_time = prev_time;
+                maneuver.stop_and_wait_maneuver.start_time = time_progress;
+            default :
+                ROS_DEBUG_STREAM("Invalid maneuver type, cannot update time progress for maneuver");
+            }
+            prev_time = time_progress;
+        }
+    }
+
+    void RouteFollowingPlugin::setManeuverStartDist(cav_msgs::Maneuver& maneuver, double start_dist){
         switch(maneuver.type){
             case cav_msgs::Maneuver::LANE_FOLLOWING :
                 maneuver.lane_following_maneuver.start_dist = start_dist;
@@ -188,19 +223,6 @@ namespace route_following_plugin
 
     }
     
-    double RouteFollowingPlugin::get_final_speed(cav_msgs::Maneuver maneuver){
-        double speed;
-        if(maneuver.type == cav_msgs::Maneuver::STOP_AND_WAIT){
-            speed =0.0;
-        }
-        else if(maneuver.type == cav_msgs::Maneuver::LANE_FOLLOWING){
-            speed =  maneuver.lane_following_maneuver.end_speed;
-        }
-        else{
-            speed = GET_MANEUVER_PROPERTY(maneuver,end_speed);
-        }
-        return speed;
-    }
 
     int RouteFollowingPlugin::findLaneletIndexFromPath(int target_id, lanelet::routing::LaneletPath& path)
     {
@@ -214,57 +236,55 @@ namespace route_following_plugin
         return -1;
     }
     
-    cav_msgs::Maneuver RouteFollowingPlugin::composeManeuverMessage(double current_dist, double end_dist, double current_speed, double target_speed, int lane_id, ros::Time current_time)
-    {
+    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int lane_id, ros::Time start_time){
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
         maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_following_maneuver.parameters.planning_tactical_plugin = "InLaneCruisingPlugin";
         maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = "RouteFollowingPlugin";
-        maneuver_msg.lane_following_maneuver.start_dist = current_dist;
-        maneuver_msg.lane_following_maneuver.start_speed = current_speed;
-        maneuver_msg.lane_following_maneuver.start_time = current_time;
+        maneuver_msg.lane_following_maneuver.start_dist = start_dist;
+        maneuver_msg.lane_following_maneuver.start_speed = start_speed;
+        maneuver_msg.lane_following_maneuver.start_time = start_time;
         maneuver_msg.lane_following_maneuver.end_dist = end_dist;
         maneuver_msg.lane_following_maneuver.end_speed = target_speed;
         
         // because it is a rough plan, assume vehicle can always reach to the target speed in a lanelet
-        double cur_plus_target = current_speed + target_speed;
+        double cur_plus_target = start_speed + target_speed;
         if (cur_plus_target < 0.00001) {
-            maneuver_msg.lane_following_maneuver.end_time = current_time + ros::Duration(mvr_duration_);
+            maneuver_msg.lane_following_maneuver.end_time = start_time + ros::Duration(mvr_duration_);
         } else {
-            maneuver_msg.lane_following_maneuver.end_time = current_time + ros::Duration((end_dist - current_dist) / (0.5 * cur_plus_target));
+            maneuver_msg.lane_following_maneuver.end_time = start_time + ros::Duration((end_dist - start_dist) / (0.5 * cur_plus_target));
         }
         maneuver_msg.lane_following_maneuver.lane_id = std::to_string(lane_id);
-        current_time = maneuver_msg.lane_following_maneuver.end_time;
-        ROS_INFO_STREAM("Creating lane follow start dist:"<<current_dist<<" end dist:"<<end_dist);
+        ROS_INFO_STREAM("Creating lane follow start dist:"<<start_dist<<" end dist:"<<end_dist);
         ROS_INFO_STREAM("Duration:"<<maneuver_msg.lane_following_maneuver.end_time.toSec() - maneuver_msg.lane_following_maneuver.start_time.toSec());
         return maneuver_msg;
     }
 
-    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneChangeManeuverMessage(double current_dist, double end_dist, double current_speed, double target_speed, int starting_lane_id,int ending_lane_id, ros::Time current_time){
+    cav_msgs::Maneuver RouteFollowingPlugin::composeLaneChangeManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int starting_lane_id,int ending_lane_id, ros::Time start_time){
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_CHANGE;
         maneuver_msg.lane_change_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.lane_change_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_change_maneuver.parameters.planning_tactical_plugin = lane_change_plugin_;
         maneuver_msg.lane_change_maneuver.parameters.planning_strategic_plugin = "RouteFollowingPlugin";
-        maneuver_msg.lane_change_maneuver.start_dist = current_dist;
-        maneuver_msg.lane_change_maneuver.start_speed = current_speed;
-        maneuver_msg.lane_change_maneuver.start_time = current_time;
+        maneuver_msg.lane_change_maneuver.start_dist = start_dist;
+        maneuver_msg.lane_change_maneuver.start_speed = start_speed;
+        maneuver_msg.lane_change_maneuver.start_time = start_time;
         maneuver_msg.lane_change_maneuver.end_dist = end_dist;
         maneuver_msg.lane_change_maneuver.end_speed = target_speed;
         // because it is a rough plan, assume vehicle can always reach to the target speed in a lanelet
-        double cur_plus_target = current_speed + target_speed;
+        double cur_plus_target = start_speed + target_speed;
         if (cur_plus_target < 0.00001) {
-            maneuver_msg.lane_change_maneuver.end_time = current_time + ros::Duration(mvr_duration_);
+            maneuver_msg.lane_change_maneuver.end_time = start_time + ros::Duration(mvr_duration_);
         } else {
-            maneuver_msg.lane_change_maneuver.end_time = current_time + ros::Duration((end_dist - current_dist) / (0.5 * cur_plus_target));
+            maneuver_msg.lane_change_maneuver.end_time = start_time + ros::Duration((end_dist - start_dist) / (0.5 * cur_plus_target));
         }
         maneuver_msg.lane_change_maneuver.starting_lane_id = std::to_string(starting_lane_id);
         maneuver_msg.lane_change_maneuver.ending_lane_id = std::to_string(ending_lane_id);
-        current_time = maneuver_msg.lane_change_maneuver.end_time;
-        ROS_INFO_STREAM("Creating lane change start dist:"<<current_dist<<" end dist:"<<end_dist<<" Starting llt:"<<starting_lane_id<<" Ending llt:"<<ending_lane_id);
+        
+        ROS_INFO_STREAM("Creating lane change start dist:"<<start_dist<<" end dist:"<<end_dist<<" Starting llt:"<<starting_lane_id<<" Ending llt:"<<ending_lane_id);
         ROS_INFO_STREAM("Duration:"<<maneuver_msg.lane_change_maneuver.end_time.toSec() - maneuver_msg.lane_change_maneuver.start_time.toSec());
         return maneuver_msg;
     }
@@ -283,37 +303,15 @@ namespace route_following_plugin
 
     double RouteFollowingPlugin::findSpeedLimit(const lanelet::ConstLanelet& llt)
     {
-        lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules();
-        double target_speed = 0.0, traffic_speed =0.0, param_speed =0.0;
-        double hardcoded_max=lanelet::Velocity(hardcoded_params::control_limits::MAX_LONGITUDINAL_VELOCITY_MPS * lanelet::units::MPS()).value();
-
-        if (traffic_rules)
+        try
         {
-            traffic_speed=(*traffic_rules)->speedLimit(llt).speedLimit.value();
-            
-        }
-        else{
-            ROS_WARN(" Valid traffic rules object could not be built.");
-        }
-
-        if(config_limit > 0.0 && config_limit < hardcoded_max)
+           lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules();
+           return (*traffic_rules)->speedLimit(llt).speedLimit.value();
+        } 
+        catch(const std::exception& e)
         {
-            param_speed = config_limit;
-            ROS_DEBUG("Using Configurable value");
-        }
-        else 
-        {
-            param_speed = hardcoded_max;
-            ROS_DEBUG(" Using Hardcoded maximum");
-        }
-        //If either value is 0, use the other valid limit
-        if(traffic_speed <= epislon_ || param_speed <= epislon_){
-            target_speed = std::max(traffic_speed, param_speed);
-        }
-        else{
-            target_speed = std::min(traffic_speed,param_speed);
+            ROS_WARN_STREAM(" Valid traffic rules object could not be built.");
         }
         
-        return target_speed;
     }
 }

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -94,7 +94,10 @@ namespace route_following_plugin
         }
 
         double route_length = wm_->getRouteEndTrackPos().downtrack;
-        double start_dist, end_dist, start_speed;
+        double start_dist = 0.0;
+        double end_dist = 0.0;
+        double start_speed = 0.0;
+
         size_t shortest_path_index;
         //Find lane changes in path - up to the second to last lanelet in path (till lane change is possible)
         for(shortest_path_index = 0; shortest_path_index < route_shortest_path.size() - 1; ++shortest_path_index){
@@ -336,7 +339,7 @@ namespace route_following_plugin
         return maneuver_msg;
     }
 
-    bool RouteFollowingPlugin::isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, int target_id)
+    bool RouteFollowingPlugin::isLaneChangeNeeded(lanelet::routing::LaneletRelations relations, lanelet::Id target_id) const
     {
         //This method is constrained to the lanelet being checked against being accessible. A non-accessible target lanelet would result in unspecified behavior
         for(auto& relation : relations)
@@ -351,12 +354,11 @@ namespace route_following_plugin
 
     double RouteFollowingPlugin::findSpeedLimit(const lanelet::ConstLanelet& llt)
     {
-        try
+        if(lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules())
         {
-           lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = wm_->getTrafficRules();
            return (*traffic_rules)->speedLimit(llt).speedLimit.value();
         } 
-        catch(const std::exception& e)
+        else
         {
             throw std::invalid_argument("Valid traffic rules object could not be built");
         }

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -133,7 +133,7 @@ namespace route_following_plugin
         }
         //TO DO  - Update this block so that Stop and wait is the last maneuver ----
         //add lane follow as last maneuver if there is a lanelet unplanned for in path
-        if (shortest_path_index < route_shortest_path.size() - 1)
+        if (shortest_path_index < route_shortest_path.size())
         {
             double target_speed_in_lanelet = findSpeedLimit(route_shortest_path.back());
             start_dist = wm_->routeTrackPos(route_shortest_path.back().centerline2d().front()).downtrack;
@@ -180,6 +180,7 @@ namespace route_following_plugin
         if (resp.new_plan.maneuvers.size() == 0)
         {
             ROS_WARN_STREAM("Cannot plan maneuver because no route is found");
+            return true;
         }
         //update plan
 

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -178,9 +178,13 @@ namespace route_following_plugin
         ros::Time prev_time = time_progress;
 
         for(auto& maneuver : maneuvers){
-            double cur_plus_target = GET_MANEUVER_PROPERTY(maneuver,start_speed) + GET_MANEUVER_PROPERTY(maneuver, end_speed);
+            double maneuver_start_speed = GET_MANEUVER_PROPERTY(maneuver,start_speed);
+            double manever_end_speed = GET_MANEUVER_PROPERTY(maneuver,end_speed);
+            double cur_plus_target = maneuver_start_speed + manever_end_speed;
             ros::Duration maneuver_duration;
-            maneuver_duration = ros::Duration((GET_MANEUVER_PROPERTY(maneuver,end_dist) - GET_MANEUVER_PROPERTY(maneuver,start_dist)) / (0.5 * cur_plus_target));
+            double maneuver_start_dist = GET_MANEUVER_PROPERTY(maneuver,start_dist);
+            double maneuver_end_dist = GET_MANEUVER_PROPERTY(maneuver,end_dist);
+            maneuver_duration = ros::Duration((maneuver_end_dist - maneuver_start_dist) / (0.5 * cur_plus_target));
 
             time_progress += maneuver_duration;
             switch(maneuver.type){

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -113,7 +113,14 @@ namespace route_following_plugin
 
             end_dist = wm_->routeTrackPos(route_shortest_path[shortest_path_index].centerline2d().back()).downtrack;
             end_dist = std::min(end_dist, route_length);
-
+            
+            if (std::fabs(start_dist - end_dist) < 0.1) //TODO: edge case that was not recreatable. Sometimes start and end dist was same which crashes inlanecruising
+            {
+                ROS_WARN_STREAM("start and end dist are equal! shortest path id" << shortest_path_index << ", lanelet id:" << route_shortest_path[shortest_path_index].id() <<
+                    ", start and end dist:" << start_dist);
+                continue;
+            }
+            
             if (isLaneChangeNeeded(following_lanelets, route_shortest_path[shortest_path_index + 1].id()))
             {
                 maneuvers.push_back(composeLaneChangeManeuverMessage(start_dist, end_dist, start_speed, target_speed_in_lanelet, route_shortest_path[shortest_path_index].id(), route_shortest_path[shortest_path_index + 1].id()));

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -178,7 +178,6 @@ namespace route_following_plugin
             time_progress += maneuver_duration;
             switch(maneuver.type){
                 case cav_msgs::Maneuver::LANE_FOLLOWING :
-                std::cout<<"Time progress in update Time progress:"<<prev_time.toSec() - GET_MANEUVER_PROPERTY(maneuver, start_time).toSec() <<std::endl;
                 maneuver.lane_following_maneuver.start_time = prev_time;
                 maneuver.lane_following_maneuver.end_time = time_progress;
             case cav_msgs::Maneuver::LANE_CHANGE :

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -300,9 +300,6 @@ namespace route_following_plugin
         double start_time_change = GET_MANEUVER_PROPERTY(maneuvers.front(), start_time).toSec() - start_time.toSec();
         ASSERT_EQ(start_time_change, 10.0);
 
-        std::cout<<"Time before updating:"<<maneuvers.front().lane_following_maneuver.start_time.toSec() - start_time.toSec()<<std::endl;
-        std::cout<<"Time after updating:"<<GET_MANEUVER_PROPERTY(maneuvers.front(), start_time).toSec() - start_time.toSec()<<std::endl; 
-
     }
     
 

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -77,7 +77,7 @@ namespace route_following_plugin
         EXPECT_FALSE(rfp.identifyLaneChange(relations, 0));
     }
 
-    TEST(RouteFollowingPlugin,DISABLED_TestAssociateSpeedLimit)
+    TEST(RouteFollowingPlugin,TestAssociateSpeedLimit)
     {
         //Use Guidance Lib to create map
         carma_wm::test::MapOptions options;
@@ -161,7 +161,7 @@ namespace route_following_plugin
 
     }
 
-    TEST(RouteFollowingPlugin,DISABLED_TestAssociateSpeedLimitusingosm)
+    TEST(RouteFollowingPlugin,TestAssociateSpeedLimitusingosm)
     {
         // File to process. Path is relative to test folder
         std::string file = "../resource/map/town01_vector_map_1.osm";

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -70,11 +70,11 @@ namespace route_following_plugin
     {
         RouteFollowingPlugin rfp;
         auto relations = lanelet::routing::LaneletRelations();
-        EXPECT_TRUE(rfp.identifyLaneChange(relations, 1));
+        EXPECT_TRUE(rfp.isLaneChangeNeeded(relations, 1));
         lanelet::routing::LaneletRelation relation;
         relation.relationType = lanelet::routing::RelationType::Successor;
         relations.push_back(relation);
-        EXPECT_FALSE(rfp.identifyLaneChange(relations, 0));
+        EXPECT_FALSE(rfp.isLaneChangeNeeded(relations, 0));
     }
 
     TEST(RouteFollowingPlugin,TestAssociateSpeedLimit)
@@ -297,6 +297,9 @@ namespace route_following_plugin
 
         double start_time_change = GET_MANEUVER_PROPERTY(maneuvers.front(), start_time).toSec() - start_time.toSec();
         ASSERT_EQ(start_time_change, 10.0);
+
+        std::cout<<"Time before updating:"<<maneuvers.front().lane_following_maneuver.start_time.toSec() - start_time.toSec()<<std::endl;
+        std::cout<<"Time after updating:"<<GET_MANEUVER_PROPERTY(maneuvers.front(), start_time).toSec() - start_time.toSec()<<std::endl; 
 
     }
     

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -77,7 +77,7 @@ namespace route_following_plugin
         EXPECT_FALSE(rfp.isLaneChangeNeeded(relations, 0));
     }
 
-    TEST(RouteFollowingPlugin,TestAssociateSpeedLimit)
+    TEST(RouteFollowingPlugin, TestAssociateSpeedLimit)
     {
         //Use Guidance Lib to create map
         carma_wm::test::MapOptions options;
@@ -132,7 +132,7 @@ namespace route_following_plugin
         plan_req1.planning_completion_time;
         
         ros::Time current_time = ros::Time::now();
-        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0,0,0,0,0, current_time));
+        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0,0,0,11.176,0, current_time));
         pplan.prior_plan=plan_req1;
         plan.request=pplan;
         //PlanManeuversResponse 
@@ -150,7 +150,7 @@ namespace route_following_plugin
         if(worker.plan_maneuver_cb(plan.request,plan.response)){    
             //check target speeds in updated response
             lanelet::Velocity limit=30_mph;
-            ASSERT_EQ(plan.response.new_plan.maneuvers[0].lane_following_maneuver.end_speed,0);
+            ASSERT_EQ(plan.response.new_plan.maneuvers[0].lane_following_maneuver.end_speed,11.176);
             for(auto i=1;i<plan.response.new_plan.maneuvers.size();i++){
                 ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value()) ;
             }
@@ -196,6 +196,7 @@ namespace route_following_plugin
         cmw->carma_wm::CARMAWorldModel::setMap(map);
 
         RouteFollowingPlugin worker;
+        ros::Time::init();  //initializing ros time to use ros::Time::now()
         //get position on map
         auto llt=map.get()->laneletLayer.get(start_id);
         lanelet::LineString3d left_bound=llt.leftBound();
@@ -243,7 +244,7 @@ namespace route_following_plugin
         plan_req1.planning_start_time;
         plan_req1.planning_completion_time;
         ros::Time current_time = ros::Time::now();
-        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0,0,0,0,start_id,current_time));
+        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0,0,0,11.176,start_id,current_time));
         pplan.prior_plan=plan_req1;
         plan.request=pplan;
         //PlanManeuversResponse 
@@ -252,7 +253,6 @@ namespace route_following_plugin
 
         plan.response=newplan;
     
-        ros::Time::init();  //initializing ros time to use ros::Time::now()
         lanelet::BasicPoint2d curr_loc(worker.pose_msg_.pose.position.x, worker.pose_msg_.pose.position.y);
         worker.current_loc_ = curr_loc;
         worker.latest_maneuver_plan_ = worker.route_cb(shortest_path);
@@ -280,7 +280,7 @@ namespace route_following_plugin
         else ASSERT_EQ(speed,11.176);                                                                            
     }
 
-        TEST(RouteFollowingPlugin,TestHelperfunctions)
+        TEST(RouteFollowingPlugin, TestHelperfunctions)
     {   
         RouteFollowingPlugin worker;
         /*composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int lane_id, ros::Time start_time);*/

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -32,7 +32,6 @@
 #include <lanelet2_core/geometry/LineString.h>
 #include <string>
 
-
 namespace route_following_plugin
 {
 
@@ -53,7 +52,7 @@ namespace route_following_plugin
         RouteFollowingPlugin rfp;
         ros::Time::init();
         ros::Time current_time = ros::Time::now();
-        auto msg = rfp.composeLaneFollowingManeuverMessage(1.0, 10.0, 0.9, 11.176, 2, current_time);
+        auto msg = rfp.composeLaneFollowingManeuverMessage(1.0, 10.0, 0.9, 11.176, 2);
         EXPECT_EQ(cav_msgs::Maneuver::LANE_FOLLOWING, msg.type);
         EXPECT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION, msg.lane_following_maneuver.parameters.neogition_type);
         EXPECT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN, msg.lane_following_maneuver.parameters.presence_vector);
@@ -81,88 +80,90 @@ namespace route_following_plugin
     {
         //Use Guidance Lib to create map
         carma_wm::test::MapOptions options;
-        options.lane_length_=25;
-        options.lane_width_=3.7;
-        options.speed_limit_=carma_wm::test::MapOptions::SpeedLimit::DEFAULT;
-        options.obstacle_=carma_wm::test::MapOptions::Obstacle::NONE;
-        std::shared_ptr<carma_wm::CARMAWorldModel> cmw=std::make_shared<carma_wm::CARMAWorldModel>();
+        options.lane_length_ = 25;
+        options.lane_width_ = 3.7;
+        options.speed_limit_ = carma_wm::test::MapOptions::SpeedLimit::DEFAULT;
+        options.obstacle_ = carma_wm::test::MapOptions::Obstacle::NONE;
+        std::shared_ptr<carma_wm::CARMAWorldModel> cmw = std::make_shared<carma_wm::CARMAWorldModel>();
         //create the Semantic Map
-        lanelet::LaneletMapPtr map=carma_wm::test::buildGuidanceTestMap(options.lane_width_,options.lane_length_);
+        lanelet::LaneletMapPtr map = carma_wm::test::buildGuidanceTestMap(options.lane_width_, options.lane_length_);
 
         //set the map with default routingGraph
         cmw->carma_wm::CARMAWorldModel::setMap(map);
-        carma_wm::test::setRouteByIds({1210,1213},cmw);
+        carma_wm::test::setRouteByIds({1210, 1213}, cmw);
 
         lanelet::LaneletMapConstPtr const_map(map);
-        lanelet::traffic_rules::TrafficRulesUPtr traffic_rules=lanelet::traffic_rules::TrafficRulesFactory::create(lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
+        lanelet::traffic_rules::TrafficRulesUPtr traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(lanelet::Locations::Germany, lanelet::Participants::VehicleCar);
         lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*map, *traffic_rules);
 
         //Compute and print shortest path
-        lanelet::Lanelet start_lanelet=map->laneletLayer.get(1210);
-        lanelet::Lanelet end_lanelet=map->laneletLayer.get(1213);
+        lanelet::Lanelet start_lanelet = map->laneletLayer.get(1210);
+        lanelet::Lanelet end_lanelet = map->laneletLayer.get(1213);
         auto route = map_graph->getRoute(start_lanelet, end_lanelet);
- 
+
         cmw.get()->setConfigSpeedLimit(30.0);
 
         RouteFollowingPlugin worker;
         cmw->carma_wm::CARMAWorldModel::setMap(map);
-        worker.wm_=cmw;
+        worker.wm_ = cmw;
 
         //Define current position and velocity
 
         lanelet::BasicPoint2d current_loc = start_lanelet.centerline2d().front();
         worker.current_loc_ = current_loc;
-        
+
         //define twist
-        worker.current_speed_=10.0;
-        
-       //Define plan for request and response
+        worker.current_speed_ = 10.0;
+
+        //Define plan for request and response
         //PlanManeuversRequest
         cav_srvs::PlanManeuvers plan;
         cav_srvs::PlanManeuversRequest pplan;
-        
+
         cav_msgs::ManeuverPlan plan_req1;
         plan_req1.header;
         plan_req1.maneuver_plan_id;
         plan_req1.planning_start_time;
         plan_req1.planning_completion_time;
-        
-        ros::Time current_time = ros::Time::now();
-        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0,0,0,11.176,0, current_time));
-        pplan.prior_plan=plan_req1;
-        plan.request=pplan;
-        //PlanManeuversResponse 
-        cav_srvs::PlanManeuversResponse newplan;
-        for(auto i=0;i<plan_req1.maneuvers.size();i++) newplan.new_plan.maneuvers.push_back(plan_req1.maneuvers[i]);
 
-        plan.response=newplan;
-        
+        ros::Time current_time = ros::Time::now();
+        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0, 0, 0, 11.176, 0));
+        pplan.prior_plan = plan_req1;
+        plan.request = pplan;
+        //PlanManeuversResponse
+        cav_srvs::PlanManeuversResponse newplan;
+        for (auto i = 0; i < plan_req1.maneuvers.size(); i++)
+            newplan.new_plan.maneuvers.push_back(plan_req1.maneuvers[i]);
+
+        plan.response = newplan;
+
         //RouteFollowing plan maneuver callback
         ros::Time::init();
         auto shortest_path = cmw->getRoute()->shortestPath();
 
-        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path);
-        if(worker.plan_maneuver_cb(plan.request,plan.response)){    
+        worker.latest_maneuver_plan_ = worker.routeCb(shortest_path);
+        if (worker.planManeuverCb(plan.request, plan.response))
+        {
             //check target speeds in updated response
-            lanelet::Velocity limit=30_mph;
-            ASSERT_EQ(plan.response.new_plan.maneuvers[0].lane_following_maneuver.end_speed,11.176);
-            for(auto i=1;i<plan.response.new_plan.maneuvers.size();i++){
-                ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value()) ;
+            lanelet::Velocity limit = 30_mph;
+            ASSERT_EQ(plan.response.new_plan.maneuvers[0].lane_following_maneuver.end_speed, 11.176);
+            for (auto i = 1; i < plan.response.new_plan.maneuvers.size(); i++)
+            {
+                ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value());
             }
         }
-        else{
+        else
+        {
             EXPECT_TRUE(false);
-        } 
-        
-
+        }
     }
 
     TEST(RouteFollowingPlugin, TestAssociateSpeedLimitusingosm)
     {
         // File to process. Path is relative to test folder
         std::string file = "../resource/map/town01_vector_map_1.osm";
-        lanelet::Id start_id=100;
-        lanelet::Id end_id=111;
+        lanelet::Id start_id = 100;
+        lanelet::Id end_id = 111;
         /***
          * VAVLID PATHs (consists of lanenet ids): (This is also the shortest path because certain Lanelets missing)
          * 159->160->164->136->135->137->144->121; 
@@ -187,99 +188,101 @@ namespace route_following_plugin
         {
             FAIL() << "Input map does not contain any lanelets";
         }
-        std::shared_ptr<carma_wm::CARMAWorldModel> cmw=std::make_shared<carma_wm::CARMAWorldModel>();
+        std::shared_ptr<carma_wm::CARMAWorldModel> cmw = std::make_shared<carma_wm::CARMAWorldModel>();
         cmw->carma_wm::CARMAWorldModel::setMap(map);
 
         RouteFollowingPlugin worker;
-        ros::Time::init();  //initializing ros time to use ros::Time::now()
+        ros::Time::init(); //initializing ros time to use ros::Time::now()
         //get position on map
-        auto llt=map.get()->laneletLayer.get(start_id);
-        lanelet::LineString3d left_bound=llt.leftBound();
-        lanelet::LineString3d right_bound=llt.rightBound();
+        auto llt = map.get()->laneletLayer.get(start_id);
+        lanelet::LineString3d left_bound = llt.leftBound();
+        lanelet::LineString3d right_bound = llt.rightBound();
         geometry_msgs::PoseStamped left;
         geometry_msgs::PoseStamped right;
-        for(lanelet::Point3d& p : left_bound)
+        for (lanelet::Point3d &p : left_bound)
         {
-            left.pose.position.x=p.x();
-            left.pose.position.y=p.y();
-            left.pose.position.z=p.z();
-
+            left.pose.position.x = p.x();
+            left.pose.position.y = p.y();
+            left.pose.position.z = p.z();
         }
-        for(lanelet::Point3d& p : right_bound)
+        for (lanelet::Point3d &p : right_bound)
         {
-            right.pose.position.x=p.x();
-            right.pose.position.y=p.y();
-            right.pose.position.z=p.z();
+            right.pose.position.x = p.x();
+            right.pose.position.y = p.y();
+            right.pose.position.z = p.z();
         }
         //Assign start of centerline of start lanelet as current position
         lanelet::BasicPoint2d start_location;
         start_location = llt.centerline2d().back();
         worker.current_loc_ = start_location;
-        
+
         //define twist
-        worker.current_speed_=0.0;
+        worker.current_speed_ = 0.0;
 
         //Set Route
-        carma_wm::test::setRouteByIds({start_id,end_id},cmw);
+        carma_wm::test::setRouteByIds({start_id, end_id}, cmw);
         cmw->carma_wm::CARMAWorldModel::setMap(map);
-        worker.wm_=cmw;
+        worker.wm_ = cmw;
         auto shortest_path = cmw->getRoute()->shortestPath();
         //Define plan for request and response
         //PlanManeuversRequest
         cav_srvs::PlanManeuvers plan;
         cav_srvs::PlanManeuversRequest pplan;
-        
+
         cav_msgs::ManeuverPlan plan_req1;
         plan_req1.header;
         plan_req1.maneuver_plan_id;
         plan_req1.planning_start_time;
         plan_req1.planning_completion_time;
         ros::Time current_time = ros::Time::now();
-        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0.0, 100.0 ,0,11.176,start_id,current_time));
-        pplan.prior_plan=plan_req1;
-        plan.request=pplan;
-        //PlanManeuversResponse 
+        plan_req1.maneuvers.push_back(worker.composeLaneFollowingManeuverMessage(0.0, 100.0, 0, 11.176, start_id));
+        pplan.prior_plan = plan_req1;
+        plan.request = pplan;
+        //PlanManeuversResponse
         cav_srvs::PlanManeuversResponse newplan;
-        for(auto i=0;i<plan_req1.maneuvers.size();i++) newplan.new_plan.maneuvers.push_back(plan_req1.maneuvers[i]);
+        for (auto i = 0; i < plan_req1.maneuvers.size(); i++)
+            newplan.new_plan.maneuvers.push_back(plan_req1.maneuvers[i]);
 
-        plan.response=newplan;
-        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path);
-        if(worker.plan_maneuver_cb(plan.request,plan.response)){   
+        plan.response = newplan;
+        worker.latest_maneuver_plan_ = worker.routeCb(shortest_path);
+        if (worker.planManeuverCb(plan.request, plan.response))
+        {
             //check target speeds in updated response
-            lanelet::Velocity limit=25_mph;
-            
-            for(auto i=0;i<plan.response.new_plan.maneuvers.size() -1 ;i++){
-                std::cout<<"Maneuver end speed:"<<plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed<<std::endl;
-                ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value()) ;
+            lanelet::Velocity limit = 25_mph;
+
+            for (auto i = 0; i < plan.response.new_plan.maneuvers.size() - 1; i++)
+            {
+                ASSERT_EQ(plan.response.new_plan.maneuvers[i].lane_following_maneuver.end_speed, limit.value());
             }
-            
         }
-        else{
-            EXPECT_TRUE(false); 
+        else
+        {
+            EXPECT_TRUE(false);
         }
         //Test findSpeedLimit function
-        auto current_lanelets= lanelet::geometry::findNearest(worker.wm_->getMap()->laneletLayer, worker.current_loc_, 10); 
+        auto current_lanelets = lanelet::geometry::findNearest(worker.wm_->getMap()->laneletLayer, worker.current_loc_, 10);
         lanelet::ConstLanelet current_lanelet = current_lanelets[0].second;
-        double speed=worker.findSpeedLimit(current_lanelet);
-        if(speed < 11.176)
+        double speed = worker.findSpeedLimit(current_lanelet);
+        if (speed < 11.176)
         {
             ASSERT_EQ(speed, 0.0);
         }
-        else ASSERT_EQ(speed,11.176);                                                                            
+        else
+            ASSERT_EQ(speed, 11.176);
     }
 
-        TEST(RouteFollowingPlugin, TestHelperfunctions)
-    {   
+    TEST(RouteFollowingPlugin, TestHelperfunctions)
+    {
         RouteFollowingPlugin worker;
         /*composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, int lane_id, ros::Time start_time);*/
         ros::Time::init();
         ros::Time start_time = ros::Time::now();
-        cav_msgs::Maneuver maneuver = worker.composeLaneFollowingManeuverMessage(10.0 ,100.0 ,0.0, 100.0, 101, start_time);
+        cav_msgs::Maneuver maneuver = worker.composeLaneFollowingManeuverMessage(10.0, 100.0, 0.0, 100.0, 101);
 
         worker.setManeuverStartDist(maneuver, 50.0);
-        ASSERT_EQ(maneuver.lane_following_maneuver.start_dist,50.0);
-        
-        ros::Time new_start_time = start_time + ros::Duration (10.0);
+        ASSERT_EQ(maneuver.lane_following_maneuver.start_dist, 50.0);
+
+        ros::Time new_start_time = start_time + ros::Duration(10.0);
         std::vector<cav_msgs::Maneuver> maneuvers;
         maneuvers.push_back(maneuver);
 
@@ -287,9 +290,7 @@ namespace route_following_plugin
 
         double start_time_change = GET_MANEUVER_PROPERTY(maneuvers.front(), start_time).toSec() - start_time.toSec();
         ASSERT_EQ(start_time_change, 10.0);
-
     }
-    
 
 }
 
@@ -300,5 +301,3 @@ int main(int argc, char **argv)
     auto res = RUN_ALL_TESTS();
     return res;
 }
-
-

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -145,7 +145,8 @@ namespace route_following_plugin
         ros::Time::init();
         auto shortest_path = cmw->getRoute()->shortestPath();
         lanelet::BasicPoint2d curr_loc(worker.pose_msg_.pose.position.x, worker.pose_msg_.pose.position.y);
-        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path, curr_loc);
+        worker.current_loc_ = curr_loc;
+        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path);
         if(worker.plan_maneuver_cb(plan.request,plan.response)){    
             //check target speeds in updated response
             lanelet::Velocity limit=30_mph;
@@ -253,7 +254,8 @@ namespace route_following_plugin
     
         ros::Time::init();  //initializing ros time to use ros::Time::now()
         lanelet::BasicPoint2d curr_loc(worker.pose_msg_.pose.position.x, worker.pose_msg_.pose.position.y);
-        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path, curr_loc);
+        worker.current_loc_ = curr_loc;
+        worker.latest_maneuver_plan_ = worker.route_cb(shortest_path);
         if(worker.plan_maneuver_cb(plan.request,plan.response)){   
             //check target speeds in updated response
             lanelet::Velocity limit=25_mph;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR refactors the route following plugin to be more simplistic is forming maneuver plans.
## Description
In this implementation the maneuver planning is done as a call back when the route is set. Following that the maneuvers are added to the response when a request is sent. 
The time, starting distance and starting speed values are updated each time the plan is added to the response.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is needed to allow lane change maneuvers to be formed correctly in between lane following maneuvers.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code was unit tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
