### PR TITLE
Assign route_name field to route message published after rerouting due to route invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@
 # Stage 1 - Acquire the CARMA source as well as any extra packages
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastoldev/autoware.ai:develop AS base-image
+FROM usdotfhwastolcandidate/autoware.ai:zephyr AS base-image
 
 FROM base-image AS source-code
 

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -578,7 +578,9 @@ namespace route {
                 this->rs_worker_.on_route_event(RouteStateWorker::RouteEvent::ROUTE_STARTED);
                 publish_route_event(cav_msgs::RouteEvent::ROUTE_STARTED);  
             }    
+            std::string original_route_name = route_msg_.route_name;
             route_msg_=compose_route_msg(route);
+            route_msg_.route_name = original_route_name;
             route_msg_.is_rerouted = true;
             route_msg_.map_version = world_model_->getMapVersion();
             route_marker_msg_=compose_route_marker_msg(route);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
A minor update is made to the logic in RouteGeneratorWorker's spin_callback() method in order to assign a name to the route_name field of the cav_msgs/Route.msg message that is published after successful rerouting due to a route invalidation. By assigning a route name, the `if(route_msg_.route_name != "")` downstream check  will be successful, which will enable messages to continue to be published to the /guidance/route_state topic.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #1306: /guidance/route_state stops publishing after a carma3/Incident_Use_Case MobilityOperation message is received and processed. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With this fix, after successful rerouting due to route invalidation, messages will continue to be published to /guidance/route_state.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested on Blue Lexus with zephyr release.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
