### PR TITLE
Fix typo in intersection_transit_maneuvering.cpp

### DIFF
--- a/intersection_transit_maneuvering/src/intersection_transit_maneuvering.cpp
+++ b/intersection_transit_maneuvering/src/intersection_transit_maneuvering.cpp
@@ -116,7 +116,7 @@ namespace intersection_transit_maneuvering
                 new_maneuver.lane_following_maneuver.parameters.maneuver_id = maneuver.intersection_transit_straight_maneuver.parameters.maneuver_id;
                 new_maneuver.lane_following_maneuver.parameters.planning_strategic_plugin = maneuver.intersection_transit_straight_maneuver.parameters.planning_strategic_plugin;
                 new_maneuver.lane_following_maneuver.parameters.planning_tactical_plugin = maneuver.intersection_transit_straight_maneuver.parameters.planning_tactical_plugin;
-                new_maneuver.lane_following_maneuver.parameters.neogition_type = maneuver.intersection_transit_straight_maneuver.parameters.neogition_type;
+                new_maneuver.lane_following_maneuver.parameters.negotiation_type = maneuver.intersection_transit_straight_maneuver.parameters.negotiation_type;
                 new_maneuver.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
 
                 new_maneuver.lane_following_maneuver.start_dist = maneuver.intersection_transit_straight_maneuver.start_dist;
@@ -139,7 +139,7 @@ namespace intersection_transit_maneuvering
                 new_maneuver.lane_following_maneuver.parameters.maneuver_id = maneuver.intersection_transit_left_turn_maneuver.parameters.maneuver_id;
                 new_maneuver.lane_following_maneuver.parameters.planning_strategic_plugin = maneuver.intersection_transit_left_turn_maneuver.parameters.planning_strategic_plugin;
                 new_maneuver.lane_following_maneuver.parameters.planning_tactical_plugin = maneuver.intersection_transit_left_turn_maneuver.parameters.planning_tactical_plugin;
-                new_maneuver.lane_following_maneuver.parameters.neogition_type = maneuver.intersection_transit_left_turn_maneuver.parameters.neogition_type;
+                new_maneuver.lane_following_maneuver.parameters.negotiation_type = maneuver.intersection_transit_left_turn_maneuver.parameters.negotiation_type;
                 new_maneuver.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
 
                 new_maneuver.lane_following_maneuver.start_dist = maneuver.intersection_transit_left_turn_maneuver.start_dist;
@@ -161,7 +161,7 @@ namespace intersection_transit_maneuvering
                 new_maneuver.lane_following_maneuver.parameters.maneuver_id = maneuver.intersection_transit_right_turn_maneuver.parameters.maneuver_id;
                 new_maneuver.lane_following_maneuver.parameters.planning_strategic_plugin = maneuver.intersection_transit_right_turn_maneuver.parameters.planning_strategic_plugin;
                 new_maneuver.lane_following_maneuver.parameters.planning_tactical_plugin = maneuver.intersection_transit_right_turn_maneuver.parameters.planning_tactical_plugin;
-                new_maneuver.lane_following_maneuver.parameters.neogition_type = maneuver.intersection_transit_right_turn_maneuver.parameters.neogition_type;
+                new_maneuver.lane_following_maneuver.parameters.negotiation_type = maneuver.intersection_transit_right_turn_maneuver.parameters.negotiation_type;
                 new_maneuver.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
 
                 new_maneuver.lane_following_maneuver.start_dist = maneuver.intersection_transit_right_turn_maneuver.start_dist;

