### PR TITLE
Update carma packages to use newer version of autoware_msgs

### DIFF
--- a/guidance/src/guidance/guidance_state_machine.cpp
+++ b/guidance/src/guidance/guidance_state_machine.cpp
@@ -89,7 +89,7 @@ namespace guidance
         if (current_guidance_state_ == State::ENTER_PARK)
         {
             // '3' indicates vehicle gearshift is currently set to PARK
-            if(msg->gearshift == 3)
+            if(msg->current_gear.gear== autoware_msgs::Gear::PARK)
             {
                 onGuidanceSignal(Signal::OVERRIDE); // Required for ENTER_PARK -> INACTIVE
 

--- a/guidance/test/test_guidance_state_machine.cpp
+++ b/guidance/test/test_guidance_state_machine.cpp
@@ -81,7 +81,7 @@ TEST(GuidanceStateMachineTest, testStates)
     // test ENTER_PARK state at end of route
     EXPECT_EQ(6, static_cast<int>(gsm.getCurrentState()));
     autoware_msgs::VehicleStatus vehicle_status;
-    vehicle_status.gearshift = 3; // '3' indicates gearshift is set to Park
+    vehicle_status.current_gear.gear = autoware_msgs::Gear::PARK; // '3' indicates gearshift is set to Park
     autoware_msgs::VehicleStatusConstPtr vehicle_status_pointer(new autoware_msgs::VehicleStatus(vehicle_status));
     gsm.onVehicleStatus(vehicle_status_pointer);
     // test DRIVERS_READY state


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details

The lanelet2 upgrade required upgrading some parts of the autoware_msgs. These changes reflect this change in message definitions.

## Description

Changed how the guidance nodes and tests reference the gear.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Needed to complete the lanelet2 upgrade.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Ran the unit tests for the guidance package. All tests passed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
