### PR TITLE
Update to package format 3 and run xmllint

### DIFF
--- a/cooperative_lanechange/package.xml
+++ b/cooperative_lanechange/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>cooperative_lanechange</name>
   <version>3.3.0</version>
   <description>The node is to plan a cooperative lane change trajectory</description>
@@ -20,5 +20,3 @@
   <depend>unobstructed_lanechange</depend>  
   <depend>roslib</depend>
 </package>
-
-  

--- a/lightbar_manager/package.xml
+++ b/lightbar_manager/package.xml
@@ -3,9 +3,9 @@
   <name>lightbar_manager</name>
   <version>3.3.0</version>
   <description>LightBar Manager</description>
-  <author>Misheel Bayartsengel</author>
   <maintainer email="carma@dot.gov">carma</maintainer>
   <license>Apache 2.0 License</license>
+  <author>Misheel Bayartsengel</author>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>carma_utils</depend>
   <depend>cav_msgs</depend>

--- a/mock_drivers/mock_lightbar_driver/package.xml
+++ b/mock_drivers/mock_lightbar_driver/package.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>mock_lightbar_driver</name>
-  <description>The mock_lightbar_driver package</description>
   <version>1.0.0</version>
-  <buildtool_depend>catkin</buildtool_depend>
-  <license>APACHE 2.0</license>
+  <description>The mock_lightbar_driver package</description>
   <maintainer email="Jerry.Sun@leidos.com">Jerry Sun</maintainer>
+  <license>APACHE 2.0</license>
+  <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
   <depend>cav_srvs</depend>
   <depend>cav_msgs</depend>
   <depend>carma_utils</depend>
-  
-
-
 </package>

--- a/mock_drivers/rosbag_mock_drivers/package.xml
+++ b/mock_drivers/rosbag_mock_drivers/package.xml
@@ -15,12 +15,9 @@
   <name>rosbag_mock_drivers</name>
   <version>1.0.0</version>
   <description>The rosbag_mock_drivers package</description>
-
-  <author email="Pcguglielmino@leidos.com">Peter Guglielmino</author>
   <maintainer email="carma@dot.gov">carma</maintainer>
-
   <license>Apache 2.0</license>
-
+  <author email="Pcguglielmino@leidos.com">Peter Guglielmino</author>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
@@ -34,6 +31,5 @@
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>

--- a/platooning_control/package.xml
+++ b/platooning_control/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>platoon_control</name>
   <version>3.3.0</version>
   <description>The node is to control a platooning maneuver</description>

--- a/port_drayage_plugin/package.xml
+++ b/port_drayage_plugin/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>port_drayage_plugin</name>
   <version>1.0.0</version>
   <description>CARMA plugin to support port drayage applications for CARMA Freight</description>

--- a/pure_pursuit_jerk_wrapper/package.xml
+++ b/pure_pursuit_jerk_wrapper/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>pure_pursuit_jerk_wrapper</name>
   <version>0.0.0</version>
   <description>The pure_pursuit_jerk_wrapper package</description>

--- a/route_following_plugin/package.xml
+++ b/route_following_plugin/package.xml
@@ -16,7 +16,7 @@
  the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>route_following_plugin</name>
   <version>3.2.0</version>
   <description>The strategic plugin generates maneuvers to make the vehicle follow the route. </description>


### PR DESCRIPTION
Update remaining packages that had package format version 2 to version 3 and address any xmllint issues when testing against the package format v3 schema (typically just reordering items). 
