### PR TITLE
a1 release verification testing fixes

### DIFF
--- a/arbitrator/config/arbitrator_params.yaml
+++ b/arbitrator/config/arbitrator_params.yaml
@@ -23,7 +23,7 @@ beam_width: 3
 # Unit: N/a
 use_fixed_costs: true
 
-# Map: The priorities/costs associated with each plugin during the planning 
-# process, values will be normalized at runtime
+# Map: The priorities associated with each plugin during the planning 
+# process, values will be normalized at runtime and inverted into costs
 # Unit: N/a
-plugin_priorities: {RouteFollowingPlugin: 4.0, PlatooningStrategicPlugin: 6.0, WorkZonePlugin: 8.0}
+plugin_priorities: {RouteFollowingPlugin: 4.0, WorkZonePlugin: 8.0, PlatooningStrategicPlugin: 1.0}

--- a/arbitrator/config/arbitrator_params.yaml
+++ b/arbitrator/config/arbitrator_params.yaml
@@ -26,4 +26,4 @@ use_fixed_costs: true
 # Map: The priorities/costs associated with each plugin during the planning 
 # process, values will be normalized at runtime
 # Unit: N/a
-plugin_priorities: {RouteFollowingPlugin: 4.0, WorkZonePlugin: 8.0}
+plugin_priorities: {RouteFollowingPlugin: 4.0, PlatooningStrategicPlugin: 6.0, WorkZonePlugin: 8.0}

--- a/arbitrator/config/arbitrator_params.yaml
+++ b/arbitrator/config/arbitrator_params.yaml
@@ -26,4 +26,4 @@ use_fixed_costs: true
 # Map: The priorities/costs associated with each plugin during the planning 
 # process, values will be normalized at runtime
 # Unit: N/a
-plugin_priorities: {RouteFollowingPlugin: 4.0, PlatooningStrategicPlugin: 6.0, WorkZonePlugin: 8.0}
+plugin_priorities: {RouteFollowingPlugin: 4.0, WorkZonePlugin: 8.0}

--- a/arbitrator/src/fixed_priority_cost_function.cpp
+++ b/arbitrator/src/fixed_priority_cost_function.cpp
@@ -17,6 +17,7 @@
 #include "fixed_priority_cost_function.hpp"
 #include "arbitrator_utils.hpp"
 #include "cav_msgs/ManeuverParameters.h"
+#include <ros/ros.h>
 #include <limits>
 
 namespace arbitrator
@@ -37,6 +38,7 @@ namespace arbitrator
         for (auto it = plugin_priorities.begin(); it != plugin_priorities.end(); it++)
         {
             plugin_costs_[it->first] = 1.0 - (it->second / max_priority);
+            ROS_INFO_STREAM("FixedPriorityCostFunction: " << "Plugin: " << it->first << " Normalized Cost: " << plugin_costs_[it->first]);
         }
     }
 

--- a/carma/launch/guidance.launch
+++ b/carma/launch/guidance.launch
@@ -119,7 +119,7 @@
   <include file="$(find wz_strategic_plugin)/launch/wz_strategic_plugin.launch" />
 
   <!-- Platooning Control Plugin -->
-  <include file="$(find platoon_control)/launch/platoon_control.launch" />
+  <!--include file="$(find platoon_control)/launch/platoon_control.launch" /-->
 
   <!-- Twist Filter -->
   <group>
@@ -158,11 +158,6 @@
     <include file="$(find inlanecruising_plugin)/launch/inlanecruising_plugin.launch" />
   </group>
 
-  <!-- Platooning Tactical Plugin -->
-  <group>
-    <remap from="final_waypoints" to="base_waypoints"/>
-    <include file="$(find platooning_tactical_plugin)/launch/platooning_tactical_plugin.launch" />
-  </group>
   
     <!-- StopandWait Plugin -->
   <group>
@@ -216,13 +211,7 @@
     <remap from="incoming_mobility_operation" to="$(optenv CARMA_MSG_NS)/incoming_mobility_operation"/>
     <include file="$(find port_drayage_plugin)/launch/port_drayage_plugin.launch" />
   </group>
