### PR TITLE
Feature/arbitrator provided maneuver state

### DIFF
--- a/arbitrator/CMakeLists.txt
+++ b/arbitrator/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(arbitrator)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
@@ -29,6 +29,8 @@ find_package(catkin REQUIRED COMPONENTS
   cav_msgs
   cav_srvs
   roscpp
+  lanelet2_core
+  carma_wm
 )
 
 ## System dependencies are found with CMake's conventions
@@ -52,7 +54,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
    INCLUDE_DIRS include
 #  LIBRARIES arbitrator
-   CATKIN_DEPENDS carma_utils cav_msgs cav_srvs roscpp
+   CATKIN_DEPENDS carma_utils cav_msgs cav_srvs roscpp lanelet2_core carma_wm
 #  DEPENDS system_lib
 )
 

--- a/arbitrator/include/arbitrator.hpp
+++ b/arbitrator/include/arbitrator.hpp
@@ -23,6 +23,10 @@
 #include "planning_strategy.hpp"
 #include "capabilities_interface.hpp"
 #include <cav_msgs/GuidanceState.h>
+#include "vehicle_state.hpp"
+#include <carma_wm/WorldModel.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
 
 namespace arbitrator 
 {
@@ -45,6 +49,7 @@ namespace arbitrator
              * \param planning_strategy A planning strategy implementation for generating plans
              * \param min_plan_duration The minimum acceptable length of a plan
              * \param planning_frequency The frequency at which to generate high-level plans when engaged
+             * \param wm pointer to an inialized world model.
              */ 
             Arbitrator(ros::CARMANodeHandle *nh, 
                 ros::CARMANodeHandle *pnh, 
@@ -52,7 +57,8 @@ namespace arbitrator
                 CapabilitiesInterface *ci, 
                 PlanningStrategy &planning_strategy,
                 ros::Duration min_plan_duration,
-                ros::Rate planning_frequency):
+                ros::Rate planning_frequency,
+                carma_wm::WorldModelConstPtr wm):
                 sm_(sm),
                 nh_(nh),
                 pnh_(pnh),
@@ -60,7 +66,8 @@ namespace arbitrator
                 planning_strategy_(planning_strategy),
                 initialized_(false),
                 min_plan_duration_(min_plan_duration),
-                time_between_plans_(planning_frequency.expectedCycleTime()) {};
+                time_between_plans_(planning_frequency.expectedCycleTime()),
+                wm_(wm) {};
             
             /**
              * \brief Begin the operation of the arbitrator.
@@ -68,6 +75,19 @@ namespace arbitrator
              * Loops internally via ros::Duration sleeps and spins
              */
             void run();
+
+            /**
+             * \brief Callback for the pose subscriber, which will store latest pose locally
+             * \param msg Latest pose message
+             */
+            void pose_cb(const geometry_msgs::PoseStampedConstPtr& msg);
+
+            /**
+             * \brief Callback for the twist subscriber, which will store latest twist locally
+             * \param msg Latest twist message
+             */
+            void twist_cb(const geometry_msgs::TwistStampedConstPtr& msg);
+            
         protected:
             /**
              * \brief Function to be executed during the initial state of the Arbitrator
@@ -103,6 +123,9 @@ namespace arbitrator
             void guidance_state_cb(const cav_msgs::GuidanceState::ConstPtr& msg);
 
         private:
+            
+            VehicleState vehicle_state_; // The current state of the vehicle for populating planning requests
+
             ArbitratorStateMachine *sm_;
             ros::Publisher final_plan_pub_;
             ros::Subscriber guidance_state_sub_;
@@ -114,6 +137,8 @@ namespace arbitrator
             CapabilitiesInterface *capabilities_interface_;
             PlanningStrategy &planning_strategy_;
             bool initialized_;
+            carma_wm::WorldModelConstPtr wm_;
+
     };
 };
 

--- a/arbitrator/include/neighbor_generator.hpp
+++ b/arbitrator/include/neighbor_generator.hpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <cav_msgs/ManeuverPlan.h>
+#include "vehicle_state.hpp"
 
 namespace arbitrator
 {

--- a/arbitrator/include/neighbor_generator.hpp
+++ b/arbitrator/include/neighbor_generator.hpp
@@ -33,9 +33,11 @@ namespace arbitrator
              * \brief Generate the list of neighbors/children that a given node in the search graph
              *      expands to
              * \param plan The maneuver plan to expand upon
+             * \param initial_state The initial state of the vehicle at the start of plan. This will be provided to planners for specific use when plan is empty
+             *
              * \return A vector containing the new plans generated from it, if any
              */
