### PR TITLE
Add logic to publish group id and intersection ids

### DIFF
--- a/carma_wm/include/carma_wm/WMListener.h
+++ b/carma_wm/include/carma_wm/WMListener.h
@@ -24,6 +24,7 @@
 #include <carma_utils/CARMAUtils.h>
 #include <autoware_lanelet2_msgs/MapBin.h>
 #include <queue>
+#include <geometry_msgs/PoseStamped.h>
 
 namespace carma_wm
 {
@@ -123,6 +124,7 @@ public:
 private:
   // Callback function that uses lock to edit the map
   void mapUpdateCallback(const autoware_lanelet2_msgs::MapBinPtr& geofence_msg);
+  void currentLocationCallback(const geometry_msgs::PoseStamped& current_pos);
   ros::Subscriber roadway_objects_sub_;
   ros::Subscriber map_update_sub_;
   std::unique_ptr<WMListenerWorker> worker_;
@@ -133,7 +135,7 @@ private:
   ros::Subscriber route_sub_;
   ros::Subscriber traffic_spat_sub_;
   ros::Subscriber curr_location_sub_;
-  ros::Publisher control_msg_pub_;
+  ros::Publisher intersection_group_ids_pub_;
   const bool multi_threaded_;
   std::mutex mw_mutex_;
   

--- a/carma_wm/include/carma_wm/WMListener.h
+++ b/carma_wm/include/carma_wm/WMListener.h
@@ -132,6 +132,8 @@ private:
   ros::Subscriber map_sub_;
   ros::Subscriber route_sub_;
   ros::Subscriber traffic_spat_sub_;
+  ros::Subscriber curr_location_sub_;
+  ros::Publisher control_msg_pub_;
   const bool multi_threaded_;
   std::mutex mw_mutex_;
   

--- a/carma_wm/include/carma_wm/WorldModelUtils.h
+++ b/carma_wm/include/carma_wm/WorldModelUtils.h
@@ -115,6 +115,13 @@ namespace utils
  */
 uint32_t get32BitId(uint16_t intersection_id, uint8_t signal_group_id);
 
+struct InterGroupIds_t{
+  uint16_t intersection_id;
+  uint8_t  group_id;
+};
+
+InterGroupIds_t* getInterGroupIdsByLightRegId(uint32_t light_reg_id);
+
 }  // namespace utils
 
 }  // namespace carma_wm

--- a/carma_wm/src/WMListener.cpp
+++ b/carma_wm/src/WMListener.cpp
@@ -90,10 +90,7 @@ void WMListener::currentLocationCallback(const geometry_msgs::PoseStamped& curre
   std_msgs::Int32MultiArray intersection_group_ids = worker_->getIntersectionGroupIdsByCurLoc(current_pos);
 
   //If the intersection_group_ids has data, publishing intersection/group ids
-  if(intersection_group_ids)
-  {
-    intersection_group_ids_pub_.publish(intersection_group_ids);
-  }
+  intersection_group_ids_pub_.publish(intersection_group_ids);
 }
 
 void WMListener::setMapCallback(std::function<void()> callback)