-  <!-- Platoon Strategic Plugin -->
-  <group>
-  <remap from="incoming_mobility_response" to="$(optenv CARMA_MSG_NS)/incoming_mobility_response"/>
-  <remap from="incoming_mobility_request" to="$(optenv CARMA_MSG_NS)/incoming_mobility_request"/>
-  <remap from="incoming_mobility_operation" to="$(optenv CARMA_MSG_NS)/incoming_mobility_operation"/>
-    <include file = "$(find platoon_strategic)/launch/platoon_strategic.launch"/>
-  </group>
+
 
   <!-- Intersection Transit Maneuvering Plugin-->
   <group>

--- a/carma/launch/guidance.launch
+++ b/carma/launch/guidance.launch
@@ -119,7 +119,7 @@
   <include file="$(find wz_strategic_plugin)/launch/wz_strategic_plugin.launch" />
 
   <!-- Platooning Control Plugin -->
-  <!--include file="$(find platoon_control)/launch/platoon_control.launch" /-->
+  <include file="$(find platoon_control)/launch/platoon_control.launch" />
 
   <!-- Twist Filter -->
   <group>
@@ -158,6 +158,11 @@
     <include file="$(find inlanecruising_plugin)/launch/inlanecruising_plugin.launch" />
   </group>
 
+  <!-- Platooning Tactical Plugin -->
+  <group>
+    <remap from="final_waypoints" to="base_waypoints"/>
+    <include file="$(find platooning_tactical_plugin)/launch/platooning_tactical_plugin.launch" />
+  </group>
   
     <!-- StopandWait Plugin -->
   <group>
@@ -212,7 +217,14 @@
     <include file="$(find port_drayage_plugin)/launch/port_drayage_plugin.launch" />
   </group>
 
-
+  <!-- Platoon Strategic Plugin -->
+  <group>
+    <remap from="incoming_mobility_response" to="$(optenv CARMA_MSG_NS)/incoming_mobility_response"/>
+    <remap from="incoming_mobility_request" to="$(optenv CARMA_MSG_NS)/incoming_mobility_request"/>
+    <remap from="incoming_mobility_operation" to="$(optenv CARMA_MSG_NS)/incoming_mobility_operation"/>
+      <include file = "$(find platoon_strategic)/launch/platoon_strategic.launch"/>
+    </group>
+    
   <!-- Intersection Transit Maneuvering Plugin-->
   <group>
    <include file = "$(find intersection_transit_maneuvering)/launch/intersection_transit_maneuvering.launch"/>
@@ -230,4 +242,3 @@
   </group>
 
 </launch>
-

--- a/carma/launch/guidance.launch
+++ b/carma/launch/guidance.launch
@@ -222,9 +222,9 @@
     <remap from="incoming_mobility_response" to="$(optenv CARMA_MSG_NS)/incoming_mobility_response"/>
     <remap from="incoming_mobility_request" to="$(optenv CARMA_MSG_NS)/incoming_mobility_request"/>
     <remap from="incoming_mobility_operation" to="$(optenv CARMA_MSG_NS)/incoming_mobility_operation"/>
-      <include file = "$(find platoon_strategic)/launch/platoon_strategic.launch"/>
-    </group>
-    
+    <include file = "$(find platoon_strategic)/launch/platoon_strategic.launch"/>
+  </group>
+
   <!-- Intersection Transit Maneuvering Plugin-->
   <group>
    <include file = "$(find intersection_transit_maneuvering)/launch/intersection_transit_maneuvering.launch"/>

--- a/carma_wm/include/carma_wm/IndexedDistanceMap.h
+++ b/carma_wm/include/carma_wm/IndexedDistanceMap.h
@@ -149,7 +149,7 @@ public:
    *        NOTE: Unlike the rest of this class, this method runs in O(log n) where n is this.size() for accessing linestring index
    *              If accessing point index (get_point=true) then it runs an addition O(log m) where m is the linestring index.size();
    *              This means the max complexity of this function is O(log n) + O(log m)
