### PR TITLE
Fix/participants

### DIFF
--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -214,6 +214,13 @@ public:
   ros::V_string invertParticipants(const ros::V_string& input_participants) const;
 
   /*!
+   * \brief Combines a list of the given participants into a single "vehicle" type if participants cover all possible vehicle types.
+            Returns the input with no change if it doesn't cover all.
+   * \param ros::V_string participants vector of strings 
+   */
+  ros::V_string combineParticipantsToVehicle(const ros::V_string& input_participants) const;
+
+  /*!
    *  \brief Callback triggered whenever a new subscriber connects to the map_update topic of this node.
    *         This callback will publish the all updates for the current map to that node so that any missed updates are already included.
    *          

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -390,8 +390,8 @@ ros::V_string WMBroadcaster::participantsChecker(const cav_msgs::TrafficControlM
       participants.push_back(lanelet::Participants::VehicleTruck);
     }
   }
-
-  return  participants;
+  // combine to single vehicle type if possible, otherwise pass through
+  return  combineParticipantsToVehicle(participants);
 }
 
 ros::V_string WMBroadcaster::invertParticipants(const ros::V_string& input_participants) const
@@ -408,6 +408,27 @@ ros::V_string WMBroadcaster::invertParticipants(const ros::V_string& input_parti
     if(std::find(input_participants.begin(),input_participants.end(),lanelet::Participants::VehicleTruck)== input_participants.end()) participants.emplace_back(lanelet::Participants::VehicleTruck);
   }
   return  participants;
+}
+
+ros::V_string WMBroadcaster::combineParticipantsToVehicle(const ros::V_string& input_participants) const
+{
+  ros::V_string participants;
+
+  if(std::find(input_participants.begin(),input_participants.end(),lanelet::Participants::VehicleMotorcycle)!= input_participants.end() &&
+      std::find(input_participants.begin(),input_participants.end(),lanelet::Participants::VehicleBus) != input_participants.end() &&
+      std::find(input_participants.begin(),input_participants.end(),lanelet::Participants::VehicleCar) != input_participants.end() &&
+      std::find(input_participants.begin(),input_participants.end(),lanelet::Participants::VehicleTruck) != input_participants.end())
+  {
+    ROS_DEBUG_STREAM("Detected participants to cover all possible vehicle types");
+    participants.emplace_back(lanelet::Participants::Vehicle);
+  }
+  else
+  {
+    ROS_DEBUG_STREAM("Not making any changes to the participants list");
+    participants = input_participants;
+  }
+
+  return participants;
 }
 
 // currently only supports geofence message version 1: TrafficControlMessageV01 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
TCM from carma-cloud sends individual participants (vehiclecar or vehicletruck etc), which carma_wm_ctrl updates individually. However, carma_wm's current functionality only works for lanelet::vehicle type. Therefore, this PR adds extra check if the individual participants cover all possible vehicle types, if so, compile it into one participant type of `vehicle`

<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Summit Point Ford Fusion TCM integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
