### PR TITLE
Fix/near zero comparison

### DIFF
--- a/basic_autonomy/include/basic_autonomy/helper_functions.h
+++ b/basic_autonomy/include/basic_autonomy/helper_functions.h
@@ -49,11 +49,11 @@ namespace waypoint_generation
      * correctly returns the end point's index if the given state, despite being valid, is farther than the given points and can technically be near any of them.
      * 
      * \param points BasicLineString2d points
-     * \param ending_downtrack ending downtrack along the route to get index of
+     * \param target_downtrack target downtrack along the route to get index of
      * 
      * \return index of nearest point in points
      */
-    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double ending_downtrack);
+    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double target_downtrack);
 
     /**
      * \brief Helper method to split a list of PointSpeedPair into separate point and speed lists 

--- a/basic_autonomy/include/basic_autonomy/helper_functions.h
+++ b/basic_autonomy/include/basic_autonomy/helper_functions.h
@@ -20,7 +20,8 @@ namespace basic_autonomy
 {
 namespace waypoint_generation
 {
-    
+    //Small value corresponding to 0.1 mm in meters for comparing distance to a near zero.
+    const double epsilon_ = 0.0000001;
     /**
      * \brief Returns the nearest point (in terms of cartesian 2d distance) to the provided vehicle pose in the provided l
      * 

--- a/basic_autonomy/include/basic_autonomy/helper_functions.h
+++ b/basic_autonomy/include/basic_autonomy/helper_functions.h
@@ -43,13 +43,13 @@ namespace waypoint_generation
     int get_nearest_point_index(const std::vector<PointSpeedPair>& points,
                                                  const cav_msgs::VehicleState& state);
     /**
-     * \brief Returns the nearest point to the provided vehicle pose in the provided list by utilizing the downtrack measured along the route
+     * \brief Returns the nearest "less than" point to the provided vehicle pose in the provided list by utilizing the downtrack measured along the route
      * NOTE: This function compares the downtrack, provided by routeTrackPos, of each points in the list to get the closest one to the given point's downtrack.
      * Therefore, it is rather costlier method than comparing cartesian distance between the points and getting the closest. This way, however, the function
      * correctly returns the end point's index if the given state, despite being valid, is farther than the given points and can technically be near any of them.
      * 
      * \param points BasicLineString2d points
-     * \param target_downtrack target downtrack along the route to get index of
+     * \param target_downtrack target downtrack along the route to get index near to
      * 
      * \return index of nearest point in points
      */

--- a/basic_autonomy/src/helper_functions.cpp
+++ b/basic_autonomy/src/helper_functions.cpp
@@ -65,9 +65,9 @@ namespace waypoint_generation
     int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double ending_downtrack)
     {
         int best_index = points.size() - 1;
-        for(int i=0;i < points.size();i++){
+        for(int i = 0;i < points.size(); i++){
             double downtrack = wm->routeTrackPos(points[i]).downtrack;
-            if(downtrack > ending_downtrack){
+            if(downtrack > ending_downtrack + epsilon_){
                 best_index = i - 1;
                 if (best_index < 0)
                 {

--- a/basic_autonomy/src/helper_functions.cpp
+++ b/basic_autonomy/src/helper_functions.cpp
@@ -67,12 +67,10 @@ namespace waypoint_generation
         int best_index = points.size() - 1;
         for(int i = 0;i < points.size(); i++){
             double downtrack = wm->routeTrackPos(points[i]).downtrack;
-            if(downtrack > target_downtrack + epsilon_){
-                best_index = i - 1;
-                if (best_index < 0)
-                {
-                throw std::invalid_argument("Given points are beyond the ending_downtrack");
-                }
+            if(downtrack > target_downtrack){
+                //If value is negative, best index should be index 0
+                best_index = std::max(0, i - 1);
+
                 ROS_DEBUG_STREAM("get_nearest_index_by_downtrack>> Found best_idx: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y() << ", downtrack: "<< downtrack);
                 break;
             }

--- a/basic_autonomy/src/helper_functions.cpp
+++ b/basic_autonomy/src/helper_functions.cpp
@@ -62,12 +62,12 @@ namespace waypoint_generation
         return best_index;
     }
 
-    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double ending_downtrack)
+    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double target_downtrack)
     {
         int best_index = points.size() - 1;
         for(int i = 0;i < points.size(); i++){
             double downtrack = wm->routeTrackPos(points[i]).downtrack;
-            if(downtrack > ending_downtrack + epsilon_){
+            if(downtrack > target_downtrack + epsilon_){
                 best_index = i - 1;
                 if (best_index < 0)
                 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes an issue with get_nearest_index_by_downtrack in basic autonomy where a query for a target 0.0 downtrack results in an exception. 
Adding this value results in an assumptions that the points being queried are at least 0.1mm apart, which seems reasonably small to allow.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes were unit tested and integration tested.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