-   *  TODO: Add info about complexity and returned data
+   *  
    * \throw std::invalid_argument if distance does not fit within bounds [0, totalLength()]
    * 
    * \param distance The downtrack distance in meters to get the element for

--- a/carma_wm/include/carma_wm/IndexedDistanceMap.h
+++ b/carma_wm/include/carma_wm/IndexedDistanceMap.h
@@ -147,10 +147,10 @@ public:
   /*!
    * \brief Returns index of the linestring which the provided distance is within.
    *        NOTE: Unlike the rest of this class, this method runs in O(log n) where n is this.size()
-   *
+   *  TODO: Add info about complexity and returned data
    * \throw std::invalid_argument if distance does not fit within bounds [0, totalLength()]
    * \return The linestring index which this distance is inside
    */
-  size_t getElementIndexByDistance(double distance) const;
+  std::pair<size_t, size_t> getElementIndexByDistance(double distance, bool get_point=true) const;
 };
 }  // namespace carma_wm

--- a/carma_wm/include/carma_wm/IndexedDistanceMap.h
+++ b/carma_wm/include/carma_wm/IndexedDistanceMap.h
@@ -146,10 +146,18 @@ public:
 
   /*!
    * \brief Returns index of the linestring which the provided distance is within.
-   *        NOTE: Unlike the rest of this class, this method runs in O(log n) where n is this.size()
+   *        NOTE: Unlike the rest of this class, this method runs in O(log n) where n is this.size() for accessing linestring index
+   *              If accessing point index (get_point=true) then it runs an addition O(log m) where m is the linestring index.size();
+   *              This means the max complexity of this function is O(log n) + O(log m)
    *  TODO: Add info about complexity and returned data
    * \throw std::invalid_argument if distance does not fit within bounds [0, totalLength()]
-   * \return The linestring index which this distance is inside
+   * 
+   * \param distance The downtrack distance in meters to get the element for
+   * \param get_point Set to true if you wish to access the index of the point prior to the provided distance. 
+   *                  If false then pair->second will always be 0
+   * 
+   * 
+   * \return A pair of the linestring index (first) and point index (second) which have their start distances before the provided distance
    */
   std::pair<size_t, size_t> getElementIndexByDistance(double distance, bool get_point=true) const;
 };

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -391,9 +391,13 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                                          << getRouteEndTrackPos().downtrack);
     return boost::none;
   }
+    ROS_DEBUG_STREAM(">>> Downtrack:" << downtrack);
 
   // Use fast lookup to identify the points before and after the provided downtrack on the route
   size_t ls_i = shortest_path_distance_map_.getElementIndexByDistance(downtrack); // Get the linestring matching the provided downtrack
+    ROS_DEBUG_STREAM(">>> ls_i: " << ls_i << ", of size: " << shortest_path_distance_map_.size());
+
+
   double ls_length = shortest_path_distance_map_.elementLength(ls_i);
   double ls_downtrack = shortest_path_distance_map_.distanceToElement(ls_i);
   auto linestring = shortest_path_centerlines_[ls_i];

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -397,25 +397,38 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
   size_t ls_i = shortest_path_distance_map_.getElementIndexByDistance(downtrack); // Get the linestring matching the provided downtrack
     ROS_DEBUG_STREAM(">>> ls_i: " << ls_i << ", of size: " << shortest_path_distance_map_.size());
 
-
   double ls_length = shortest_path_distance_map_.elementLength(ls_i);
+  
   double ls_downtrack = shortest_path_distance_map_.distanceToElement(ls_i);
+  
   auto linestring = shortest_path_centerlines_[ls_i];
 
   // Use the percentage traveled along this linestring to index into the cenertline
   double relative_downtrack = downtrack - ls_downtrack;
+
   double lanelet_percentage = relative_downtrack / ls_length;
+
   int centerline_size = linestring.size();