-            virtual std::vector<cav_msgs::ManeuverPlan> generate_neighbors(cav_msgs::ManeuverPlan plan) const = 0;
+            virtual std::vector<cav_msgs::ManeuverPlan> generate_neighbors(cav_msgs::ManeuverPlan plan, const VehicleState& initial_state) const = 0;
 
             /**
              * \brief Virtual destructor provided for memory safety

--- a/arbitrator/include/planning_strategy.hpp
+++ b/arbitrator/include/planning_strategy.hpp
@@ -18,9 +18,11 @@
 #define __ARBITRATOR_INCLUDE_PLANNING_STRATEGY_HPP__
 
 #include <cav_msgs/ManeuverPlan.h>
+#include "vehicle_state.hpp"
 
 namespace arbitrator
 {
+
     /**
      * \brief Generic interface representing a strategy for arriving at a maneuver
      * plan
@@ -30,9 +32,12 @@ namespace arbitrator
         public:
             /**
              * \brief Generate a plausible maneuver plan
+             * 
+             * \param start_state The starting state of the vehicle to plan for
+             * 
              * \return A maneuver plan from the vehicle's current state
              */
-            virtual cav_msgs::ManeuverPlan generate_plan() = 0;
+            virtual cav_msgs::ManeuverPlan generate_plan(const VehicleState& start_state) = 0;
 
             /**
              * \brief Virtual destructor provided for memory safety

--- a/arbitrator/include/plugin_neighbor_generator.hpp
+++ b/arbitrator/include/plugin_neighbor_generator.hpp
@@ -46,9 +46,10 @@ namespace arbitrator
              * Generates a list of neighbor states for the given plan using 
              * the plugins available to the system
              * \param plan The plan that is the current search state
+             * \param initial_state The initial state of the vehicle at the start of plan. This will be provided to planners for specific use when plan is empty
              * \return A list of subsequent plans building on top of the input plan
              */
-            std::vector<cav_msgs::ManeuverPlan> generate_neighbors(cav_msgs::ManeuverPlan plan) const;
+            std::vector<cav_msgs::ManeuverPlan> generate_neighbors(cav_msgs::ManeuverPlan plan, const VehicleState& initial_state) const;
         private:
             T &ci_;
     };

--- a/arbitrator/include/plugin_neighbor_generator.hpp
+++ b/arbitrator/include/plugin_neighbor_generator.hpp
@@ -19,6 +19,7 @@
 
 #include "neighbor_generator.hpp"
 #include "capabilities_interface.hpp"
