### PR TITLE
Fix ILC "no points to fit in time span" exception

### DIFF
--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -560,7 +560,7 @@ std::vector<PointSpeedPair> InLaneCruisingPlugin::maneuvers_to_points(const std:
 
     ROS_DEBUG_STREAM("Used downtrack: " << starting_downtrack);
 
-    auto lanelets = wm->getLaneletsBetween(starting_downtrack, lane_following_maneuver.end_dist, true, true);
+    auto lanelets = wm->getLaneletsBetween(starting_downtrack, lane_following_maneuver.end_dist + config_.buffer_ending_downtrack, true, true);
 
     if (lanelets.empty())
     {

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -239,6 +239,7 @@ namespace route_following_plugin
             return;
 
         lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
+        current_loc_ = current_loc;
         double current_progress = wm_->routeTrackPos(current_loc).downtrack;
         
         auto llts = wm_->getLaneletsFromPoint(current_loc, 10);                                          


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes bugs in route_following_plugin and inlanecruising_plugin which gives above error in title. It was found during platooning test. route_following_plugin's bug was introduced in recent lane_change PR, and inlanecruising_plugin is needed as without it, buffer_ending_downtrack would not do anything.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1347

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
integration tested at ACM
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