+    ROS_DEBUG_STREAM(">>> ls_length: " << ls_length << ", : ls_downtrack" << ls_downtrack << ", linestring.size():" << linestring.size() << 
+                       ", relative_downtrack:" << relative_downtrack << ", lanelet_percentage: " << lanelet_percentage << ", centerline_size:" << centerline_size);
+
   int index = lanelet_percentage * centerline_size;
+
   int prior_idx = std::min(index, centerline_size - 1);
+
   int next_idx = std::min(index + 1, centerline_size - 1);
+    ROS_DEBUG_STREAM(">>> index: " << index << ", of prior_idx: " << prior_idx << ", next_idx: "<<  next_idx);
 
   // This if block handles the edge case where the downtrack distance has landed exactly on an existing point
   if (prior_idx == next_idx)
   {  // If both indexes are the same we are on the point
+    ROS_DEBUG_STREAM(">>> inside exactly existing point logic");
+    
     if (crosstrack == 0)
     {  // Crosstrack not provided so we can return the point directly
       auto prior_point = linestring[prior_idx];
+    ROS_DEBUG_STREAM(">>> returning prior_point.x()" << prior_point.x() << ", prior_point.y() "<< prior_point.y());
+
       return lanelet::BasicPoint2d(prior_point.x(), prior_point.y());
     }
 
@@ -427,6 +440,8 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
       next_point = linestring[prior_idx + 1].basicPoint2d(); // No need to check bounds as this class will reject routes with fewer than 2 points in a centerline
       x = prior_point.x();
       y = prior_point.y();
+    ROS_DEBUG_STREAM(">>> 111 prior_point.x()" << prior_point.x() << ", prior_point.y() "<< prior_point.y());
+
     }
     else
     {  // If this is the end point compute the crosstrack based on previous point
@@ -434,6 +449,8 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
       next_point = linestring[prior_idx].basicPoint2d();
       x = next_point.x();
       y = next_point.y();
+    ROS_DEBUG_STREAM(">>> 1111 next_point.x()" << next_point.x() << ", next_point.y() "<< next_point.y());
+
     }
 
     // Compute the crosstrack
@@ -442,6 +459,9 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                     // to the target point
     double delta_x = cos(theta) * crosstrack;
     double delta_y = sin(theta) * crosstrack;
+    ROS_DEBUG_STREAM(">>> 1111 delta_x" << delta_x << ", delta_y "<< delta_y);
+    ROS_DEBUG_STREAM(">>> 1111 x" << x << ", y "<< y);
+
     return lanelet::BasicPoint2d(x + delta_x, y + delta_y);
   }
 
@@ -451,19 +471,31 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
   double prior_to_next_dist = next_downtrack - prior_downtrack;
   double prior_to_target_dist = relative_downtrack - prior_downtrack;
   double interpolation_percentage = 0;
+  
+  ROS_DEBUG_STREAM(">>> prior_downtrack: " << prior_downtrack << ", : next_downtrack" << next_downtrack << ", prior_to_next_dist:" << prior_to_next_dist << 
+                       ", prior_to_target_dist:" << prior_to_target_dist << ", interpolation_percentage: " << interpolation_percentage);
+
+
   if (prior_to_next_dist < 0.000001)
   {
     interpolation_percentage = 0;
+    ROS_DEBUG_STREAM(">>> here");
   }
   else
   {
     interpolation_percentage = prior_to_target_dist / prior_to_next_dist; // Use the percentage progress between both points to compute the downtrack point
   }
+  ROS_DEBUG_STREAM(">>> interpolation_percentage: " << interpolation_percentage);
+
   auto prior_point = linestring[prior_idx].basicPoint2d();
   auto next_point = linestring[next_idx].basicPoint2d();
   auto delta_vec = next_point - prior_point;
+    ROS_DEBUG_STREAM(">>>1 prior_point.x():" << prior_point.x() <<", prior_point.x()" << prior_point.x());
+    ROS_DEBUG_STREAM(">>>1 next_point.x():" << next_point.x() <<", next_point.x()" << next_point.x());
+
   double x = prior_point.x() + interpolation_percentage * delta_vec.x();
   double y = prior_point.y() + interpolation_percentage * delta_vec.y();
