### PR TITLE
Fix invalid build errors

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -24,12 +24,12 @@ source /opt/autoware.ai/ros/install/setup.bash --extend
 
 cd ~/carma_ws
 
-sudo mkdir /opt/carma # Create install directory
+sudo mkdir -p /opt/carma # Create install directory
 sudo chown carma /opt/carma # Set owner to expose permissions for build
 sudo chgrp carma /opt/carma # Set group to expose permissions for build
 
 echo "Building CARMA"
-
-colcon build --cmake-args --install --install-space /opt/carma/install -DCMAKE_BUILD_TYPE=Release
+# --packages-up-to traffic_incident_parser platoon_strategic
+colcon build --install-base /opt/carma/install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 echo "Build Complete"

--- a/platooning_strategic/CMakeLists.txt
+++ b/platooning_strategic/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 ###################################
 ## catkin specific configuration ##

--- a/platooning_strategic/include/platoon_manager.h
+++ b/platooning_strategic/include/platoon_manager.h
@@ -28,6 +28,7 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <autoware_msgs/ControlCommandStamped.h>
+#include <boost/format.hpp>
 
 
 

--- a/platooning_strategic/include/platoon_strategic.h
+++ b/platooning_strategic/include/platoon_strategic.h
@@ -26,6 +26,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/format.hpp>
 #include <carma_utils/CARMAUtils.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>

--- a/traffic_incident_parser/CMakeLists.txt
+++ b/traffic_incident_parser/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   lanelet2_core
 )
 
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -42,6 +44,7 @@ catkin_package(
 include_directories(
  include
   ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 add_executable(traffic_incident_parser_node src/main.cpp src/traffic_incident_parser_node.cpp)
@@ -50,7 +53,7 @@ add_library(traffic_incident_parser_worker_lib src/traffic_incident_parser_worke
 add_dependencies(traffic_incident_parser_worker_lib ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(traffic_incident_parser_node traffic_incident_parser_worker_lib ${catkin_LIBRARIES})
+target_link_libraries(traffic_incident_parser_node traffic_incident_parser_worker_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 #############
 ## Install ##
@@ -84,4 +87,4 @@ catkin_add_gmock(${PROJECT_NAME}-test
   test/test_traffic_parser.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
 )
-target_link_libraries(${PROJECT_NAME}-test traffic_incident_parser_worker_lib ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}-test traffic_incident_parser_worker_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/truck_inspection_client/CMakeLists.txt
+++ b/truck_inspection_client/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 ###################################
 ## catkin specific configuration ##

--- a/truck_inspection_client/include/truck_inspection_client.h
+++ b/truck_inspection_client/include/truck_inspection_client.h
@@ -23,7 +23,7 @@
 #include <cav_msgs/MobilityRequest.h>
 #include <cav_msgs/BSM.h>
 #include <std_msgs/String.h>
-#include "boost/format.hpp"
+#include <boost/format.hpp>
 #include <boost/chrono.hpp>
 #include <boost/thread/thread.hpp>
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Recent sync with 3.7 seems to have introduced some build errors in noetic/develop. This PR resolves them. 
The root cause was incorrectly imported Boost deps that were hidden by catkin_make. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Build testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
