### PR TITLE
Update checkout.bash to work with CI properly

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -46,10 +46,10 @@ if [[ "$BRANCH" = "noetic/develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch $BRANCH
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch $BRANCH
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/release
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/release
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/release
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/release
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch noetic/develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch noetic/develop
 fi
 
 # add astuff messages


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the checkout.bash script to by default point at noetic/develop to support CI usage. 
The need for this change does point to a fundamental flaw in the checkout.bash script since it effectively renders the -d argument meaningless. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working CI on noetic branch
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Running ci here
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