+    ROS_DEBUG_STREAM(">>>1 x: " << x << ", y:" << y);
 
   if (crosstrack != 0) // If the crosstrack is not set no need to do the costly computation.
   {  
@@ -472,8 +504,12 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                     // to the target point
     double delta_x = cos(theta) * crosstrack;
     double delta_y = sin(theta) * crosstrack;
+    ROS_DEBUG_STREAM(">>>2 delta_x: " << delta_x << ">>> delta_y: " << delta_y);
+
     x += delta_x;  // Adjust x and y of target point to account for crosstrack
     y += delta_y;
+    ROS_DEBUG_STREAM(">>>2 x: " << x << ">>> y: " << y);
+    
   }
 
   return lanelet::BasicPoint2d(x, y);

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -391,15 +391,11 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                                          << getRouteEndTrackPos().downtrack);
     return boost::none;
   }
-    ROS_DEBUG_STREAM(">>> Downtrack:" << downtrack);
 
   // Use fast lookup to identify the points before and after the provided downtrack on the route
   auto indices = shortest_path_distance_map_.getElementIndexByDistance(downtrack, true); // Get the linestring matching the provided downtrack
   size_t ls_i = std::get<0>(indices);
   size_t pt_i = std::get<1>(indices);
-  
-    ROS_DEBUG_STREAM(">>> ls_i: " << ls_i << ", of size: " << shortest_path_distance_map_.size());
-
   
   auto linestring = shortest_path_centerlines_[ls_i];
 
@@ -414,24 +410,17 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
 
   size_t centerline_size = linestring.size();
 
-  ROS_DEBUG_STREAM(">>> ls_downtrack" << ls_downtrack << ", linestring.size():" << linestring.size() << 
-                       ", relative_downtrack:" << relative_downtrack << ", centerline_size:" << centerline_size);
-
-
   size_t prior_idx = std::min(pt_i, centerline_size - 1);
 
   size_t next_idx = std::min(pt_i + 1, centerline_size - 1);
-    ROS_DEBUG_STREAM(">>> pt_i: " << pt_i << ", of prior_idx: " << prior_idx << ", next_idx: "<<  next_idx);
 
   // This if block handles the edge case where the downtrack distance has landed exactly on an existing point
   if (prior_idx == next_idx)
   {  // If both indexes are the same we are on the point
-    ROS_DEBUG_STREAM(">>> inside exactly existing point logic");
     
     if (crosstrack == 0)
     {  // Crosstrack not provided so we can return the point directly
       auto prior_point = linestring[prior_idx];
-    ROS_DEBUG_STREAM(">>> returning prior_point.x()" << prior_point.x() << ", prior_point.y() "<< prior_point.y());
 
       return lanelet::BasicPoint2d(prior_point.x(), prior_point.y());
     }
@@ -444,7 +433,6 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
       next_point = linestring[prior_idx + 1].basicPoint2d(); // No need to check bounds as this class will reject routes with fewer than 2 points in a centerline
       x = prior_point.x();
       y = prior_point.y();
-    ROS_DEBUG_STREAM(">>> 111 prior_point.x()" << prior_point.x() << ", prior_point.y() "<< prior_point.y());
 
     }
     else
@@ -453,7 +441,6 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
       next_point = linestring[prior_idx].basicPoint2d();
       x = next_point.x();
       y = next_point.y();
-    ROS_DEBUG_STREAM(">>> 1111 next_point.x()" << next_point.x() << ", next_point.y() "<< next_point.y());
 
     }
 
@@ -463,8 +450,6 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                     // to the target point
     double delta_x = cos(theta) * crosstrack;
     double delta_y = sin(theta) * crosstrack;
-    ROS_DEBUG_STREAM(">>> 1111 delta_x" << delta_x << ", delta_y "<< delta_y);
-    ROS_DEBUG_STREAM(">>> 1111 x" << x << ", y "<< y);
 
     return lanelet::BasicPoint2d(x + delta_x, y + delta_y);
   }