--- a/carma_wm/src/WMListener.cpp
+++ b/carma_wm/src/WMListener.cpp
@@ -37,6 +37,7 @@ WMListener::WMListener(bool multi_thread) : worker_(std::unique_ptr<WMListenerWo
   route_sub_ = nh_.subscribe("route", 1, &WMListenerWorker::routeCallback, worker_.get());
   roadway_objects_sub_ = nh_.subscribe("roadway_objects", 1, &WMListenerWorker::roadwayObjectListCallback, worker_.get());
   traffic_spat_sub_ = nh_.subscribe("incoming_spat", 10, &WMListenerWorker::incomingSpatCallback, worker_.get());
+  curr_location_sub_ = cnh_.subscribe("current_pose", 1,&WMListenerWorker::currentLocationCallback, worker_.get());
 
   double cL;
   nh2_.getParam("/config_speed_limit", cL);

--- a/carma_wm/src/WMListener.cpp
+++ b/carma_wm/src/WMListener.cpp
@@ -88,8 +88,6 @@ void WMListener::mapUpdateCallback(const autoware_lanelet2_msgs::MapBinPtr& geof
 void WMListener::currentLocationCallback(const geometry_msgs::PoseStamped& current_pos)
 {
   std_msgs::Int32MultiArray intersection_group_ids = worker_->getIntersectionGroupIdsByCurLoc(current_pos);
-
-  //If the intersection_group_ids has data, publishing intersection/group ids
   intersection_group_ids_pub_.publish(intersection_group_ids);
 }
 

--- a/carma_wm/src/WMListener.cpp
+++ b/carma_wm/src/WMListener.cpp
@@ -38,6 +38,7 @@ WMListener::WMListener(bool multi_thread) : worker_(std::unique_ptr<WMListenerWo
   roadway_objects_sub_ = nh_.subscribe("roadway_objects", 1, &WMListenerWorker::roadwayObjectListCallback, worker_.get());
   traffic_spat_sub_ = nh_.subscribe("incoming_spat", 10, &WMListenerWorker::incomingSpatCallback, worker_.get());
   curr_location_sub_ = cnh_.subscribe("current_pose", 1,&WMListenerWorker::currentLocationCallback, worker_.get());
+  intersection_group_ids_pub_ = nh_.advertise<std_msgs::Int32MultiArray>("intersection_signal_group_ids", 1, true);
 
   double cL;
   nh2_.getParam("/config_speed_limit", cL);

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -429,6 +429,30 @@ double WMListenerWorker::getConfigSpeedLimit() const
   return config_speed_limit_;
 }
 
+void WMListenerWorker::currentLocationCallback(const geometry_msgs::PoseStamped& current_pos)
+{  
+  const lanelet::BasicPoint2d cur_loc;
+  cur_loc.x() = current_pos.pose.position.x;
+  cur_loc.y() = current_pos.pose.position.y;
 
+  std::vector<lanelet::CarmaTrafficLightPtr> light_v = world_model_->getLightsAlongRoute(cur_loc);
+  lanelet::CarmaTrafficLightPtr first_light = light_v.front();
+  ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
+  
+  for( const auto& ligth_id_m : traffic_light_ids_ ) 
+  {
+        std::cout << "Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]\n";
+        if(ligth_id_m.second == first_light->id() )
+        {
+            ROS_DEBUG_STREAM("CURRENT Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]"));
+            ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
+            uint32_t temp = ligth_id_m.first;
+            //get intersection id and group id
+            unit8_t group_id = (uint8_t)(temp >> 0);
+            unit16_t intersection_id = (unit16_t)(temp >> 8);
+            ROS_DEBUG_STREAM("Intersection id:[" << intersection_id << "] Groupd id:[" << group_id << "]"));
+        }
+    }
+}
 
 }  // namespace carma_wm

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -429,37 +429,42 @@ double WMListenerWorker::getConfigSpeedLimit() const
   return config_speed_limit_;
 }
 
-void WMListenerWorker::currentLocationCallback(const geometry_msgs::PoseStamped& current_pos)
+std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(const geometry_msgs::PoseStamped& current_pos)
 {  
-  const lanelet::BasicPoint2d cur_loc;
+  //Get all traffic light regulatory elements along the route based on current SV position
+  lanelet::BasicPoint2d cur_loc;
   cur_loc.x() = current_pos.pose.position.x;
   cur_loc.y() = current_pos.pose.position.y;
-
   std::vector<lanelet::CarmaTrafficLightPtr> light_v = world_model_->getLightsAlongRoute(cur_loc);
   lanelet::CarmaTrafficLightPtr first_light = light_v.front();
   ROS_DEBUG_STREAM("Get Value TF_LIGHT of Id: " << first_light->id());
   
-  for(const auto& ligth_id_m : traffic_light_ids_ ) 
+  /**
+   * Iterate all elements in the map (The traffic light regulatory element Ids and intersection/group ids mapping). 
+   * Return the intersection/group id that map to the first traffic light regulatory element Id along the subject vehicle route
+  ***/
+  for(const auto& ligth_id_m : world_model_->traffic_light_ids_ ) 
   {
         std::cout << "Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]\n";
-        if(ligth_id_m.second == first_light->id() )
+        if( ligth_id_m.second == first_light->id() )
         {
-            ROS_DEBUG_STREAM("CURRENT Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]"));
+            ROS_DEBUG_STREAM("CURRENT Key:" << ligth_id_m.first << "Value:" << ligth_id_m.second);
             ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
             uint32_t temp = ligth_id_m.first;
             //get intersection id and group id
             unsigned group_id = (temp & 0xFF);
             unsigned intersection_id = (temp >> 8);
-            ROS_DEBUG_STREAM("Intersection id:[" << intersection_id << "] Groupd id:[" << group_id << "]"));
+            ROS_DEBUG_STREAM("Intersection id: " << intersection_id << " Groupd id:" << group_id);
             
             std_msgs::Int32MultiArray intersection_group_ids;
             intersection_group_ids.data[0] = intersection_id;
             intersection_group_ids.data[1] = intersection_id;
-
-            //publish intersection and group ids
-            intersection_group_ids_pub_.publish(intersection_group_ids);
+            return intersection_group_ids;            
         }
     }
