### PR TITLE
Add vehicle status generator

### DIFF
--- a/vehicle_status_generator/CMakeLists.txt
+++ b/vehicle_status_generator/CMakeLists.txt
@@ -1,0 +1,102 @@
+#
+# Copyright (C) 2018-2021 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+cmake_minimum_required(VERSION 2.8.3)
+project(vehicle_status_generator)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++14)
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  cav_msgs
+  carma_utils
+  automotive_platform_msgs
+  geometry_msgs
+  pacmod_msgs
+  j2735_msgs
+  novatel_gps_msgs
+  wgs84_utils
+  lanelet2_extension
+  carma_wm
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  CATKIN_DEPENDS roscpp std_msgs cav_msgs carma_utils automotive_platform_msgs
+                 geometry_msgs pacmod_msgs j2735_msgs novatel_gps_msgs wgs84_utils lanelet2_extension carma_wm
+  DEPENDS Boost
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  include
+)
+
+file(GLOB_RECURSE headers */*.hpp */*.h)
+
+add_executable( ${PROJECT_NAME}
+  ${headers}
+  src/vehicle_status_generator.cpp
+  src/vehicle_status_generator_worker.cpp
+  src/main.cpp)
+add_library(vehicle_status_generator_worker_library src/vehicle_status_generator_worker.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+add_dependencies(vehicle_status_generator_worker_library ${catkin_EXPORTED_TARGETS})
+
+#############
+## Install ##
+#############
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Install C++
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Install Other Resources
+install(DIRECTORY launch config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+catkin_add_gmock(${PROJECT_NAME}-test test/test_vehicle_status_generator_worker.cpp)
+target_link_libraries(${PROJECT_NAME}-test vehicle_status_generator_worker_library ${catkin_LIBRARIES})

--- a/vehicle_status_generator/config/parameters.yaml
+++ b/vehicle_status_generator/config/parameters.yaml
@@ -1,0 +1,4 @@
+# The desired frequency for Mobility Operation generation
+vehicle_status_generation_frequency_: 10.0
+yield_max_deceleration: 1.0
+x_gap: 2.0

--- a/vehicle_status_generator/include/vehicle_status_generator.h
+++ b/vehicle_status_generator/include/vehicle_status_generator.h
@@ -52,7 +52,7 @@ namespace vehicle_status_generator
         // node handles
         std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
 
-        double yield_max_deceleration = 3.0;
+        double vehicle_deceleration_limit = 3.0;
 
         // worker class
         VehicleStatusGeneratorWorker worker;

--- a/vehicle_status_generator/include/vehicle_status_generator.h
+++ b/vehicle_status_generator/include/vehicle_status_generator.h
@@ -1,0 +1,96 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <boost/shared_ptr.hpp>
+#include <carma_utils/CARMAUtils.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <cav_msgs/BSM.h>
+#include <cav_msgs/MobilityOperation.h>
+#include <automotive_platform_msgs/VelocityAccelCov.h>
+#include <pacmod_msgs/YawRateRpt.h>
+#include <j2735_msgs/TransmissionState.h>
+#include <std_msgs/Float64.h>
+#include <wgs84_utils/wgs84_utils.h>
+#include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
+#include <lanelet2_extension/projection/local_frame_projector.h>
+#include <std_msgs/String.h>
+#include "vehicle_status_generator_worker.h"
+
+#include <carma_wm/WMListener.h>
+#include <carma_wm/WorldModel.h>
+
+namespace vehicle_status_generator
+{
+
+    class VehicleStatusGenerator
+    {
+
+    public:
+
+        VehicleStatusGenerator();
+
+        // general starting point of this node
+        void run();
+
+    private:
+
+        // node handles
+        std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
+
+        double yield_max_deceleration = 3.0;
+
+        // worker class
+        VehicleStatusGeneratorWorker worker;
+
+        // publisher for generated BSMs
+        ros::Publisher  vehicle_status_pub;
+
+        // subscribers for gathering data from the platform
+        ros::Subscriber speed_sub_;
+
+        // frequency for vehicle_status generation
+        double vehicle_status_generation_frequency_;
+
+        // size of the vehicle
+        double vehicle_length_, vehicle_width_;
+
+        // acceleration limit
+        double vehicle_acceleration_limit_;
+        
+        // minimum safety gap in m
+        double x_gap = 2.0;
+
+        // timer to run the bsm generation task
+        ros::Timer timer_;
+
+        // the Mobility Operation object that all subscribers make updates to
+        cav_msgs::MobilityOperation mo_;
+
+        double current_speed_;
+
+        // initialize this node
+        void initialize();
+
+        // callbacks for the subscribers
+        void speedCallback(const std_msgs::Float64ConstPtr& msg);
+
+        // callback for the timer
+        void generateMobilityOperation(const ros::TimerEvent& event);
+    };
+
+}

--- a/vehicle_status_generator/include/vehicle_status_generator_worker.h
+++ b/vehicle_status_generator/include/vehicle_status_generator_worker.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <ros/ros.h>
+#include <stdint.h>
+#include <algorithm>
+
+namespace vehicle_status_generator
+{
+    class VehicleStatusGeneratorWorker
+    {
+        public:
+            
+            VehicleStatusGeneratorWorker();
+            uint8_t getNextMsgCount();
+            std::vector<uint8_t> getMsgId(const ros::Time now);
+            uint16_t getSecMark(const ros::Time now);
+
+        private:
+
+            // variables for BSM generation
+            uint8_t msg_count_ {0};
+            int random_id_ {0};
+            ros::Time last_id_generation_time_;
+    };
+}

--- a/vehicle_status_generator/launch/vehicle_status_generator.launch
+++ b/vehicle_status_generator/launch/vehicle_status_generator.launch
@@ -1,0 +1,19 @@
+<!--
+  Copyright (C) 2018-2021 LEIDOS.
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+  This file is used to launch a ros wrapper of Autoware planner as a CARMA strategic plugin.
+-->
+<launch>
+    <rosparam command="load" file="$(find vehicle_status_generator)/config/parameters.yaml"/>
+    <node name="vehicle_status_generator" pkg="vehicle_status_generator" type="vehicle_status_generator"/>
+</launch>

--- a/vehicle_status_generator/package.xml
+++ b/vehicle_status_generator/package.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<!--  
+ Copyright (C) 2018-2021 LEIDOS.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+-->
+
+<package format="3">
+  <name>vehicle_status_generator</name>
+  <version>3.3.0</version>
+  <description>This generates BSM according to J2735 standard.</description>
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>cav_msgs</depend>
+  <depend>carma_utils</depend>
+  <depend>automotive_platform_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pacmod_msgs</depend>
+  <depend>j2735_msgs</depend>
+  <depend>novatel_gps_msgs</depend>
+  <depend>wgs84_utils</depend>
+  <depend>lanelet2_extension</depend>
+  <depend>carma_wm</depend>
+</package>

--- a/vehicle_status_generator/src/main.cpp
+++ b/vehicle_status_generator/src/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include "vehicle_status_generator.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "vehicle_status_generator");
+    vehicle_status_generator::VehicleStatusGenerator vsg;
+    vsg.run();
+    return 0;
+};

--- a/vehicle_status_generator/src/vehicle_status_generator.cpp
+++ b/vehicle_status_generator/src/vehicle_status_generator.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#include "vehicle_status_generator.h"
+
+namespace vehicle_status_generator
+{
+    VehicleStatusGenerator::VehicleStatusGenerator() : vehicle_status_generation_frequency_(10.0) {}
+
+    void VehicleStatusGenerator::initialize()
+    {
+        nh_.reset(new ros::CARMANodeHandle());
+        pnh_.reset(new ros::CARMANodeHandle("~"));
+        
+        pnh_->param<double>("vehicle_status_generation_frequency_", vehicle_status_generation_frequency_, 10.0);
+        nh_->param<double>("vehicle_length", vehicle_length_, 5.0);
+        nh_->param<double>("vehicle_width", vehicle_width_, 2.0);
+
+        nh_->param<double>("vehicle_acceleration_limit", vehicle_acceleration_limit_, 2.0);
+        nh_->param<double>("yield_max_deceleration", yield_max_deceleration, 2.0);
+        nh_->param<double>("x_gap", x_gap, 2.0);
+
+        vehicle_status_pub = nh_->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
+        timer_ = nh_->createTimer(ros::Duration(1.0 / vehicle_status_generation_frequency_), &VehicleStatusGenerator::generateMobilityOperation, this);
+        speed_sub_ = nh_->subscribe("vehicle_speed_cov", 1, &VehicleStatusGenerator::speedCallback, this);
+
+    }
+
+    void VehicleStatusGenerator::run()
+    {
+        initialize();
+        ros::CARMANodeHandle::spin();
+    }
+
+    void VehicleStatusGenerator::speedCallback(const std_msgs::Float64ConstPtr& msg)
+    {
+        current_speed_ = msg->data;
+    }
+
+    void VehicleStatusGenerator::generateMobilityOperation(const ros::TimerEvent& event)
+    {
+        mo_.header.timestamp = ros::Time::now().toNSec();
+        mo_.header.sender_bsm_id = std::string(reinterpret_cast<const char*>(&worker.getMsgId(ros::Time::now())[0]), worker.getMsgId(ros::Time::now()).size());
+        mo_.strategy_params = std::to_string(x_gap) + "," + std::to_string(vehicle_acceleration_limit_) + "," + std::to_string(yield_max_deceleration);
+
+        vehicle_status_pub.publish(mo_);
+    }
+}

--- a/vehicle_status_generator/src/vehicle_status_generator.cpp
+++ b/vehicle_status_generator/src/vehicle_status_generator.cpp
@@ -30,9 +30,9 @@ namespace vehicle_status_generator
         nh_->param<double>("vehicle_length", vehicle_length_, 5.0);
         nh_->param<double>("vehicle_width", vehicle_width_, 2.0);
 
-        nh_->param<double>("vehicle_acceleration_limit", vehicle_acceleration_limit_, 2.0);
-        nh_->param<double>("yield_max_deceleration", yield_max_deceleration, 2.0);
-        nh_->param<double>("x_gap", x_gap, 2.0);
+        nh_->param<double>("/vehicle_acceleration_limit", vehicle_acceleration_limit_, 2.0);
+        nh_->param<double>("/vehicle_deceleration_limit", vehicle_deceleration_limit, 2.0);
+        nh_->param<double>("/guidance/yield_plugin/x_gap", x_gap, 2.0);
 
         vehicle_status_pub = nh_->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
         timer_ = nh_->createTimer(ros::Duration(1.0 / vehicle_status_generation_frequency_), &VehicleStatusGenerator::generateMobilityOperation, this);
@@ -55,7 +55,7 @@ namespace vehicle_status_generator
     {
         mo_.header.timestamp = ros::Time::now().toNSec();
         mo_.header.sender_bsm_id = std::string(reinterpret_cast<const char*>(&worker.getMsgId(ros::Time::now())[0]), worker.getMsgId(ros::Time::now()).size());
-        mo_.strategy_params = std::to_string(x_gap) + "," + std::to_string(vehicle_acceleration_limit_) + "," + std::to_string(yield_max_deceleration);
+        mo_.strategy_params = std::to_string(x_gap) + "," + std::to_string(vehicle_acceleration_limit_) + "," + std::to_string(vehicle_deceleration_limit);
 
         vehicle_status_pub.publish(mo_);
     }

--- a/vehicle_status_generator/src/vehicle_status_generator_worker.cpp
+++ b/vehicle_status_generator/src/vehicle_status_generator_worker.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "vehicle_status_generator_worker.h"
+#include <stdlib.h>
+#include <ros/ros.h>
+#include <random>
+
+namespace vehicle_status_generator
+{
+    VehicleStatusGeneratorWorker::VehicleStatusGeneratorWorker() {}
+    
+    uint8_t VehicleStatusGeneratorWorker::getNextMsgCount()
+    {
+        uint8_t old_msg_count = msg_count_;
+        msg_count_++;
+        if(msg_count_ == 128)
+        {
+            msg_count_ = 0;
+        }
+        return old_msg_count;
+    }
+
+    std::vector<uint8_t> VehicleStatusGeneratorWorker::getMsgId(const ros::Time now)
+    {
+        std::vector<uint8_t> id(4);
+        // need to change ID every 5 mins
+        ros::Duration id_timeout(60 * 5);
+
+        std::default_random_engine generator;
+        std::uniform_int_distribution<int> dis(0,INT_MAX);
+
+        if(now - last_id_generation_time_ >= id_timeout)
+        {
+            random_id_ = dis(generator);
+            last_id_generation_time_ = now;
+        }
+        for(int i = 0; i < id.size(); ++i)
+        {
+            id[i] = random_id_ >> (8 * i);
+        }
+        return id;
+    }
+
+}

--- a/vehicle_status_generator/test/test_vehicle_status_generator_worker.cpp
+++ b/vehicle_status_generator/test/test_vehicle_status_generator_worker.cpp
@@ -43,17 +43,6 @@ TEST(VehicleStatusWorkerTest, testMsgId)
     EXPECT_TRUE(msgId2 != msgId3);
 }
 