@@ -475,31 +460,22 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
   double prior_to_next_dist = next_downtrack - prior_downtrack;
   double prior_to_target_dist = relative_downtrack - prior_downtrack;
   double interpolation_percentage = 0;
-  
-  ROS_DEBUG_STREAM(">>> prior_downtrack: " << prior_downtrack << ", : next_downtrack" << next_downtrack << ", prior_to_next_dist:" << prior_to_next_dist << 
-                       ", prior_to_target_dist:" << prior_to_target_dist << ", interpolation_percentage: " << interpolation_percentage);
-
 
   if (prior_to_next_dist < 0.000001)
   {
     interpolation_percentage = 0;
-    ROS_DEBUG_STREAM(">>> here");
   }
   else
   {
     interpolation_percentage = prior_to_target_dist / prior_to_next_dist; // Use the percentage progress between both points to compute the downtrack point
   }
-  ROS_DEBUG_STREAM(">>> interpolation_percentage: " << interpolation_percentage);
 
   auto prior_point = linestring[prior_idx].basicPoint2d();
   auto next_point = linestring[next_idx].basicPoint2d();
   auto delta_vec = next_point - prior_point;
-    ROS_DEBUG_STREAM(">>>1 prior_point.x():" << prior_point.x() <<", prior_point.x()" << prior_point.x());
-    ROS_DEBUG_STREAM(">>>1 next_point.x():" << next_point.x() <<", next_point.x()" << next_point.x());
 
   double x = prior_point.x() + interpolation_percentage * delta_vec.x();
   double y = prior_point.y() + interpolation_percentage * delta_vec.y();
-    ROS_DEBUG_STREAM(">>>1 x: " << x << ", y:" << y);
 
   if (crosstrack != 0) // If the crosstrack is not set no need to do the costly computation.
   {  
@@ -508,11 +484,9 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
                                     // to the target point
     double delta_x = cos(theta) * crosstrack;
     double delta_y = sin(theta) * crosstrack;
-    ROS_DEBUG_STREAM(">>>2 delta_x: " << delta_x << ">>> delta_y: " << delta_y);
 
     x += delta_x;  // Adjust x and y of target point to account for crosstrack
     y += delta_y;
-    ROS_DEBUG_STREAM(">>>2 x: " << x << ">>> y: " << y);
     
   }
 

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -460,6 +460,7 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
   double prior_to_next_dist = next_downtrack - prior_downtrack;
   double prior_to_target_dist = relative_downtrack - prior_downtrack;
   double interpolation_percentage = 0;
