### PR TITLE
Fix for platoon shutdown during workzone run

### DIFF
--- a/platooning_strategic/src/platoon_strategic.cpp
+++ b/platooning_strategic/src/platoon_strategic.cpp
@@ -140,6 +140,11 @@ namespace platoon_strategic
                 lane_id =  stoi(maneuver.lane_following_maneuver.lane_ids[0]);
             }
         }
+        else
+        {
+            ROS_WARN_STREAM("Detected a maneuver other than LANE_FOLLOWING, which is currently not supported. Using 0 index...");
+            lane_id = 0;
+        }
     }
 
     
@@ -191,6 +196,11 @@ namespace platoon_strategic
             time_progress = req.prior_plan.planning_completion_time;
             int end_lanelet =0;
             updateCurrentStatus(req.prior_plan.maneuvers.back(),speed_progress,current_progress,end_lanelet);
+            if (end_lanelet == 0)
+            {
+                ROS_WARN_STREAM("Was not able to extract valid info from prior maneuver, returning...");
+                return true;
+            }
             last_lanelet_index = findLaneletIndexFromPath(end_lanelet,shortest_path);
         }
         bool approaching_route_end = false;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
During workzone testing, platooning plugin received new type of maneuver other than lane_follow, which resulted in the plugin crashing. This is fixed by return empty trajectory if not supported as it is not used.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1451 Definitely related to this.
https://github.com/usdot-fhwa-stol/carma-platform/issues/1456 Most likely will fix this as well, the exact issue was not reproducible

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
At TFHRC using Fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
