### PR TITLE
Fix/route graph trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@
 # Stage 1 - Acquire the CARMA source as well as any extra packages
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastol/autoware.ai:latency_fix AS base-image
+FROM usdotfhwastoldev/autoware.ai:develop AS base-image
 
 FROM base-image AS source-code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@
 # Stage 1 - Acquire the CARMA source as well as any extra packages
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastoldev/autoware.ai:develop AS base-image
+FROM usdotfhwastol/autoware.ai:latency_fix AS base-image
 
 FROM base-image AS source-code
 

--- a/carma_wm/include/carma_wm/CARMAWorldModel.h
+++ b/carma_wm/include/carma_wm/CARMAWorldModel.h
@@ -58,8 +58,9 @@ public:
    *
    *  \param map A shared pointer to the map which will share ownership to this object
    *  \param map_version Optional field to set the map version. While this is technically optional its uses is highly advised to manage synchronization.
+   *  \param recompute_routing_graph Optional field which if true will result in the routing graph being recomputed. NOTE: If this map is the first map set the graph will always be recomputed
    */
-  void setMap(lanelet::LaneletMapPtr map, size_t map_version = 0);
+  void setMap(lanelet::LaneletMapPtr map, size_t map_version = 0, bool recompute_routing_graph = true);
 
   /*! \brief Set the current route. This route must match the current map for this class to function properly
    *

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -485,9 +485,13 @@ void CARMAWorldModel::setMap(lanelet::LaneletMapPtr map, size_t map_version, boo
   // If the routing graph should be updated then recompute it
   if (recompute_routing_graph) {
 
+    ROS_INFO_STREAM("Building routing graph");
+
     TrafficRulesConstPtr traffic_rules = *(getTrafficRules(lanelet::Participants::Vehicle));
     lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*semantic_map_, *traffic_rules);
     map_routing_graph_ = std::move(map_graph);
+
+    ROS_INFO_STREAM("Done building routing graph");
 
   }
 }

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -469,15 +469,27 @@ TrackPos CARMAWorldModel::getRouteEndTrackPos() const
   return p;
 }
 
-void CARMAWorldModel::setMap(lanelet::LaneletMapPtr map, size_t map_version)
+void CARMAWorldModel::setMap(lanelet::LaneletMapPtr map, size_t map_version, bool recompute_routing_graph)
 {
+  // If this is the first time the map has been set, then recompute the routing graph
+  if (!semantic_map_) {
+
+    ROS_INFO_STREAM("First time map is set in carma_wm. Routing graph will be recomputed reguardless of method inputs.");
+
+    recompute_routing_graph = true;
+  }
+
   semantic_map_ = map;
   map_version_ = map_version;
-  // Build routing graph from map
-  TrafficRulesConstPtr traffic_rules = *(getTrafficRules(lanelet::Participants::Vehicle));
+  
+  // If the routing graph should be updated then recompute it
+  if (recompute_routing_graph) {
 
-  lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*semantic_map_, *traffic_rules);
-  map_routing_graph_ = std::move(map_graph);
+    TrafficRulesConstPtr traffic_rules = *(getTrafficRules(lanelet::Participants::Vehicle));
+    lanelet::routing::RoutingGraphUPtr map_graph = lanelet::routing::RoutingGraph::build(*semantic_map_, *traffic_rules);
+    map_routing_graph_ = std::move(map_graph);
+
+  }
 }
 
 size_t CARMAWorldModel::getMapVersion() const 

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -185,8 +185,8 @@ void WMListenerWorker::mapUpdateCallback(const autoware_lanelet2_msgs::MapBinPtr
     }
   }
   
-  // set the map to set a new routing
-  world_model_->setMap(world_model_->getMutableMap(), current_map_version_);
+  // set the Map to trigger a new route graph construction if rerouting was required by the updates. 
+  world_model_->setMap(world_model_->getMutableMap(), current_map_version_, rerouting_flag_);
 
   
   ROS_INFO_STREAM("Finished Applying the Map Update with Geofence Id:" << gf_ptr->id_); 

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -251,6 +251,7 @@ private:
   std::unordered_set<lanelet::Lanelet> filterSuccessorLanelets(const std::unordered_set<lanelet::Lanelet>& possible_lanelets, const std::unordered_set<lanelet::Lanelet>& root_lanelets);
   lanelet::LaneletMapPtr base_map_;
   lanelet::LaneletMapPtr current_map_;
+  lanelet::routing::RoutingGraphUPtr current_routing_graph_; // Current map routing graph
   lanelet::Velocity config_limit;
   std::unordered_set<std::string>  checked_geofence_ids_;
   std::unordered_set<std::string>  generated_geofence_reqids_;

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -38,7 +38,7 @@ done
 cd ${dir}/src
 
 if [[ "$BRANCH" = "develop" ]]; then
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch test/platoon3
       git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
While testing Basic Travel use case at ACM it was observed that the vehicle appeared to lag heavily when the geofence message was received. Analysis of the log files indicated that this was due to the routing graph build triggered by map updates. This gave the following behavior:

- In carma_wm_ctrl. It takes 27 seconds for the geofence to be processed.
- In carma_wm, it takes 67 seconds for the update to be applied. These are really extreme times.

The reason this did not happen previously is not fully known, however, initial indications suggest it is due to map size. The ACM map is 6 times larger (number of lines) than the Summit Point map. This is substantially more geometry to be analyzed by the Lanelet2 system. 

This PR attempts to address this by only rebuilding the routing graph when it is actually required by the geofence. This should hopefully allow the Basic Travel use case to be conducted, though a more robust solution will be needed in the future. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1356
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Required for basic travel use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Has not been tested. This is a high priority blocking fix for continued testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