+  
 
   if (prior_to_next_dist < 0.000001)
   {

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -412,10 +412,11 @@ boost::optional<lanelet::BasicPoint2d> CARMAWorldModel::pointFromRouteTrackPos(c
   
   double relative_downtrack = downtrack - ls_downtrack;
 
+  size_t centerline_size = linestring.size();
+
   ROS_DEBUG_STREAM(">>> ls_downtrack" << ls_downtrack << ", linestring.size():" << linestring.size() << 
                        ", relative_downtrack:" << relative_downtrack << ", centerline_size:" << centerline_size);
 
-  size_t centerline_size = linestring.size();
 
   size_t prior_idx = std::min(pt_i, centerline_size - 1);
 

--- a/carma_wm/src/IndexedDistanceMap.cpp
+++ b/carma_wm/src/IndexedDistanceMap.cpp
@@ -59,7 +59,7 @@ std::pair<size_t, size_t> IndexedDistanceMap::getElementIndexByDistance(double d
   if (low == accum_lengths.end()) { // If we reached the end, it means we should pick the final point since we already checked the bounds
     ls_index = accum_lengths.size() - 1;
   } else {
-    ls_index = std::max(low - accum_lengths.begin() - 1, 0);
+    ls_index = std::max(low - accum_lengths.begin() - 1, (long int)0);
   }
 
   if (!get_point) { // If we are looking for the linestring index then return
@@ -73,7 +73,7 @@ std::pair<size_t, size_t> IndexedDistanceMap::getElementIndexByDistance(double d
   auto low_point = std::lower_bound (std::get<0>(accum_lengths[ls_index]).begin(), std::get<0>(accum_lengths[ls_index]).end(), relative_dist, // Binary search to find the point index 
     [](const double& a, const double& b){ return a < b; });
   
-  size_t point_idx = std::max(low_point - std::get<0>(accum_lengths[ls_index]).begin() - 1, 0);
+  size_t point_idx = std::max(low_point - std::get<0>(accum_lengths[ls_index]).begin() - 1, (long int)0);
   return std::make_pair(ls_index, point_idx);
 }
 

--- a/carma_wm/src/IndexedDistanceMap.cpp
+++ b/carma_wm/src/IndexedDistanceMap.cpp
@@ -59,7 +59,7 @@ std::pair<size_t, size_t> IndexedDistanceMap::getElementIndexByDistance(double d
   if (low == accum_lengths.end()) { // If we reached the end, it means we should pick the final point since we already checked the bounds
     ls_index = accum_lengths.size() - 1;
   } else {
-    ls_index = low - accum_lengths.begin();
+    ls_index = std::max(low - accum_lengths.begin() - 1, 0);
   }
 
   if (!get_point) { // If we are looking for the linestring index then return
@@ -73,7 +73,7 @@ std::pair<size_t, size_t> IndexedDistanceMap::getElementIndexByDistance(double d
   auto low_point = std::lower_bound (std::get<0>(accum_lengths[ls_index]).begin(), std::get<0>(accum_lengths[ls_index]).end(), relative_dist, // Binary search to find the point index 
     [](const double& a, const double& b){ return a < b; });
   
-  size_t point_idx = low_point - std::get<0>(accum_lengths[ls_index]).begin();
+  size_t point_idx = std::max(low_point - std::get<0>(accum_lengths[ls_index]).begin() - 1, 0);
   return std::make_pair(ls_index, point_idx);
 }
 

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -43,8 +43,8 @@ if [[ "$BRANCH" = "develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch develop
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch release/a1
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/novatel_gps_driver.git --branch release/a1
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch release/a1
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch release/a1
 fi

--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -111,6 +111,12 @@ bool InLaneCruisingPlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest& r
                                                                                 wpg_detail_config); // Compute the trajectory
   original_trajectory.initial_longitudinal_velocity = std::max(req.vehicle_state.longitudinal_vel, config_.minimum_speed);
 
+  // Set the planning plugin field name
+  for (auto& p : original_trajectory.trajectory_points) {
+    p.planner_plugin_name = plugin_discovery_msg_.name;
+  }
+  
+  
   if (config_.enable_object_avoidance)
   {
     ROS_DEBUG_STREAM("Activate Object Avoidance");

--- a/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
+++ b/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
@@ -93,6 +93,7 @@ namespace mobilitypath_visualizer {
 
         if (!map_projector_) {
             ROS_DEBUG_STREAM("Cannot visualize mobility path as map projection not yet available");
+            return;
         }
 
         MarkerColor cav_color;

--- a/platooning_control/src/platoon_control.cpp
+++ b/platooning_control/src/platoon_control.cpp
@@ -95,14 +95,18 @@ namespace platoon_control
 
     void  PlatoonControlPlugin::trajectoryPlan_cb(const cav_msgs::TrajectoryPlan::ConstPtr& tp){
         
-        cav_msgs::TrajectoryPlanPoint first_trajectory_point = tp->trajectory_points[1];
+        if (tp->trajectory_points.size() < 2) {
+            ROS_WARN_STREAM("PlatoonControlPlugin cannot execute trajectory as only 1 point was provided");
+            return;
+        }
+        cav_msgs::TrajectoryPlanPoint first_trajectory_point = tp->trajectory_points[1]; // TODO this variable appears to be misnamed. It is the second trajectory point
         cav_msgs::TrajectoryPlanPoint lookahead_point = getLookaheadTrajectoryPoint(*tp);
 
         trajectory_speed_ = getTrajectorySpeed(tp->trajectory_points);
 
     	
         
-        generateControlSignals(first_trajectory_point, lookahead_point);
+        generateControlSignals(first_trajectory_point, lookahead_point); // TODO this should really be called on a timer against that last trajectory so 30Hz control loop can be achieved
 
 
     }

--- a/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
+++ b/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
@@ -161,7 +161,9 @@ std::vector<PointSpeedPair> StopandWait::maneuvers_to_points(const std::vector<c
       std::min(starting_downtrack + config_.cernterline_sampling_spacing, stop_and_wait_maneuver.end_dist),
       stop_and_wait_maneuver.end_dist, config_.cernterline_sampling_spacing);
 
+
   route_points.insert(route_points.begin(), veh_pos);
+
 
   for (const auto& p : route_points)
   {
@@ -169,6 +171,7 @@ std::vector<PointSpeedPair> StopandWait::maneuvers_to_points(const std::vector<c
     pair.point = p;
     pair.speed = starting_speed; // NOTE: Since the vehicle is trying to stop the assumption made is that the speed limit is irrelevant. 
     points_and_target_speeds.push_back(pair);
+    ROS_DEBUG_STREAM("point.x: " << p.x() << ", point.y: " << p.y());
   }
 
   return points_and_target_speeds;

--- a/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
+++ b/stop_and_wait_plugin/src/stop_and_wait_plugin.cpp
@@ -171,7 +171,6 @@ std::vector<PointSpeedPair> StopandWait::maneuvers_to_points(const std::vector<c
     pair.point = p;
     pair.speed = starting_speed; // NOTE: Since the vehicle is trying to stop the assumption made is that the speed limit is irrelevant. 
     points_and_target_speeds.push_back(pair);
-    ROS_DEBUG_STREAM("point.x: " << p.x() << ", point.y: " << p.y());
   }
 
   return points_and_target_speeds;

--- a/wz_strategic_plugin/src/wz_strategic_plugin.cpp
+++ b/wz_strategic_plugin/src/wz_strategic_plugin.cpp
@@ -261,18 +261,12 @@ void WzStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversRequest
   ROS_DEBUG_STREAM("early_arrival_time_at_freeflow: " << std::to_string(early_arrival_time_at_freeflow.toSec()));
   ROS_DEBUG_STREAM("late_arrival_time_at_freeflow: " << std::to_string(late_arrival_time_at_freeflow.toSec()));
 
-  ROS_ERROR_STREAM("light_arrival_time_at_freeflow: " << std::to_string(light_arrival_time_at_freeflow.toSec()));
-  ROS_ERROR_STREAM("early_arrival_time_at_freeflow: " << std::to_string(early_arrival_time_at_freeflow.toSec()));
-  ROS_ERROR_STREAM("late_arrival_time_at_freeflow: " << std::to_string(late_arrival_time_at_freeflow.toSec()));
-
   auto early_arrival_state_at_freeflow_optional = nearest_traffic_light->predictState(early_arrival_time_at_freeflow);
 
   if (!validLightState(early_arrival_state_at_freeflow_optional, early_arrival_time_at_freeflow))
     return;
 
   ROS_DEBUG_STREAM("early_arrival_state_at_freeflow: " << early_arrival_state_at_freeflow_optional.get());
-  ROS_ERROR_STREAM("early_arrival_state_at_freeflow: " << early_arrival_state_at_freeflow_optional.get());
-
 
   auto late_arrival_state_at_freeflow_optional = nearest_traffic_light->predictState(late_arrival_time_at_freeflow);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixes encountered duing a1 verification testing, which includes:
- mobilitypath_visualizer no longer runs into race condition where it fails before map is available
- stop_and_wait_plugin no longer creates "steering right" trajectory due to bug in the way points were being sampled from route. it was comparing traveled downtrack bs lanelet's downtrack percentage to get the nearest point, which is incorrect. It directly compares downtrack using binary search now.
- inlanecruising_plugin as plugin name field
- platooning stack no longer crashes during workzone test run.


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1444
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
