### PR TITLE
1387 - Update parameter strings for pose_to_tf

### DIFF
--- a/pose_to_tf/config/parameters.yaml
+++ b/pose_to_tf/config/parameters.yaml
@@ -1,2 +1,2 @@
-child_frame: = "base_link";
-default_parent_frame: = "map";
+child_frame: base_link
+default_parent_frame: map


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR fixes the string values for the frame IDs used in the `pose_to_tf` package. The previous string values contained extra characters that, when parsed, would result in incorrect frame IDs. The `base_link` frame ID would be parsed as `= "base_link";`, and the `map` frame would be `= "map";`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1387 for the `noetic-f1tenth/develop` branch.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The incorrect syntax would create unique, but incorrect, frame IDs and prevent the transform from being broadcast to the expected IDs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The proposed changes have been tested on the C1T vehicle.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