--- a/platooning_strategic/src/platoon_strategic.cpp
+++ b/platooning_strategic/src/platoon_strategic.cpp
@@ -276,7 +276,7 @@ namespace platoon_strategic
     {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
-        maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::PLATOONING;
+        maneuver_msg.lane_following_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::PLATOONING;
         maneuver_msg.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_following_maneuver.parameters.planning_tactical_plugin = "PlatooningTacticalPlugin";
         maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = "PlatooningStrategicPlugin";

--- a/platooning_tactical_plugin/src/platooning_tactical_plugin.cpp
+++ b/platooning_tactical_plugin/src/platooning_tactical_plugin.cpp
@@ -72,7 +72,7 @@ bool PlatooningTacticalPlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryReques
   {
     if(req.maneuver_plan.maneuvers[i].type == cav_msgs::Maneuver::LANE_FOLLOWING)
     {
-      if (req.maneuver_plan.maneuvers[i].lane_following_maneuver.parameters.neogition_type != cav_msgs::ManeuverParameters::NO_NEGOTIATION)
+      if (req.maneuver_plan.maneuvers[i].lane_following_maneuver.parameters.negotiation_type != cav_msgs::ManeuverParameters::NO_NEGOTIATION)
       {
         maneuver_plan.push_back(req.maneuver_plan.maneuvers[i]);
         resp.related_maneuvers.push_back(i);
@@ -299,13 +299,13 @@ std::vector<PointSpeedPair> PlatooningTacticalPlugin::maneuvers_to_points(const 
       throw std::invalid_argument("Platooning tactical plugin does not support this maneuver type");
     }
 
-    if (manuever.lane_following_maneuver.parameters.neogition_type == cav_msgs::ManeuverParameters::NO_NEGOTIATION)
+    if (manuever.lane_following_maneuver.parameters.negotiation_type == cav_msgs::ManeuverParameters::NO_NEGOTIATION)
     {
       throw std::invalid_argument("NO_NEGOTIATION maneuver is not supported by this plugin");
     }
 
 
-    // if (manuever.lane_following_maneuver.parameters.neogition_type == cav_msgs::ManeuverParameters::PLATOONING)
+    // if (manuever.lane_following_maneuver.parameters.negotiation_type == cav_msgs::ManeuverParameters::PLATOONING)
     // {
     //   // TODO: start and end speed are floats, sp compare them with epsilon 
     //   // if ( manuever.lane_following_maneuver.start_speed != manuever.lane_following_maneuver.end_speed)

--- a/platooning_tactical_plugin/test/test_platooning_tactical_plugin_planning.cpp
+++ b/platooning_tactical_plugin/test/test_platooning_tactical_plugin_planning.cpp
@@ -80,7 +80,7 @@ TEST(PlatooningTacticalPluginTest, testPlanningCallback)
 
   cav_msgs::Maneuver maneuver;
   maneuver.type = cav_msgs::Maneuver::LANE_FOLLOWING;
-  maneuver.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::GENERAL_NEGOTIATION; 
+  maneuver.lane_following_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::GENERAL_NEGOTIATION; 
   maneuver.lane_following_maneuver.lane_id = 1200;
   maneuver.lane_following_maneuver.start_dist = 5.0;
   maneuver.lane_following_maneuver.start_time = ros::Time(0.0);
@@ -92,7 +92,7 @@ TEST(PlatooningTacticalPluginTest, testPlanningCallback)
 
   cav_msgs::Maneuver maneuver2;
   maneuver2.type = cav_msgs::Maneuver::LANE_FOLLOWING;
-  maneuver2.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::PLATOONING; 
+  maneuver2.lane_following_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::PLATOONING; 
   maneuver2.lane_following_maneuver.lane_id = 1200;
   maneuver2.lane_following_maneuver.start_dist = 14.98835712;
   maneuver2.lane_following_maneuver.start_speed = 6.7056;

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -199,7 +199,7 @@ namespace port_drayage_plugin
     {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::STOP_AND_WAIT;
-        maneuver_msg.stop_and_wait_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
+        maneuver_msg.stop_and_wait_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.stop_and_wait_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.stop_and_wait_maneuver.parameters.planning_tactical_plugin = "StopAndWaitPlugin";
         maneuver_msg.stop_and_wait_maneuver.parameters.planning_strategic_plugin = "PortDrayageWorkerPlugin";
@@ -217,7 +217,7 @@ namespace port_drayage_plugin
     {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
-        maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
+        maneuver_msg.lane_following_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_following_maneuver.parameters.planning_tactical_plugin = "InlaneCruisingPlugin";
         maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = "RouteFollowingPlugin";

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -388,7 +388,7 @@ namespace route_following_plugin
     {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_FOLLOWING;
-        maneuver_msg.lane_following_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
+        maneuver_msg.lane_following_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.lane_following_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_following_maneuver.parameters.planning_tactical_plugin = lanefollow_planning_tactical_plugin_;
         maneuver_msg.lane_following_maneuver.parameters.planning_strategic_plugin = planning_strategic_plugin_;
@@ -408,7 +408,7 @@ namespace route_following_plugin
     {
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::LANE_CHANGE;
-        maneuver_msg.lane_change_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
+        maneuver_msg.lane_change_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.lane_change_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.lane_change_maneuver.parameters.planning_tactical_plugin = lane_change_plugin_;
         maneuver_msg.lane_change_maneuver.parameters.planning_strategic_plugin = planning_strategic_plugin_;

--- a/route_following_plugin/test/test_route_following_plugin.cpp
+++ b/route_following_plugin/test/test_route_following_plugin.cpp
@@ -42,7 +42,7 @@ namespace route_following_plugin
         ros::Time current_time = ros::Time::now();
         auto msg = rfp.composeLaneFollowingManeuverMessage(1.0, 10.0, 0.9, 11.176, 2);
         EXPECT_EQ(cav_msgs::Maneuver::LANE_FOLLOWING, msg.type);
-        EXPECT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION, msg.lane_following_maneuver.parameters.neogition_type);
+        EXPECT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION, msg.lane_following_maneuver.parameters.negotiation_type);
         EXPECT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN, msg.lane_following_maneuver.parameters.presence_vector);
         EXPECT_EQ("InLaneCruisingPlugin", msg.lane_following_maneuver.parameters.planning_tactical_plugin);
         EXPECT_EQ("RouteFollowingPlugin", msg.lane_following_maneuver.parameters.planning_strategic_plugin);

--- a/stop_and_wait_plugin/test/test_stopandwait_plugin.cpp
+++ b/stop_and_wait_plugin/test/test_stopandwait_plugin.cpp
@@ -235,7 +235,7 @@ namespace stop_and_wait_plugin
         std::vector<cav_msgs::Maneuver> maneuvers_msg;  
         cav_msgs::Maneuver maneuver_msg;
         maneuver_msg.type = cav_msgs::Maneuver::STOP_AND_WAIT;
-        maneuver_msg.stop_and_wait_maneuver.parameters.neogition_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
+        maneuver_msg.stop_and_wait_maneuver.parameters.negotiation_type = cav_msgs::ManeuverParameters::NO_NEGOTIATION;
         maneuver_msg.stop_and_wait_maneuver.parameters.presence_vector = cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN;
         maneuver_msg.stop_and_wait_maneuver.parameters.planning_tactical_plugin = "StopandWaitPlugin";
         maneuver_msg.stop_and_wait_maneuver.parameters.planning_strategic_plugin = "RouteFollowingPlugin";


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
There is a typo in both carma-platform and carma-msgs where the ManeuverParameters.msg value "negotiation_type" is incorrectly spelled as "neogition_type" in multiple files.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/1371
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is to ensure that msg file values are correctly listed to avoid confusion.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