+#include "vehicle_state.hpp"
 
 namespace arbitrator
 {

--- a/arbitrator/include/plugin_neighbor_generator.tpp
+++ b/arbitrator/include/plugin_neighbor_generator.tpp
@@ -25,10 +25,21 @@
 namespace arbitrator
 {
     template <class T>
-    std::vector<cav_msgs::ManeuverPlan> PluginNeighborGenerator<T>::generate_neighbors(cav_msgs::ManeuverPlan plan) const
+    std::vector<cav_msgs::ManeuverPlan> PluginNeighborGenerator<T>::generate_neighbors(cav_msgs::ManeuverPlan plan, const VehicleState& initial_state) const
     {
         cav_srvs::PlanManeuvers msg;
+        // Set prior plan
         msg.request.prior_plan = plan;
+
+        // Set vehicle state at prior plan start
+        msg.request.header.frame_id = "map";
+        msg.request.header.stamp = initial_state.stamp;
+        msg.request.veh_x = initial_state.x;
+        msg.request.veh_y = initial_state.y;
+        msg.request.veh_downtrack = initial_state.downtrack;
+        msg.request.veh_logitudinal_velocity = initial_state.velocity;
+        msg.request.veh_lane_id = std::to_string(initial_state.lane_id);
+
         std::map<std::string, cav_srvs::PlanManeuvers> res = ci_.multiplex_service_call_for_capability(CapabilitiesInterface::STRATEGIC_PLAN_CAPABILITY, msg);
 
         // Convert map to vector of map values

--- a/arbitrator/include/tree_planner.hpp
+++ b/arbitrator/include/tree_planner.hpp
@@ -23,6 +23,7 @@
 #include "cost_function.hpp"
 #include "neighbor_generator.hpp"
 #include "search_strategy.hpp"
+#include "vehicle_state.hpp"
 
 namespace arbitrator
 {
@@ -57,8 +58,10 @@ namespace arbitrator
             /**
              * \brief Utilize the configured cost function, neighbor generator, 
              *      and search strategy, to generate a plan by means of tree search
+             * 
+             * \param start_state The starting state of the vehicle to plan for
              */
-            cav_msgs::ManeuverPlan generate_plan();
+            cav_msgs::ManeuverPlan generate_plan(const VehicleState& start_state);
         protected:
             CostFunction &cost_function_;
             NeighborGenerator &neighbor_generator_;

--- a/arbitrator/include/vehicle_state.hpp
+++ b/arbitrator/include/vehicle_state.hpp
@@ -1,0 +1,38 @@
+#ifndef __ARBITRATOR_INCLUDE_VEHICLE_STATE_HPP__
+#define __ARBITRATOR_INCLUDE_VEHICLE_STATE_HPP__
+
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <lanelet2_core/Forward.h>
+
+namespace arbitrator
+{
+/**
+ * \brief Struct defining the vehicle state required for maneuver planning
+ */
+struct VehicleState
+{
+  ros::Time stamp;                         // Time stamp of position data used to populate struct
+  double x = 0;                            // Vehicle x axis position in map frame (m)
+  double y = 0;                            // Vehicle y axis position in map frame (m)
+  double downtrack = 0;                    // Vehicle route downtrack (m)
+  double velocity = 0;                     // Vehicle logitudinal velocity
+  lanelet::Id lane_id = lanelet::InvalId;  // Vehicle lane id based on downtrack
+};
+}  // namespace arbitrator
+
+#endif  //__ARBITRATOR_INCLUDE_VEHICLE_STATE_HPP__

--- a/arbitrator/package.xml
+++ b/arbitrator/package.xml
@@ -20,6 +20,8 @@
   <depend>cav_msgs</depend>
   <depend>cav_srvs</depend>
   <depend>roscpp</depend>
+  <depend>lanelet2_core</depend>
+  <depend>carma_wm</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/arbitrator/src/arbitrator_node.cpp
+++ b/arbitrator/src/arbitrator_node.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <map>
 #include <string>
+#include <carma_wm/WorldModel.h>
+#include <carma_wm/WMListener.h>
 #include "arbitrator.hpp"
 #include "arbitrator_state_machine.hpp"
 #include "cost_system_cost_function.hpp"
@@ -65,6 +67,10 @@ int main(int argc, char** argv)
 
     double planning_frequency;
     pnh.param("planning_frequency", planning_frequency, 1.0);
+
+    carma_wm::WMListener wml;
+    auto wm = wml.getWorldModel();
+
     arbitrator::Arbitrator arbitrator{
         &nh, 
         &pnh, 
@@ -72,7 +78,11 @@ int main(int argc, char** argv)
         &ci, 
         tp, 
         ros::Duration(min_plan_duration),
-        ros::Rate(planning_frequency)};
+        ros::Rate(planning_frequency),
+        wm };
+
+    ros::Subscriber pose_sub = nh.subscribe("current_pose", 1, &arbitrator::Arbitrator::pose_cb, &arbitrator);
+    ros::Subscriber twist_sub = nh.subscribe("current_velocity", 1, &arbitrator::Arbitrator::twist_cb, &arbitrator);
 
     arbitrator.run();
 

--- a/arbitrator/src/tree_planner.cpp
+++ b/arbitrator/src/tree_planner.cpp
@@ -22,7 +22,7 @@
 
 namespace arbitrator
 {
-    cav_msgs::ManeuverPlan TreePlanner::generate_plan() 
+    cav_msgs::ManeuverPlan TreePlanner::generate_plan(const VehicleState& start_state) 
     {
         cav_msgs::ManeuverPlan root;
         std::vector<std::pair<cav_msgs::ManeuverPlan, double>> open_list;
@@ -57,7 +57,7 @@ namespace arbitrator
                 }
 
                 // Expand it, and reprioritize
-                std::vector<cav_msgs::ManeuverPlan> children = neighbor_generator_.generate_neighbors(cur_plan);
+                std::vector<cav_msgs::ManeuverPlan> children = neighbor_generator_.generate_neighbors(cur_plan, start_state);
                 
                 // Compute cost for each child and store in open list
                 for (auto child = children.begin(); child != children.end(); child++)

--- a/arbitrator/test/test_plugin_neighbor_generator.cpp
+++ b/arbitrator/test/test_plugin_neighbor_generator.cpp
@@ -68,7 +68,8 @@ namespace arbitrator
                     std::map<std::string, cav_srvs::PlanManeuvers>()));
 
         cav_msgs::ManeuverPlan plan;
-        std::vector<cav_msgs::ManeuverPlan> plans = png.generate_neighbors(plan);
+        VehicleState vs;
+        std::vector<cav_msgs::ManeuverPlan> plans = png.generate_neighbors(plan, vs);
 
         ASSERT_EQ(0, plans.size());
         ASSERT_TRUE(plans.empty());
@@ -92,7 +93,8 @@ namespace arbitrator
                     responses));
 
         cav_msgs::ManeuverPlan plan;
