### PR TITLE
Incorrect steering at the end of cooperative lanechange

### DIFF
--- a/cooperative_lanechange/src/cooperative_lanechange.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange.cpp
@@ -820,8 +820,6 @@ namespace cooperative_lanechange
 
         int total_points = std::min(centerline_start_lane.size(), centerline_end_lane.size());
         double delta_step = 1.0/(total_points - 1);
-        
-        ROS_DEBUG_STREAM(">>>>>> Creating lanechange geom");
 
         for(int i=0; i<total_points;i++){ // start from 1 as star_lane_pt is included
             lanelet::BasicPoint2d current_position;
@@ -832,10 +830,7 @@ namespace cooperative_lanechange
             current_position.y() = end_lane_pt.y()*delta + (1-delta)* start_lane_pt.y();
 
             centerline_points.push_back(current_position);
-            ROS_DEBUG_STREAM("current_position x: " << current_position.x() << ", y: " << current_position.y());
-        }
-        ROS_DEBUG_STREAM(">>>>>> Ended lanechange geom");
-        
+        }        
 
         std::unique_ptr<smoothing::SplineI> fit_curve = compute_fit(centerline_points);
         if(!fit_curve)

--- a/cooperative_lanechange/src/cooperative_lanechange.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange.cpp
@@ -819,11 +819,11 @@ namespace cooperative_lanechange
         double dist = sqrt(pow((end_lane_pt.x() - start_lane_pt.x()),2) + pow((end_lane_pt.y() - start_lane_pt.y()),2));
 
         int total_points = std::min(centerline_start_lane.size(), centerline_end_lane.size());
-        double delta_step = 1.0/total_points;
+        double delta_step = 1.0/(total_points - 1);
+        
+        ROS_DEBUG_STREAM(">>>>>> Creating lanechange geom");
 
-        centerline_points.push_back(start_lane_pt);
-
-        for(int i=1;i<total_points;i++){ // start from 1 as star_lane_pt is included
+        for(int i=0; i<total_points;i++){ // start from 1 as star_lane_pt is included
             lanelet::BasicPoint2d current_position;
             start_lane_pt = centerline_start_lane[i];
             end_lane_pt = centerline_end_lane[i];
@@ -832,9 +832,10 @@ namespace cooperative_lanechange
             current_position.y() = end_lane_pt.y()*delta + (1-delta)* start_lane_pt.y();
 
             centerline_points.push_back(current_position);
+            ROS_DEBUG_STREAM("current_position x: " << current_position.x() << ", y: " << current_position.y());
         }
-
-        centerline_points.push_back(centerline_end_lane.back()); 
+        ROS_DEBUG_STREAM(">>>>>> Ended lanechange geom");
+        
 
         std::unique_ptr<smoothing::SplineI> fit_curve = compute_fit(centerline_points);
         if(!fit_curve)

--- a/cooperative_lanechange/src/cooperative_lanechange.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange.cpp
@@ -821,7 +821,7 @@ namespace cooperative_lanechange
         int total_points = std::min(centerline_start_lane.size(), centerline_end_lane.size());
         double delta_step = 1.0/(total_points - 1);
 
-        for(int i=0; i<total_points;i++){ // start from 1 as star_lane_pt is included
+        for(int i=0; i<total_points;i++){
             lanelet::BasicPoint2d current_position;
             start_lane_pt = centerline_start_lane[i];
             end_lane_pt = centerline_end_lane[i];

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -9,8 +9,8 @@ Carma-platform release version 3.7.1 is a hotfix release for 3.7.0.
 
 Fixes in this release:
 -	Issue 1426: Route Following Plugin can seg fault in the presence of a lane change after a reroute.
--	Issue 1347: Rerouting triggered multiple time from TIM geofence.
-
+-	Issue 1427: Rerouting triggered multiple time from TIM geofence.
+-	Issue 1428: Excessive steering during lane change along curve at ACM 
 
 Version 3.7.0, released Aug 10th, 2021
 ----------------------------------------


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
At the end of lanechange (made by cooperative lanechange) the car makes a slightly random steering before going into route following mode. 
It appeared as if the pure pursuit was dropping carma_final_points although they are visualized on rviz by trajectory_points topic. This was due to the fact that there was a duplicate point (very close) at the end of the cooperative lanechange which was resulting in almost 0 time_diff which the pure pursuit was rejecting as a duplicate point. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1428
## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on black pacifica at ACM
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
