### PR TITLE
Fix/regenerate maneuvers on map update

### DIFF
--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -190,6 +190,13 @@ void WMListenerWorker::mapUpdateCallback(const autoware_lanelet2_msgs::MapBinPtr
 
   
   ROS_INFO_STREAM("Finished Applying the Map Update with Geofence Id:" << gf_ptr->id_); 
+
+  // Call user defined map callback
+  if (map_callback_)
+  {
+    ROS_INFO_STREAM("Calling user defined map update callback");
+    map_callback_();
+  }
 }
 
 /*!

--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -81,14 +81,6 @@ namespace route_following_plugin
         private:
 
         /**
-         * \brief Given a LaneletPath object, find index of the lanelet which has target_id as its lanelet ID
-         * \param target_id The laenlet ID this function is looking for
-         * \param path A list of lanelet with different lanelet IDs
-         * \return Index of the target lanelet in the list
-         */
-        int findLaneletIndexFromPath(int target_id,const lanelet::routing::LaneletPath& path) const;
-
-        /**
          * \brief Compose a lane keeping maneuver message based on input params
          * \param start_dist Start downtrack distance of the current maneuver
          * \param end_dist End downtrack distance of the current maneuver
@@ -138,8 +130,6 @@ namespace route_following_plugin
          * \param start_time The starting speed for the maneuver passed as argument
          */
         void updateStartingSpeed(cav_msgs::Maneuver& maneuver, double start_speed) const;
-
-        void updateEndingSpeed(cav_msgs::Maneuver& maneuver, double end_speed) const;
 
         /**
          * \brief Service callback for arbitrator maneuver planning
@@ -226,7 +216,6 @@ namespace route_following_plugin
         ros::Duration getManeuverDuration(cav_msgs::Maneuver &maneuver, double epsilon) const;
 
         //Unit Tests
-        FRIEND_TEST(RouteFollowingPluginTest, testFindLaneletIndexFromPath);
         FRIEND_TEST(RouteFollowingPluginTest, testComposeManeuverMessage);
         FRIEND_TEST(RouteFollowingPluginTest, testIdentifyLaneChange);
         FRIEND_TEST(RouteFollowingPlugin, TestAssociateSpeedLimit);

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -329,35 +329,6 @@ namespace route_following_plugin
         }
     }
 
-    void RouteFollowingPlugin::updateEndingSpeed(cav_msgs::Maneuver &maneuver, double end_speed) const
-    {
-        ROS_DEBUG_STREAM("end_speed: " << end_speed);
-        switch (maneuver.type)
-        {
-        case cav_msgs::Maneuver::LANE_FOLLOWING:
-            maneuver.lane_following_maneuver.end_speed = end_speed;
-            ROS_DEBUG_STREAM("end_speed updated for lane following: " << end_speed);
-            break;
-        case cav_msgs::Maneuver::LANE_CHANGE:
-            maneuver.lane_change_maneuver.end_speed = end_speed;
-            break;
-        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT:
-            maneuver.intersection_transit_straight_maneuver.end_speed = end_speed;
-            break;
-        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_LEFT_TURN:
-            maneuver.intersection_transit_left_turn_maneuver.end_speed = end_speed;
-            break;
-        case cav_msgs::Maneuver::INTERSECTION_TRANSIT_RIGHT_TURN:
-            maneuver.intersection_transit_right_turn_maneuver.end_speed = end_speed;
-            break;
-        case cav_msgs::Maneuver::STOP_AND_WAIT:
-            //Do nothing
-            break;
-        default:
-            throw std::invalid_argument("Invalid maneuver type, cannot update starting speed for maneuver");
-        }
-    }
-
     void RouteFollowingPlugin::updateStartingSpeed(cav_msgs::Maneuver &maneuver, double start_speed) const
     {
         switch (maneuver.type)
@@ -410,20 +381,6 @@ namespace route_following_plugin
         default:
             throw std::invalid_argument("Invalid maneuver type");
         }
-    }
-
-    int RouteFollowingPlugin::findLaneletIndexFromPath(int target_id, const lanelet::routing::LaneletPath &path) const
-    {
-        for (size_t i = 0; i < path.size(); ++i)
-        {
-            if (path[i].id() == target_id)
-            {
-                return i;
-            }
-        }
-        ROS_DEBUG_STREAM("Returning -1 because could not find lanelet id" << target_id);
-
-        return -1;
     }
 
     cav_msgs::Maneuver RouteFollowingPlugin::composeLaneFollowingManeuverMessage(double start_dist, double end_dist, double start_speed, double target_speed, lanelet::Id lane_id) const

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -61,6 +61,7 @@ namespace route_following_plugin
 
         wml_->setMapCallback([this]() {
             if (wm_->getRoute()) { // If this map update occured after a route was provided we need to regenerate maneuvers
+                ROS_INFO_STREAM("Recomputing maneuvers due to map update");
                 this->latest_maneuver_plan_ = routeCb(wm_->getRoute()->shortestPath());
             }
         });

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -34,18 +34,6 @@
 
 namespace route_following_plugin
 {
-    
-    TEST(RouteFollowingPluginTest, testFindLaneletIndexFromPath)
-    {
-        RouteFollowingPlugin rfp;
-        lanelet::ConstLanelets lls;
-        lanelet::Lanelet ll;
-        ll.setId(15);
-        lls.push_back(ll);
-        lanelet::routing::LaneletPath path(lls);
-        EXPECT_EQ(0, rfp.findLaneletIndexFromPath(15, path));
-        EXPECT_EQ(-1, rfp.findLaneletIndexFromPath(5, path));
-    }
 
     TEST(RouteFollowingPluginTest, testComposeManeuverMessage)
     {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR does two things. 
First, it fixes a bug in carma_wm where the user defined map update callback would only trigger when an entirely new map was received. Now the callback will be triggered either when a new map is received or an update is applied successfully. 

Second, it uses this callback to trigger a maneuver regeneration in the route_following_plugin if a route is also available. The previous temporary logic to handle this case was also removed per discussion with @adev4a 

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1351
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working basic travel use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
build and unit testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