-TEST(VehicleStatusWorkerTest, testSecMark)
-{
-    vehicle_status_generator::VehicleStatusGeneratorWorker worker;
-    ros::Time time1(10, 0);
-    EXPECT_EQ(10000, worker.getSecMark(time1));
-    ros::Time time2(70, 0);
-    EXPECT_EQ(10000, worker.getSecMark(time2));
-    ros::Time time3(71, 0);
-    EXPECT_EQ(11000, worker.getSecMark(time3));
-}
-
 // Run all the tests
 int main(int argc, char **argv)
 {

--- a/vehicle_status_generator/test/test_vehicle_status_generator_worker.cpp
+++ b/vehicle_status_generator/test/test_vehicle_status_generator_worker.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "vehicle_status_generator_worker.h"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+TEST(VehicleStatusWorkerTest, testMsgCount)
+{
+    vehicle_status_generator::VehicleStatusGeneratorWorker worker;
+    EXPECT_EQ(0, worker.getNextMsgCount());
+    for(int i = 1; i < 127; i++)
+    {
+        worker.getNextMsgCount();
+    }
+    EXPECT_EQ(127, worker.getNextMsgCount());
+    EXPECT_EQ(0, worker.getNextMsgCount());
+}
+
+TEST(VehicleStatusWorkerTest, testMsgId)
+{
+    vehicle_status_generator::VehicleStatusGeneratorWorker worker;
+    ros::Time time1(10, 0);
+    std::vector<uint8_t> msgId1 = worker.getMsgId(time1);
+    ros::Time time2(11, 0);
+    std::vector<uint8_t> msgId2 = worker.getMsgId(time2);
+    ros::Time time3(310, 0);
+    std::vector<uint8_t> msgId3 = worker.getMsgId(time3);
+    EXPECT_TRUE(msgId1 == msgId2);
+    EXPECT_TRUE(msgId2 != msgId3);
+}
+
+TEST(VehicleStatusWorkerTest, testSecMark)
+{
+    vehicle_status_generator::VehicleStatusGeneratorWorker worker;
+    ros::Time time1(10, 0);
+    EXPECT_EQ(10000, worker.getSecMark(time1));
+    ros::Time time2(70, 0);
+    EXPECT_EQ(10000, worker.getSecMark(time2));
+    ros::Time time3(71, 0);
+    EXPECT_EQ(11000, worker.getSecMark(time3));
+}
+
+// Run all the tests
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
As CARMA Platform on a vehicle entering an unsignalized intersection, I want to broadcast my status as an Entering Vehicle so that other vehicles can estimate and plan their stopping trajectories.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