+
+    //If no traffic light match the approaching traffic light for the SV, return NULL to indicate no traffic light
+    return NULL;
 }
 
 }  // namespace carma_wm

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -436,35 +436,38 @@ std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(cons
   cur_loc.x() = current_pos.pose.position.x;
   cur_loc.y() = current_pos.pose.position.y;
   std::vector<lanelet::CarmaTrafficLightPtr> light_v = world_model_->getLightsAlongRoute(cur_loc);
-  lanelet::CarmaTrafficLightPtr first_light = light_v.front();
-  ROS_DEBUG_STREAM("Get Value TF_LIGHT of Id: " << first_light->id());
-  
-  /**
-   * Iterate all elements in the map (The traffic light regulatory element Ids and intersection/group ids mapping). 
-   * Return the intersection/group id that map to the first traffic light regulatory element Id along the subject vehicle route
-  ***/
-  for(const auto& ligth_id_m : world_model_->traffic_light_ids_ ) 
+  if(!light_v.empty())
   {
-        std::cout << "Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]\n";
-        if( ligth_id_m.second == first_light->id() )
-        {
-            ROS_DEBUG_STREAM("CURRENT Key:" << ligth_id_m.first << "Value:" << ligth_id_m.second);
-            ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
-            uint32_t temp = ligth_id_m.first;
-            //get intersection id and group id
-            unsigned group_id = (temp & 0xFF);
-            unsigned intersection_id = (temp >> 8);
-            ROS_DEBUG_STREAM("Intersection id: " << intersection_id << " Groupd id:" << group_id);
-            
-            std_msgs::Int32MultiArray intersection_group_ids;
-            intersection_group_ids.data[0] = intersection_id;
-            intersection_group_ids.data[1] = group_id;
-            return intersection_group_ids;            
+      lanelet::CarmaTrafficLightPtr first_light = light_v.front();
+      ROS_DEBUG_STREAM("Get Value TF_LIGHT of Id: " << first_light->id());
+  
+      /**
+       * Iterate all elements in the map (The traffic light regulatory element Ids and intersection/group ids mapping). 
+       * Return the intersection/group id that map to the first traffic light regulatory element Id along the subject vehicle route
+      ***/
+      for(const auto& ligth_id_m : world_model_->traffic_light_ids_ ) 
+      {
+            std::cout << "Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]\n";
+            if( ligth_id_m.second == first_light->id() )
+            {
+                ROS_DEBUG_STREAM("CURRENT Key:" << ligth_id_m.first << "Value:" << ligth_id_m.second);
+                ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
+                uint32_t temp = ligth_id_m.first;
+                //get intersection id and group id
+                unsigned group_id = (temp & 0xFF);
+                unsigned intersection_id = (temp >> 8);
+                ROS_DEBUG_STREAM("Intersection id: " << intersection_id << " Groupd id:" << group_id);
+                
+                std_msgs::Int32MultiArray intersection_group_ids;
+                intersection_group_ids.data[0] = intersection_id;
+                intersection_group_ids.data[1] = group_id;
+                return intersection_group_ids;            
+            }
         }
-    }
+  }  
 
-    //If no traffic light match the approaching traffic light for the SV, return NULL to indicate no traffic light
-    return NULL;
+  //If no traffic light match the approaching traffic light for the SV, return NULL to indicate no traffic light
+  return NULL;
 }
 
 }  // namespace carma_wm

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -458,7 +458,7 @@ std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(cons
             
             std_msgs::Int32MultiArray intersection_group_ids;
             intersection_group_ids.data[0] = intersection_id;
-            intersection_group_ids.data[1] = intersection_id;
+            intersection_group_ids.data[1] = group_id;
             return intersection_group_ids;            
         }
     }

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -459,7 +459,7 @@ std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(cons
                 ROS_DEBUG_STREAM("Intersection id: " << InterGroupIds->intersection_id << " Groupd id:" << InterGroupIds->group_id);
                 intersection_group_ids.data[0] = InterGroupIds->intersection_id;
                 intersection_group_ids.data[1] = InterGroupIds->group_id;
-                delete InterGroupIds;                                      
+                free(InterGroupIds);                                      
             }
         }
   }    

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -431,6 +431,9 @@ double WMListenerWorker::getConfigSpeedLimit() const
 
 std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(const geometry_msgs::PoseStamped& current_pos)
 {  
+  
+  std_msgs::Int32MultiArray intersection_group_ids;
+
   //Get all traffic light regulatory elements along the route based on current SV position
   lanelet::BasicPoint2d cur_loc;
   cur_loc.x() = current_pos.pose.position.x;
@@ -451,23 +454,16 @@ std_msgs::Int32MultiArray WMListenerWorker::getIntersectionGroupIdsByCurLoc(cons
             if( ligth_id_m.second == first_light->id() )
             {
                 ROS_DEBUG_STREAM("CURRENT Key:" << ligth_id_m.first << "Value:" << ligth_id_m.second);
-                ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
                 uint32_t temp = ligth_id_m.first;
-                //get intersection id and group id
-                unsigned group_id = (temp & 0xFF);
-                unsigned intersection_id = (temp >> 8);
-                ROS_DEBUG_STREAM("Intersection id: " << intersection_id << " Groupd id:" << group_id);
-                
-                std_msgs::Int32MultiArray intersection_group_ids;
-                intersection_group_ids.data[0] = intersection_id;
-                intersection_group_ids.data[1] = group_id;
-                return intersection_group_ids;            
+                carma_wm::utils::InterGroupIds_t* InterGroupIds = carma_wm::utils::getInterGroupIdsByLightRegId(temp);                
+                ROS_DEBUG_STREAM("Intersection id: " << InterGroupIds->intersection_id << " Groupd id:" << InterGroupIds->group_id);
+                intersection_group_ids.data[0] = InterGroupIds->intersection_id;
+                intersection_group_ids.data[1] = InterGroupIds->group_id;
+                delete InterGroupIds;                                      
             }
         }
-  }  
-
-  //If no traffic light match the approaching traffic light for the SV, return NULL to indicate no traffic light
-  return NULL;
+  }    
+  return intersection_group_ids; 
 }
 
 }  // namespace carma_wm

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -437,9 +437,9 @@ void WMListenerWorker::currentLocationCallback(const geometry_msgs::PoseStamped&
 
   std::vector<lanelet::CarmaTrafficLightPtr> light_v = world_model_->getLightsAlongRoute(cur_loc);
   lanelet::CarmaTrafficLightPtr first_light = light_v.front();
-  ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
+  ROS_DEBUG_STREAM("Get Value TF_LIGHT of Id: " << first_light->id());
   
-  for( const auto& ligth_id_m : traffic_light_ids_ ) 
+  for(const auto& ligth_id_m : traffic_light_ids_ ) 
   {
         std::cout << "Key:[" << ligth_id_m.first << "] Value:[" << ligth_id_m.second << "]\n";
         if(ligth_id_m.second == first_light->id() )
@@ -448,9 +448,16 @@ void WMListenerWorker::currentLocationCallback(const geometry_msgs::PoseStamped&
             ROS_DEBUG_STREAM("Get First TF_LIGHT of Id: " << first_light->id());
             uint32_t temp = ligth_id_m.first;
             //get intersection id and group id
-            unit8_t group_id = (uint8_t)(temp >> 0);
-            unit16_t intersection_id = (unit16_t)(temp >> 8);
+            unsigned group_id = (temp & 0xFF);
+            unsigned intersection_id = (temp >> 8);
             ROS_DEBUG_STREAM("Intersection id:[" << intersection_id << "] Groupd id:[" << group_id << "]"));
+            
+            std_msgs::Int32MultiArray intersection_group_ids;
+            intersection_group_ids.data[0] = intersection_id;
+            intersection_group_ids.data[1] = intersection_id;
+
+            //publish intersection and group ids
+            intersection_group_ids_pub_.publish(intersection_group_ids);
         }
     }
 }

