### PR TITLE
fix for accurate platoon gap control

### DIFF
--- a/platooning_control/include/platoon_control_worker.hpp
+++ b/platooning_control/include/platoon_control_worker.hpp
@@ -75,6 +75,7 @@ namespace platoon_control
         double angVelCmd_ = 0;
         double desired_gap_ = ctrl_config.standStillHeadway;
         double actual_gap_ = 0.0;
+        bool last_cmd_set_ = false;
 
         PlatoonLeaderInfo platoon_leader;
 

--- a/platooning_control/src/platoon_control_worker.cpp
+++ b/platooning_control/src/platoon_control_worker.cpp
@@ -31,8 +31,13 @@ namespace platoon_control
     {
         double speed_cmd = 0;
         
-        // last speed command for smooth speed transition
-        lastCmdSpeed = currentSpeed;
+        if (!last_cmd_set_)
+        {
+            // last speed command for smooth speed transition
+            lastCmdSpeed = currentSpeed;
+            last_cmd_set_ = true;
+        }
+        
 
         PlatoonLeaderInfo leader = platoon_leader;
     	if(leader.staticId != "" && leader.staticId != ctrl_config.vehicle_id)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Platoonin last control command initialized as current speed, so enable speed transition and gap control more smooth.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
integration tested in Black Pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
