### PR TITLE
Fix conditional for publishing No central line points warning in RouteGeneratorWorker (`noetic/develop`)

### DIFF
--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -357,7 +357,7 @@ namespace route {
 
         route_marker_msg_.markers={};
 
-        if (!points.empty())
+        if (points.empty())
         {
             ROS_WARN_STREAM("No central line points! Returning");
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR fixes the conditional surrounding the `No central line points! Returning` warning when the `RouteGeneratorWorker` publishes route visual markers. The conditional was backwards; it issued the warning when there are central points instead of when those points are missing.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1395 for the `noetic/develop` branch.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This warning did not affect any system behavior, but it did produce incorrect and confusing warnings.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The `route` node with the proposed fix was tested against a route known to have central line points. The warning was not issued on this route.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