-        std::vector<cav_msgs::ManeuverPlan> plans = png.generate_neighbors(plan);
+        VehicleState vs;
+        std::vector<cav_msgs::ManeuverPlan> plans = png.generate_neighbors(plan, vs);
 
         ASSERT_FALSE(plans.empty());
         ASSERT_EQ(3, plans.size());

--- a/arbitrator/test/test_tree_planner.cpp
+++ b/arbitrator/test/test_tree_planner.cpp
@@ -17,6 +17,7 @@
 #include "test_utils.h"
 #include "tree_planner.hpp"
 #include <gmock/gmock.h>
+#include "vehicle_state.hpp"
 
 using ::testing::A;
 using ::testing::_;
@@ -48,7 +49,7 @@ namespace arbitrator
     class MockNeighborGenerator : public NeighborGenerator
     {
         public:
-            MOCK_CONST_METHOD1(generate_neighbors, std::vector<cav_msgs::ManeuverPlan>(cav_msgs::ManeuverPlan));
+            MOCK_CONST_METHOD2(generate_neighbors, std::vector<cav_msgs::ManeuverPlan>(cav_msgs::ManeuverPlan, const VehicleState&));
             ~MockNeighborGenerator(){};
     };
 
@@ -77,11 +78,11 @@ namespace arbitrator
 
         {
             InSequence seq;
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillOnce(
                     Return(plans)
                 );
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillRepeatedly(
                     Return(std::vector<cav_msgs::ManeuverPlan>())
                 );
@@ -97,7 +98,8 @@ namespace arbitrator
                 ReturnArg<0>()
             );
 
-        cav_msgs::ManeuverPlan plan = tp.generate_plan();
+        VehicleState state;
+        cav_msgs::ManeuverPlan plan = tp.generate_plan(state);
         ASSERT_FALSE(plan.maneuvers.empty());
         ASSERT_EQ(1, plan.maneuvers.size());
         ASSERT_EQ(ros::Time(0), plan.maneuvers[0].lane_following_maneuver.start_time);
@@ -128,11 +130,11 @@ namespace arbitrator
 
         {
             InSequence seq;
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillOnce(
                     Return(plans)
                 );
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillRepeatedly(
                     Return(std::vector<cav_msgs::ManeuverPlan>())
                 );
@@ -148,7 +150,8 @@ namespace arbitrator
                 ReturnArg<0>()
             );
 
-        cav_msgs::ManeuverPlan plan = tp.generate_plan();
+        VehicleState state;
+        cav_msgs::ManeuverPlan plan = tp.generate_plan(state);
         ASSERT_FALSE(plan.maneuvers.empty());
         ASSERT_EQ(1, plan.maneuvers.size());
         ASSERT_EQ(ros::Time(0), plan.maneuvers[0].lane_following_maneuver.start_time);
@@ -187,19 +190,19 @@ namespace arbitrator
 
         {
             InSequence seq;
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillOnce(
                     Return(plans1)
                 );
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillOnce(
                     Return(plans2)
                 );
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillOnce(
                     Return(plans3)
                 );
-            EXPECT_CALL(mng, generate_neighbors(_))
+            EXPECT_CALL(mng, generate_neighbors(_,_))
                 .WillRepeatedly(
                     Return(std::vector<cav_msgs::ManeuverPlan>())
                 );
@@ -215,7 +218,8 @@ namespace arbitrator
                 ReturnArg<0>()
             );
 
-        cav_msgs::ManeuverPlan plan = tp.generate_plan();
+        VehicleState state;
+        cav_msgs::ManeuverPlan plan = tp.generate_plan(state);
         ASSERT_FALSE(plan.maneuvers.empty());
         ASSERT_EQ(3, plan.maneuvers.size());
         ASSERT_EQ(ros::Time(0), plan.maneuvers[0].lane_following_maneuver.start_time);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the plan_maneuvers service call request to include the initial vehicle state at the start of planning. This state should be used by Strategic Plugins when the prior_plan is empty. The reasoning for this change is that currently all the Strategic Plugins contain duplicated code to get the current position/lane/velocity information in order to begin maneuver planning. This means its possible for two strategic plugins to returns plans starting from slightly offset locations based on call order. This will make sequencing plans difficult. This change should help resolve that by providing a fixed source of truth as well as reducing code duplication.

This PR should be merged after https://github.com/usdot-fhwa-stol/carma-msgs/pull/129 which contains the message spec change. 

Once this PR has been merged, I will update the existing strategic plugins (route_following, platooning, and workzone) to use this provided state for planning instead of duplicated callback methods. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1377
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
All arbitrator unit tests are passing. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