--- a/carma_wm/src/WMListenerWorker.h
+++ b/carma_wm/src/WMListenerWorker.h
@@ -24,6 +24,7 @@
 #include <cav_msgs/SPAT.h>
 #include "std_msgs/Int32MultiArray.h"
 #include "geometry_msgs/PoseStamped.h"
+#include <carma_wm/WorldModelUtils.h>
 
 namespace carma_wm
 {

--- a/carma_wm/src/WMListenerWorker.h
+++ b/carma_wm/src/WMListenerWorker.h
@@ -22,6 +22,8 @@
 #include <carma_wm/TrafficControl.h>
 #include <queue>
 #include <cav_msgs/SPAT.h>
+#include "std_msgs/Int32MultiArray.h"
+#include "geometry_msgs/PoseStamped.h"
 
 namespace carma_wm
 {
@@ -110,9 +112,9 @@ public:
   void incomingSpatCallback(const cav_msgs::SPAT& spat_msg);
 
   /***
-   * \brief Current vehicle location 
+   * \brief Get the approaching intersection id and group id based on current vehicle location 
    */
-  void currentLocationCallback(const geometry_msgs::PoseStamped& current_pos);
+  std_msgs::Int32MultiArray getIntersectionGroupIdsByCurLoc(const geometry_msgs::PoseStamped& current_pos);
 
 private:
   std::shared_ptr<CARMAWorldModel> world_model_;

--- a/carma_wm/src/WMListenerWorker.h
+++ b/carma_wm/src/WMListenerWorker.h
@@ -109,6 +109,11 @@ public:
 */
   void incomingSpatCallback(const cav_msgs::SPAT& spat_msg);
 
+  /***
+   * \brief Current vehicle location 
+   */
+  void currentLocationCallback(const geometry_msgs::PoseStamped& current_pos);
+
 private:
   std::shared_ptr<CARMAWorldModel> world_model_;
   std::function<void()> map_callback_;

--- a/carma_wm/src/WorldModelUtils.cpp
+++ b/carma_wm/src/WorldModelUtils.cpp
@@ -126,6 +126,15 @@ uint32_t get32BitId(uint16_t intersection_id, uint8_t signal_group_id)
   return temp;
 }
 
+InterGroupIds_t* getInterGroupIdsByLightRegId(uint32_t light_reg_id)
+{
+  intersection_t* InterGroupIds = (intersection_t*) malloc(sizeof(intersection_t));
+  unsigned group_id = (light_reg_id & 0xFF);
+  unsigned intersection_id = (light_reg_id >> 8);
+  InterGroupIds->intersection_id = (uint16_t)intersection_id;
+  InterGroupIds->group_id = (uint8_t)group_id;
+  return InterGroupIds;
+}
 
 } // namespace utils
 }  // namespace carma_wm

--- a/carma_wm/src/WorldModelUtils.cpp
+++ b/carma_wm/src/WorldModelUtils.cpp
@@ -128,7 +128,7 @@ uint32_t get32BitId(uint16_t intersection_id, uint8_t signal_group_id)
 
 InterGroupIds_t* getInterGroupIdsByLightRegId(uint32_t light_reg_id)
 {
-  intersection_t* InterGroupIds = (intersection_t*) malloc(sizeof(intersection_t));
+  InterGroupIds_t* InterGroupIds = (InterGroupIds_t*) malloc(sizeof(InterGroupIds_t));
   unsigned group_id = (light_reg_id & 0xFF);
   unsigned intersection_id = (light_reg_id >> 8);
   InterGroupIds->intersection_id = (uint16_t)intersection_id;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Added logic to get the traffic light regulatory element that is relevant to the SV. Publishing the relevant intersection and group ids for SV web UI to display the correct traffic signal phase.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1420
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
WorkZone use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
N/A
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
