### PR TITLE
Feature/freight arrival

### DIFF
--- a/port_drayage_plugin/config/params.yml
+++ b/port_drayage_plugin/config/params.yml
@@ -1,3 +1,3 @@
 stop_speed_epsilon: 1.0
-cmv_id: CARMA_TEST_CMV
-cargo_id: TEST_CARGO
+cmv_id: 123 // Test value; CARMA Streets expects cmv_id to be an integer
+cargo_id: 321 // Test value; CARMA Streets expects cargo_id to be an integer

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -32,12 +32,12 @@ namespace port_drayage_plugin
      */
     struct PortDrayageMobilityOperationMsg
     {
-        std::string cargo_id;
+        int cargo_id;
         std::string operation;
         PortDrayageEvent port_drayage_event_type; // PortDrayageEvent associated with this message
         bool has_cargo; // Flag to indicate whether vehicle has cargo during this action
-        std::string current_action_id;
-        std::string next_action_id;
+        int current_action_id;
+        int next_action_id;
         boost::optional<double> dest_longitude;
         boost::optional<double> dest_latitude;
         boost::optional<double> start_longitude; // Starting longitude of the carma vehicle
@@ -61,8 +61,8 @@ namespace port_drayage_plugin
             PortDrayageStateMachine _pdsm;
             std::string _host_id;
             std::string _host_bsm_id;
-            std::string _cmv_id;
-            std::string _cargo_id;
+            int _cmv_id;
+            int _cargo_id;
             std::function<void(cav_msgs::MobilityOperation)> _publish_mobility_operation;
 
             // Data member for storing the strategy_params field of the last processed port drayage MobilityOperation message intended for this vehicle's cmv_id
@@ -78,10 +78,10 @@ namespace port_drayage_plugin
             /**
              * \brief Standard constructor for the PortDrayageWorker
              * 
-             * \param cmv_id The Carrier Motor Vehicle ID string for the host
+             * \param cmv_id The Carrier Motor Vehicle ID integer for the host
              * vehicle
              * 
-             * \param cargo_id The identification string for the cargo carried
+             * \param cargo_id The identification integer for the cargo carried
              * by the host vehicle. If no cargo is being carried this should be
              * empty.
              * 
@@ -96,8 +96,8 @@ namespace port_drayage_plugin
              * comparing the current vehicle's speed to 0.0
              */
             PortDrayageWorker(
-                std::string cmv_id,
-                std::string cargo_id,
+                int cmv_id,
+                int cargo_id,
                 std::string host_id,
                 std::function<void(cav_msgs::MobilityOperation)> mobility_operations_publisher, 
                 double stop_speed_epsilon) :

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -29,10 +29,10 @@ namespace port_drayage_plugin
 
         double speed_epsilon = _pnh->param("stop_speed_epsilon", 1.0);
         declaration = _pnh->param("declaration", 1.0);
-        std::string cmv_id;
-        _pnh->param<std::string>("cmv_id", cmv_id, "");
-        std::string cargo_id;
-        _pnh->param<std::string>("cargo_id", cargo_id, "");
+        int cmv_id;
+        _pnh->param<int>("cmv_id", cmv_id, 123);
+        int cargo_id;
+        _pnh->param<int>("cargo_id", cargo_id, 321);
 
         ros::Publisher outbound_mob_op = _nh->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
         _outbound_mobility_operations_publisher = std::make_shared<ros::Publisher>(outbound_mob_op);

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -84,6 +84,20 @@ namespace port_drayage_plugin
         pt.put("cmv_id", _cmv_id);
         pt.put("cargo_id", _cargo_id);
         pt.put("operation", PORT_DRAYAGE_ARRIVAL_OPERATION_ID);
+
+        // Certain fields required by CARMA Streets are unnecessary for arrival messages and can be zero-filled
+        pt.put("cargo", 0); 
+        ptree location;
+        location.put("latitude", 0);
+        location.put("longitude", 0);
+        pt.put_child("location", location);
+        ptree destination;
+        destination.put("latitude", 0);
+        destination.put("longitude", 0);
+        pt.put_child("destination", destination);
+        pt.put("action_id", 0);
+        pt.put("next_action", 0);
+
         std::stringstream body_stream;
         boost::property_tree::json_parser::write_json(body_stream, pt);
         msg.strategy_params = body_stream.str();
@@ -99,7 +113,7 @@ namespace port_drayage_plugin
             ptree pt;
             std::istringstream strategy_params_ss(msg->strategy_params);
             boost::property_tree::json_parser::read_json(strategy_params_ss, pt);
-            std::string mobility_operation_cmv_id = pt.get<std::string>("cmv_id");
+            int mobility_operation_cmv_id = pt.get<int>("cmv_id");
 
             // Check if the received MobilityOperation message is intended for this vehicle's cmv_id   
             if(mobility_operation_cmv_id == _cmv_id) {
@@ -131,10 +145,10 @@ namespace port_drayage_plugin
         std::istringstream mobility_operation_strategy_params_ss(mobility_operation_strategy_params);
         boost::property_tree::json_parser::read_json(mobility_operation_strategy_params_ss, pt);
 
-        _latest_mobility_operation_msg.cargo_id = pt.get<std::string>("cargo_id");
+        _latest_mobility_operation_msg.cargo_id = pt.get<int>("cargo_id");
         _latest_mobility_operation_msg.has_cargo = pt.get<bool>("cargo");
-        _latest_mobility_operation_msg.current_action_id = pt.get<std::string>("action_id");
-        _latest_mobility_operation_msg.next_action_id = pt.get<std::string>("next_action");
+        _latest_mobility_operation_msg.current_action_id = pt.get<int>("action_id");
+        _latest_mobility_operation_msg.next_action_id = pt.get<int>("next_action");
         _latest_mobility_operation_msg.operation = pt.get<std::string>("operation");
 
         if(_latest_mobility_operation_msg.operation == "MOVING_TO_LOADING_AREA") {

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -46,7 +46,6 @@ TEST(PortDrayageTest, testComposeArrivalMessage)
     ASSERT_FALSE(msg.strategy_params.empty());
 
     std::istringstream strstream(msg.strategy_params);
-    std::cout << strstream.str();
     using boost::property_tree::ptree;
     ptree pt;
     boost::property_tree::json_parser::read_json(strstream, pt);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates PortDrayageWorker's compose_arrival_message() function, which is used to broadcast a Mobility Operation message from the host vehicle when it arrives at a destination in the port drayage use case. More specifically, several fields have been added to the broadcasted message's strategy_params string because these additional fields are required for V2XHub to conduct its Mobility Operation message processing.

In addition to the updates described above, the data types of several data members within PortDrayageWorker have been updated to match the expectations of V2XHub to support communications. For example, V2XHub expects/required cmv_id, cargo_id, action_id, and next_action to be integers.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested and integration tested at TFHRC with the White Pacifica and V2XHub.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
