### PR TITLE
Feature/controlled intersection case three

### DIFF
--- a/stop_controlled_intersection_tactical_plugin/include/stop_controlled_intersection_plugin.h
+++ b/stop_controlled_intersection_tactical_plugin/include/stop_controlled_intersection_plugin.h
@@ -129,6 +129,23 @@ public:
    */
   std::vector<PointSpeedPair> create_case_two_speed_profile(const carma_wm::WorldModelConstPtr& wm, const cav_msgs::Maneuver& maneuver,
                                                           std::vector<lanelet::BasicPoint2d>& route_geometry_points, double starting_speed);
+
+       /**
+   * \brief Creates a speed profile according to case three of the stop controlled intersection, 
+   * where the vehicle continuously decelerates to a stop. 
+   * \param wm Pointer to intialized world model for semantic map access
+   * 
+   * \param maneuvers The maneuver to being planned for. Maneuver meta-dara parameters are used to create the trajectory profile.
+   * 
+   * \param route_geometry_points The geometry points along the route which are associated with a speed in this method.
+   * 
+   * \param starting_speed The current speed of the vehicle at the time of the trajectory planning request
+   * 
+   * \return List of centerline points paired with speed limits
+   */
+  std::vector<PointSpeedPair> create_case_three_speed_profile(const carma_wm::WorldModelConstPtr& wm, const cav_msgs::Maneuver& maneuver,
+                                                          std::vector<lanelet::BasicPoint2d>& route_geometry_points, double starting_speed);
+
    /**
    * \brief Method converts a list of lanelet centerline points and current vehicle state into a usable list of trajectory points for trajectory planning
    * 

--- a/stop_controlled_intersection_tactical_plugin/src/stop_controlled_intersection_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/src/stop_controlled_intersection_tactical_plugin.cpp
@@ -345,7 +345,7 @@ const cav_msgs::Maneuver& maneuver, std::vector<lanelet::BasicPoint2d>& route_ge
 std::vector<PointSpeedPair> StopControlledIntersectionTacticalPlugin::create_case_three_speed_profile(const carma_wm::WorldModelConstPtr& wm,
 const cav_msgs::Maneuver& maneuver, std::vector<lanelet::BasicPoint2d>& route_geometry_points, double starting_speed){
     //Derive meta data values from maneuver message - Using order in sci_strategic_plugin
-    double a_dec = GET_MANEUVER_PROPERTY(maneuver, parameters.float_valued_meta_data[1]);
+    double a_dec = GET_MANEUVER_PROPERTY(maneuver, parameters.float_valued_meta_data[0]);
 
     //Derive start and end dist from maneuver
     double start_dist = GET_MANEUVER_PROPERTY(maneuver, start_dist);

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -55,7 +55,7 @@ namespace stop_controlled_intersection_transit_plugin
 
      carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);
     
-    //Create a request and maneuver that meets case 2s criteria
+    //Create a request and maneuver that meets case 1 criteria
     //In order to be case 1 - estimated_stop_time > scheduled_stop_time and speed_before_stop < speed_limit
     //speed_before_stop
      cav_srvs::PlanTrajectoryRequest req;

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -178,7 +178,7 @@ namespace stop_controlled_intersection_transit_plugin
 
     carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);   
 
-    //Create a request and maneuver that meets case 3 criteria
+    //Create a request and maneuver that meets case 2 criteria
     //speed_before_stop
      cav_srvs::PlanTrajectoryRequest req;
      req.vehicle_state.X_pos_global = 1.5;
@@ -285,7 +285,7 @@ namespace stop_controlled_intersection_transit_plugin
 
     carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);   
 
-    //Create a request and maneuver that meets case 1 criteria
+    //Create a request and maneuver that meets case 3 criteria
     //In order to be case 2 - estimated_stop_time > scheduled_stop_time and speed_before_decel =  speed_limit
     //speed_before_stop
      cav_srvs::PlanTrajectoryRequest req;

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -55,7 +55,7 @@ namespace stop_controlled_intersection_transit_plugin
 
      carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);
     
-    //Create a request and maneuver that meets case 1 criteria
+    //Create a request and maneuver that meets case 2s criteria
     //In order to be case 1 - estimated_stop_time > scheduled_stop_time and speed_before_stop < speed_limit
     //speed_before_stop
      cav_srvs::PlanTrajectoryRequest req;
@@ -178,8 +178,7 @@ namespace stop_controlled_intersection_transit_plugin
 
     carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);   
 
-    //Create a request and maneuver that meets case 1 criteria
-    //In order to be case 2 - estimated_stop_time > scheduled_stop_time and speed_before_decel =  speed_limit
+    //Create a request and maneuver that meets case 3 criteria
     //speed_before_stop
      cav_srvs::PlanTrajectoryRequest req;
      req.vehicle_state.X_pos_global = 1.5;
@@ -311,11 +310,6 @@ namespace stop_controlled_intersection_transit_plugin
     //Float meta data list - a_dec
     double a_dec = -pow(maneuver.lane_following_maneuver.start_speed, 2)/(2*(maneuver.lane_following_maneuver.end_dist - maneuver.lane_following_maneuver.start_dist));
     maneuver.lane_following_maneuver.parameters.float_valued_meta_data.push_back(a_dec);
-
-    req.maneuver_plan.maneuvers.push_back(maneuver);
-    req.maneuver_index_to_plan = 0;
-
-    cav_srvs::PlanTrajectoryResponse resp;
 
     //Test create_case_three_speed_profile
     std::vector<lanelet::BasicPoint2d> route_geometry_points = wm->sampleRoutePoints(

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -26,7 +26,7 @@
 
 namespace stop_controlled_intersection_transit_plugin
 {
-    TEST(StopControlledIntersectionTacticalPlugin, DISABLED_TestSCIPlanning_case_one)
+    TEST(StopControlledIntersectionTacticalPlugin, TestSCIPlanning_case_one)
     {
       //Test Stop controlled Intersection tactical plugin generation
       ros::Time::setNow(ros::Time(0.0));

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -26,7 +26,7 @@
 
 namespace stop_controlled_intersection_transit_plugin
 {
-    TEST(StopControlledIntersectionTacticalPlugin, DISABLED_TestSCIPlanning_case_one)
+    TEST(StopControlledIntersectionTacticalPlugin, TestSCIPlanning_case_one)
     {
       //Test Stop controlled Intersection tactical plugin generation
       ros::Time::setNow(ros::Time(0.0));
@@ -150,7 +150,7 @@ namespace stop_controlled_intersection_transit_plugin
     EXPECT_TRUE(trajectory.size() > 2);
   }
 
-  TEST(StopControlledIntersectionTacticalPlugin, DISABLED_TestSCIPlanning_case_two){
+  TEST(StopControlledIntersectionTacticalPlugin, TestSCIPlanning_case_two){
     //Test Stop controlled Intersection tactical plugin generation
     ros::Time::setNow(ros::Time(0.0));
     StopControlledIntersectionTacticalPluginConfig config;

--- a/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
+++ b/stop_controlled_intersection_tactical_plugin/test/test_sci_tactical_plugin.cpp
@@ -316,14 +316,15 @@ namespace stop_controlled_intersection_transit_plugin
             std::min(maneuver.lane_following_maneuver.start_dist , maneuver.lane_following_maneuver.end_dist), 
             maneuver.lane_following_maneuver.end_dist, 1.0);
     
-    std::vector<PointSpeedPair> case_two_profile = plugin.create_case_three_speed_profile(wm, maneuver, route_geometry_points, req.vehicle_state.longitudinal_vel);
-    double prev_speed = case_two_profile.front().speed;
-    for(int i = 1;i <case_two_profile.size();i++){
-      double current_speed = case_two_profile[i].speed;
+    std::vector<PointSpeedPair> case_three_profile = plugin.create_case_three_speed_profile(wm, maneuver, route_geometry_points, req.vehicle_state.longitudinal_vel);
+    double prev_speed = case_three_profile.front().speed;
+    for(int i = 1;i <case_three_profile.size();i++){
+      double current_speed = case_three_profile[i].speed;
       EXPECT_TRUE(current_speed <= prev_speed);
       
       prev_speed = current_speed;
     }
+    EXPECT_TRUE(case_three_profile.back().speed < 0.5); //Last speed is less than 0.5mps
   }
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
A tactical plugin for Stop Controlled Intersection cases is developed, which creates a trajectory for the request maneuver based on the cases defined for the tsmo use case.

Under case three we creates a trajectory to continuously decelerate the vehicle to a stop.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Code has been unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
