### PR TITLE
add intersection departure logic

### DIFF
--- a/sci_strategic_plugin/config/parameters.yaml
+++ b/sci_strategic_plugin/config/parameters.yaml
@@ -4,7 +4,7 @@ vehicle_decel_limit_multiplier : 0.50
 # Double: multiplier to apply to the maximum allowable vehicle acceleration limit so we plan under our capabilities
 vehicle_accel_limit_multiplier : 0.50
 
-# Double: A buffer infront of the stopping location which will still be considered a valid stop. Units in meters
+# Double: A buffer before of the stopping location which will still be considered a valid stop. Units in meters
 stop_line_buffer : 2.0
 
 # Double: Update time interval of carma streets. Units in s

--- a/sci_strategic_plugin/config/parameters.yaml
+++ b/sci_strategic_plugin/config/parameters.yaml
@@ -20,4 +20,4 @@ lane_following_plugin_name : StopControlledIntersectionTacticalPlugin
 stop_and_wait_plugin_name : StopAndWaitPlugin
 
 # String: The name of the plugin to use for intersection transit trajectory planning
-intersection_transit_plugin_name : StopControlledIntersectionTacticalPlugin
+intersection_transit_plugin_name : IntersectionTransitPlugin

--- a/sci_strategic_plugin/include/sci_strategic_plugin.h
+++ b/sci_strategic_plugin/include/sci_strategic_plugin.h
@@ -109,6 +109,12 @@ public:
   void mobilityOperationCb(const cav_msgs::MobilityOperationConstPtr& msg);
 
   /**
+   * \brief callback function for current pose
+   * \param msg input pose stamed msg
+   */
+  void currentPoseCb(const geometry_msgs::PoseStampedConstPtr& msg);
+
+  /**
    * \brief Compose a lane keeping maneuver message based on input params
    *
    * \param start_dist Start downtrack distance of the current maneuver
@@ -274,6 +280,9 @@ public:
 
   // approximate speed limit 
   double speed_limit_ = 100.0;
+
+  // downtrack of host vehicle
+  double current_downtrack_ = 0.0;
 
   bool approaching_stop_controlled_interction_ = false;
 

--- a/sci_strategic_plugin/include/sci_strategic_plugin.h
+++ b/sci_strategic_plugin/include/sci_strategic_plugin.h
@@ -126,6 +126,14 @@ public:
                                                          double target_speed, ros::Time start_time, double time_to_stop,
                                                          std::vector<lanelet::Id> lane_ids);
 
+  cav_msgs::Maneuver composeStopAndWaitManeuverMessage(double current_dist, double end_dist, double start_speed,
+                                                      const lanelet::Id& starting_lane_id, const lanelet::Id& ending_lane_id,
+                                                      ros::Time start_time, ros::Time end_time) const;
+
+  cav_msgs::Maneuver composeIntersectionTransitMessage(double start_dist, double end_dist, double start_speed, 
+                                                      double target_speed, ros::Time start_time, ros::Time end_time,
+                                                      const lanelet::Id& starting_lane_id, const lanelet::Id& ending_lane_id) const;
+
   /**
    * \brief Helper method to extract the initial vehicle state from the planning request method based on if the
    * prior_plan was set or not.

--- a/sci_strategic_plugin/include/sci_strategic_plugin_config.h
+++ b/sci_strategic_plugin/include/sci_strategic_plugin_config.h
@@ -53,7 +53,7 @@ struct SCIStrategicPluginConfig
   std::string stop_and_wait_plugin_name = "StopAndWaitPlugin";
 
   //! The name of the plugin to use for intersection transit trajectory planning
-  std::string intersection_transit_plugin_name = "StopControlledIntersectionTacticalPlugin";
+  std::string intersection_transit_plugin_name = "IntersectionTransitPlugin";
 
   //! License plate of the vehicle.
   std::string vehicle_id = "default_id";

--- a/sci_strategic_plugin/src/main.cpp
+++ b/sci_strategic_plugin/src/main.cpp
@@ -61,6 +61,10 @@ int main(int argc, char** argv)
   
   // Mobility Operation Subscriber
   ros::Subscriber mob_operation_sub = nh.subscribe("incoming_mobility_operation", 1, &sci_strategic_plugin::SCIStrategicPlugin::mobilityOperationCb, &plugin);
+  
+  // Current Pose Subscriber
+  ros::Subscriber current_pose_sub = nh.subscribe("current_pose", 1, &sci_strategic_plugin::SCIStrategicPlugin::currentPoseCb, &plugin);
+
 
   ros::Timer discovery_pub_timer =
       nh.createTimer(ros::Duration(ros::Rate(10.0)), [&plugin, &plugin_discovery_pub](const auto&) {

--- a/sci_strategic_plugin/src/sci_strategic_plugin.cpp
+++ b/sci_strategic_plugin/src/sci_strategic_plugin.cpp
@@ -242,15 +242,13 @@ bool SCIStrategicPlugin::planManeuverCb(cav_srvs::PlanManeuversRequest& req, cav
       std::vector<lanelet::ConstLanelet> crossed_lanelets =
           getLaneletsBetweenWithException(current_downtrack_, stop_intersection_down_track, true, true);
 
-  auto current_lanelet = getLaneletsBetweenWithException(current_downtrack_, current_downtrack_, true).front();
-
   if (distance_to_stopline >= 0)
   {
     if (distance_to_stopline > config_.stop_line_buffer)
     {
       // approaching stop line
       
-      speed_limit_ = findSpeedLimit(current_lanelet);
+      speed_limit_ = findSpeedLimit(crossed_lanelets.front());
 
       // lane following to intersection
       double time_to_schedule_stop = (scheduled_stop_time_ - street_msg_timestamp_)*1000.0;
@@ -270,7 +268,7 @@ bool SCIStrategicPlugin::planManeuverCb(cav_srvs::PlanManeuversRequest& req, cav
       double stop_duration = (scheduled_enter_time_ - scheduled_stop_time_)*1000.0;
       ROS_DEBUG_STREAM("Planning stop and wait maneuver");
       resp.new_plan.maneuvers.push_back(composeStopAndWaitManeuverMessage(
-        current_downtrack_, stop_intersection_down_track, current_state.speed, current_lanelet.id(),
+        current_downtrack_, stop_intersection_down_track, current_state.speed, crossed_lanelets.front().id(),
         stop_line_lanelet.id(), current_state.stamp,
         req.header.stamp + ros::Duration(stop_duration)));
     }

--- a/sci_strategic_plugin/src/sci_strategic_plugin.cpp
+++ b/sci_strategic_plugin/src/sci_strategic_plugin.cpp
@@ -86,7 +86,6 @@ void SCIStrategicPlugin::mobilityOperationCb(const cav_msgs::MobilityOperationCo
 {
   if (msg->strategy == stop_controlled_intersection_strategy_)
   {
-    // TODO: Add Samir's code here to detect approaching an intersection and publish status and intent
     approaching_stop_controlled_interction_ = true;
     if (msg->strategy_params != previous_strategy_params_)
     {

--- a/sci_strategic_plugin/test/test_sci_strategic_plugin.cpp
+++ b/sci_strategic_plugin/test/test_sci_strategic_plugin.cpp
@@ -25,10 +25,12 @@ TEST(SCIStrategicPlugin, UnitTest1)
 {
     ros::CARMANodeHandle nh;
     ros::Publisher mob_op_pub = nh.advertise<cav_msgs::MobilityOperation>("incoming_mobility_operation", 5);
+    ros::Publisher pose_pub = nh.advertise<geometry_msgs::PoseStamped>("current_pose", 5);
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
     ros::spinOnce(); 
     
     EXPECT_EQ(1, mob_op_pub.getNumSubscribers());
+    EXPECT_EQ(1, pose_pub.getNumSubscribers());
 }
 
 int main (int argc, char **argv) {

--- a/sci_strategic_plugin/test/test_strategic_plugin.cpp
+++ b/sci_strategic_plugin/test/test_strategic_plugin.cpp
@@ -53,7 +53,8 @@ TEST(SCIStrategicPluginTest, composeLaneFollowingManeuverMessage)
 
   ASSERT_EQ(cav_msgs::Maneuver::LANE_FOLLOWING, result.type);
   ASSERT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION, result.lane_following_maneuver.parameters.negotiation_type);
-  ASSERT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN,
+  ASSERT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN | cav_msgs::ManeuverParameters::HAS_INT_META_DATA | 
+  cav_msgs::ManeuverParameters::HAS_FLOAT_META_DATA | cav_msgs::ManeuverParameters::HAS_STRING_META_DATA,
             result.lane_following_maneuver.parameters.presence_vector);
   ASSERT_TRUE(config.lane_following_plugin_name.compare(
                   result.lane_following_maneuver.parameters.planning_tactical_plugin) == 0);
@@ -71,6 +72,62 @@ TEST(SCIStrategicPluginTest, composeLaneFollowingManeuverMessage)
   ASSERT_TRUE(result.lane_following_maneuver.lane_ids[1].compare("1201") == 0);
   ASSERT_TRUE(result.lane_following_maneuver.parameters.int_valued_meta_data[0] == 1);
 }
+
+TEST(SCIStrategicPluginTest, composeIntersectionTransitMessage)
+{
+  std::shared_ptr<carma_wm::CARMAWorldModel> wm;
+  SCIStrategicPluginConfig config;
+  SCIStrategicPlugin sci(wm, config);
+
+  auto result = sci.composeIntersectionTransitMessage(10.2, 20.4, 5, 10, ros::Time(1.2), ros::Time(2.2), 1200, 1201);
+
+  ASSERT_EQ(cav_msgs::Maneuver::INTERSECTION_TRANSIT_STRAIGHT, result.type);
+  ASSERT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION,
+            result.intersection_transit_straight_maneuver.parameters.negotiation_type);
+  ASSERT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN,
+            result.intersection_transit_straight_maneuver.parameters.presence_vector);
+  ASSERT_TRUE(config.intersection_transit_plugin_name.compare(
+                  result.intersection_transit_straight_maneuver.parameters.planning_tactical_plugin) == 0);
+  ASSERT_TRUE(config.strategic_plugin_name.compare(
+                  result.intersection_transit_straight_maneuver.parameters.planning_strategic_plugin) == 0);
+
+  ASSERT_EQ(10.2, result.intersection_transit_straight_maneuver.start_dist);
+  ASSERT_EQ(20.4, result.intersection_transit_straight_maneuver.end_dist);
+  ASSERT_EQ(5, result.intersection_transit_straight_maneuver.start_speed);
+  ASSERT_EQ(10, result.intersection_transit_straight_maneuver.end_speed);
+  ASSERT_EQ(ros::Time(1.2), result.intersection_transit_straight_maneuver.start_time);
+  ASSERT_EQ(ros::Time(2.2), result.intersection_transit_straight_maneuver.end_time);
+  ASSERT_TRUE(result.intersection_transit_straight_maneuver.starting_lane_id.compare("1200") == 0);
+  ASSERT_TRUE(result.intersection_transit_straight_maneuver.ending_lane_id.compare("1201") == 0);
+}
+
+TEST(SCIStrategicPluginTest, composeStopAndWaitManeuverMessage)
+{
+  std::shared_ptr<carma_wm::CARMAWorldModel> wm;
+  SCIStrategicPluginConfig config;
+  SCIStrategicPlugin sci(wm, config);
+
+  auto result = sci.composeStopAndWaitManeuverMessage(10.2, 20.4, 5, 1200, 1201, ros::Time(1.2), ros::Time(2.2));
+
+  ASSERT_EQ(cav_msgs::Maneuver::STOP_AND_WAIT, result.type);
+  ASSERT_EQ(cav_msgs::ManeuverParameters::NO_NEGOTIATION, result.stop_and_wait_maneuver.parameters.negotiation_type);
+  ASSERT_EQ(cav_msgs::ManeuverParameters::HAS_TACTICAL_PLUGIN | cav_msgs::ManeuverParameters::HAS_FLOAT_META_DATA,
+            result.stop_and_wait_maneuver.parameters.presence_vector);
+  ASSERT_TRUE(config.stop_and_wait_plugin_name.compare(
+                  result.stop_and_wait_maneuver.parameters.planning_tactical_plugin) == 0);
+  ASSERT_TRUE(
+      config.strategic_plugin_name.compare(result.stop_and_wait_maneuver.parameters.planning_strategic_plugin) == 0);
+
+  ASSERT_EQ(10.2, result.stop_and_wait_maneuver.start_dist);
+  ASSERT_EQ(20.4, result.stop_and_wait_maneuver.end_dist);
+  ASSERT_EQ(5, result.stop_and_wait_maneuver.start_speed);
+  ASSERT_EQ(ros::Time(1.2), result.stop_and_wait_maneuver.start_time);
+  ASSERT_EQ(ros::Time(2.2), result.stop_and_wait_maneuver.end_time);
+  ASSERT_TRUE(result.stop_and_wait_maneuver.starting_lane_id.compare("1200") == 0);
+  ASSERT_TRUE(result.stop_and_wait_maneuver.ending_lane_id.compare("1201") == 0);
+}
+
+
 
 TEST(SCIStrategicPluginTest, findSpeedLimit)
 {

--- a/sci_strategic_plugin/test/test_strategic_plugin.cpp
+++ b/sci_strategic_plugin/test/test_strategic_plugin.cpp
@@ -346,11 +346,21 @@ TEST(SCIStrategicPluginTest, maneuvercbtest)
   SCIStrategicPluginConfig config;
   SCIStrategicPlugin sci(cmw_ptr, config);
 
+  // pose callback test
+  geometry_msgs::PoseStamped pose_msg;
+  pose_msg.pose.position.x = 1.0;
+  pose_msg.pose.position.y = 1.0;
+  auto msg = boost::make_shared<const geometry_msgs::PoseStamped>(pose_msg);
+  sci.currentPoseCb(msg);
+  ASSERT_NEAR(1.0, sci.current_downtrack_, 0.1);
+
+
   sci.approaching_stop_controlled_interction_ = true;
 
   cav_srvs::PlanManeuversRequest req;
   cav_srvs::PlanManeuversResponse resp;
 
+  // approaching intersection
   req = cav_srvs::PlanManeuversRequest();
   req.veh_x = 1.85;
   req.veh_y = 1.0; 
@@ -369,7 +379,7 @@ TEST(SCIStrategicPluginTest, maneuvercbtest)
   // case 3
   ASSERT_EQ(3, resp.new_plan.maneuvers[0].lane_following_maneuver.parameters.int_valued_meta_data[0]);
 
-
+  // at the stop line
   cav_srvs::PlanManeuversRequest req1;
   cav_srvs::PlanManeuversResponse resp1;
 
@@ -387,5 +397,6 @@ TEST(SCIStrategicPluginTest, maneuvercbtest)
   ASSERT_EQ(1, resp1.new_plan.maneuvers.size());
   ASSERT_EQ(resp1.new_plan.maneuvers[0].stop_and_wait_maneuver.starting_lane_id, "1212");
   ASSERT_EQ(resp1.new_plan.maneuvers[0].stop_and_wait_maneuver.ending_lane_id, "1212");
+
 
 }

--- a/sci_strategic_plugin/test/test_strategic_plugin.cpp
+++ b/sci_strategic_plugin/test/test_strategic_plugin.cpp
@@ -272,6 +272,19 @@ TEST(SCIStrategicPluginTest, caseTwoSpeedProfiletest)
   EXPECT_NEAR(12, metadata[4], 0.01);
 }
 
+TEST(SCIStrategicPluginTest, mob_op_cb_test)
+{
+  std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
+  SCIStrategicPluginConfig config;
+  SCIStrategicPlugin sci(wm, config);
+  sci.approaching_stop_controlled_interction_ = false;
+  cav_msgs::MobilityOperation incoming_msg;
+  incoming_msg.strategy = "Carma/stop_controlled_intersection";
+  auto msg = boost::make_shared<const cav_msgs::MobilityOperation>(incoming_msg);
+  sci.mobilityOperationCb(msg);
+  EXPECT_EQ(true, sci.approaching_stop_controlled_interction_);
+}
+
 
 TEST(SCIStrategicPluginTest, caseThreeSpeedProfiletest)
 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add intersection departure logic to the stop-controlled intersection strategic plugin. The scheduled times for entering and departing the intersection are received from CARMA Streets and maneuvers are composed according to those times, as well as specifications of the intersection such as speed limit and stop line position.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
