### PR TITLE
Revert inlanecruising to 3.7.2 and fix build errors from basic_autonomy

### DIFF
--- a/basic_autonomy/CMakeLists.txt
+++ b/basic_autonomy/CMakeLists.txt
@@ -73,6 +73,9 @@ add_library(
   ${PROJECT_NAME} 
   src/basic_autonomy.cpp
   src/smoothing/BSpline.cpp
+  src/smoothing/filters.cpp
+  src/log/log.cpp
+  src/helper_functions.cpp
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/basic_autonomy/include/basic_autonomy/helper_functions.h
+++ b/basic_autonomy/include/basic_autonomy/helper_functions.h
@@ -31,24 +31,7 @@ namespace waypoint_generation
      * \return index of nearest point in points
      */
     int get_nearest_point_index(const std::vector<lanelet::BasicPoint2d>& points,
-                                                 const cav_msgs::VehicleState& state)
-    {
-        lanelet::BasicPoint2d veh_point(state.X_pos_global, state.Y_pos_global);
-        double min_distance = std::numeric_limits<double>::max();
-        int i = 0;
-        int best_index = 0;
-        for (const auto& p : points)
-        {
-            double distance = lanelet::geometry::distance2d(p, veh_point);
-            if (distance < min_distance)
-            {
-                best_index = i;
-                min_distance = distance;
-            }
-            i++;
-        }
-        return best_index;
-    }
+                                                 const cav_msgs::VehicleState& state);
 
     /**
      * \brief Returns the nearest point (in terms of cartesian 2d distance) to the provided vehicle pose in the provided list
@@ -59,25 +42,7 @@ namespace waypoint_generation
      * \return index of nearest point in points
      */
     int get_nearest_point_index(const std::vector<PointSpeedPair>& points,
-                                                 const cav_msgs::VehicleState& state)
-    {
-        lanelet::BasicPoint2d veh_point(state.X_pos_global, state.Y_pos_global);
-        ROS_DEBUG_STREAM("veh_point: " << veh_point.x() << ", " << veh_point.y());
-        double min_distance = std::numeric_limits<double>::max();
-        int i = 0;
-        int best_index = 0;
-        for (const auto& p : points)
-        {
-            double distance = lanelet::geometry::distance2d(p.point, veh_point);
-            if (distance < min_distance)
-            {
-            best_index = i;
-            min_distance = distance;
-            }
-            i++;
-        }
-        return best_index;
-    }
+                                                 const cav_msgs::VehicleState& state);
 
     /**
      * \brief Returns the nearest "less than" point to the provided vehicle pose in the provided list by utilizing the downtrack measured along the route
@@ -90,23 +55,7 @@ namespace waypoint_generation
      * 
      * \return index of nearest point in points
      */
-    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double target_downtrack)
-    {
-        int best_index = points.size() - 1;
-        for(int i = 0;i < points.size(); i++){
-            double downtrack = wm->routeTrackPos(points[i]).downtrack;
-            if(downtrack > target_downtrack){
-                //If value is negative, best index should be index 0
-                best_index = std::max(0, i - 1);
-
-                ROS_DEBUG_STREAM("get_nearest_index_by_downtrack>> Found best_idx: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y() << ", downtrack: "<< downtrack);
-                break;
-            }
-        }
-        ROS_DEBUG_STREAM("get_nearest_index_by_downtrack>> Found best_idx: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y());
-
-        return best_index;
-    }
+    int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double target_downtrack);
 
     /**
      * \brief Helper method to split a list of PointSpeedPair into separate point and speed lists 
@@ -116,17 +65,7 @@ namespace waypoint_generation
      */ 
     void split_point_speed_pairs(const std::vector<PointSpeedPair>& points,
                                                 std::vector<lanelet::BasicPoint2d>* basic_points,
-                                                std::vector<double>* speeds)
-    {
-        basic_points->reserve(points.size());
-        speeds->reserve(points.size());
-
-        for (const auto& p : points)
-        {
-            basic_points->push_back(p.point);
-            speeds->push_back(p.speed);
-        }
-    }
+                                                std::vector<double>* speeds);
 
     /**
      * \brief Overload: Returns the nearest point to the provided vehicle pose in the provided list by utilizing the downtrack measured along the route
@@ -141,15 +80,7 @@ namespace waypoint_generation
      * \return index of nearest point in points
      */
     int get_nearest_index_by_downtrack(const std::vector<PointSpeedPair>& points, const carma_wm::WorldModelConstPtr& wm,
-                                      const cav_msgs::VehicleState& state)
-    {
-        lanelet::BasicPoint2d state_pos(state.X_pos_global, state.Y_pos_global);
-        double ending_downtrack = wm->routeTrackPos(state_pos).downtrack;
-        std::vector<lanelet::BasicPoint2d> basic_points;
-        std::vector<double> speeds;
-        split_point_speed_pairs(points, &basic_points, &speeds);
-        return get_nearest_index_by_downtrack(basic_points, wm, ending_downtrack);
-    }
+                                      const cav_msgs::VehicleState& state);
 
     /**
      * \brief Overload: Returns the nearest point to the provided vehicle pose  in the provided list by utilizing the downtrack measured along the route
@@ -164,12 +95,7 @@ namespace waypoint_generation
      * \return index of nearest point in points
      */
     int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm,
-                                      const cav_msgs::VehicleState& state)
-    {
-        lanelet::BasicPoint2d state_pos(state.X_pos_global, state.Y_pos_global);
-        double ending_downtrack = wm->routeTrackPos(state_pos).downtrack;
-        return get_nearest_index_by_downtrack(points, wm, ending_downtrack);
-    }                                                                                                                                     
+                                      const cav_msgs::VehicleState& state);                                                                                                                               
 
 
 }

--- a/basic_autonomy/include/basic_autonomy/log/log.h
+++ b/basic_autonomy/include/basic_autonomy/log/log.h
@@ -26,21 +26,12 @@ namespace log
 /**
  * \brief Helper function to convert a lanelet::BasicPoint2d to a string
  */ 
-std::string basicPointToStream(lanelet::BasicPoint2d point)
-{
-  std::ostringstream out;
-  out << point.x() << ", " << point.y();
-  return out.str();
-}
+std::string basicPointToStream(lanelet::BasicPoint2d point);
+
 /**
  * \brief Helper function to convert a PointSpeedPair to a string
  */ 
-std::string pointSpeedPairToStream(waypoint_generation::PointSpeedPair point)
-{
-  std::ostringstream out;
-  out << "Point: " << basicPointToStream(point.point) << " Speed: " << point.speed;
-  return out.str();
-}
+std::string pointSpeedPairToStream(waypoint_generation::PointSpeedPair point);
 
 /**
  * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is a string returned by func
@@ -67,13 +58,7 @@ void printDebugPerLine(const std::vector<T>& values, std::string (*free_func)(T)
 /**
  * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is << prefix << value
  */ 
-void printDoublesPerLineWithPrefix(const std::string& prefix, const std::vector<double>& values)
-{
-  for (const auto& value : values)
-  {
-    ROS_DEBUG_STREAM(prefix << value);
-  }
-}
+void printDoublesPerLineWithPrefix(const std::string& prefix, const std::vector<double>& values);
 
 }  // namespace log
 }  // namespace basic_autonomy

--- a/basic_autonomy/include/basic_autonomy/smoothing/BSpline.h
+++ b/basic_autonomy/include/basic_autonomy/smoothing/BSpline.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2019-2020 LEIDOS.
+ * Copyright (C) 2019-2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/basic_autonomy/include/basic_autonomy/smoothing/filters.h
+++ b/basic_autonomy/include/basic_autonomy/smoothing/filters.h
@@ -33,45 +33,8 @@ namespace smoothing
  * \param window_size The number of points to use in the moving window for averaging
  * 
  * \return The filterted points
- */// NEW
-std::vector<double> moving_average_filter(const std::vector<double> input, int window_size, bool ignore_first_point=true)
-{
-  if (window_size % 2 == 0) {
-    throw std::invalid_argument("moving_average_filter window size must be odd");
-  }
-
-  std::vector<double> output;
-  output.reserve(input.size());
-
-  if (input.size() == 0) {
-    return output;
-  }
-
-  int start_index = 0;
-  if (ignore_first_point) {
-    start_index = 1;
-    output.push_back(input[0]);
-  }
-
-  for (int i = start_index; i<input.size(); i++) {
-    
-    
-    double total = 0;
-    int sample_min = std::max(0, i - window_size / 2);
-    int sample_max = std::min((int) input.size() - 1 , i + window_size / 2);
-
-    int count = sample_max - sample_min + 1;
-    std::vector<double> sample;
-    sample.reserve(count);
-    for (int j = sample_min; j <= sample_max; j++) {
-      total += input[j];
-    }
-    output.push_back(total / (double) count);
-
-  }
-
-  return output;
-}
+ */
+std::vector<double> moving_average_filter(const std::vector<double> input, int window_size, bool ignore_first_point=true);
 
 };  // namespace smoothing
 };  // namespace basic_autonomy

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 LEIDOS.
+ * Copyright (C) 2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/basic_autonomy/src/log/log.cpp
+++ b/basic_autonomy/src/log/log.cpp
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <basic_autonomy/log/log.h>
+
+namespace basic_autonomy
+{
+namespace log
+{
+/**
+ * \brief Helper function to convert a lanelet::BasicPoint2d to a string
+ */ 
+std::string basicPointToStream(lanelet::BasicPoint2d point)
+{
+  std::ostringstream out;
+  out << point.x() << ", " << point.y();
+  return out.str();
+}
+/**
+ * \brief Helper function to convert a PointSpeedPair to a string
+ */ 
+std::string pointSpeedPairToStream(waypoint_generation::PointSpeedPair point)
+{
+  std::ostringstream out;
+  out << "Point: " << basicPointToStream(point.point) << " Speed: " << point.speed;
+  return out.str();
+}
+
+/**
+ * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is << prefix << value
+ */ 
+void printDoublesPerLineWithPrefix(const std::string& prefix, const std::vector<double>& values)
+{
+  for (const auto& value : values)
+  {
+    ROS_DEBUG_STREAM(prefix << value);
+  }
+}
+
+}  // namespace log
+}  // namespace basic_autonomy

--- a/basic_autonomy/src/smoothing/BSpline.cpp
+++ b/basic_autonomy/src/smoothing/BSpline.cpp
@@ -1,3 +1,21 @@
+
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
 #include <basic_autonomy/smoothing/BSpline.h>
 
 namespace basic_autonomy

--- a/basic_autonomy/src/smoothing/filters.cpp
+++ b/basic_autonomy/src/smoothing/filters.cpp
@@ -1,0 +1,64 @@
+
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <basic_autonomy/smoothing/filters.h>
+namespace basic_autonomy
+{
+namespace smoothing
+{
+
+std::vector<double> moving_average_filter(const std::vector<double> input, int window_size, bool ignore_first_point)
+{
+  if (window_size % 2 == 0) {
+    throw std::invalid_argument("moving_average_filter window size must be odd");
+  }
+
+  std::vector<double> output;
+  output.reserve(input.size());
+
+  if (input.size() == 0) {
+    return output;
+  }
+
+  int start_index = 0;
+  if (ignore_first_point) {
+    start_index = 1;
+    output.push_back(input[0]);
+  }
+
+  for (int i = start_index; i<input.size(); i++) {
+    
+    
+    double total = 0;
+    int sample_min = std::max(0, i - window_size / 2);
+    int sample_max = std::min((int) input.size() - 1 , i + window_size / 2);
+
+    int count = sample_max - sample_min + 1;
+    std::vector<double> sample;
+    sample.reserve(count);
+    for (int j = sample_min; j <= sample_max; j++) {
+      total += input[j];
+    }
+    output.push_back(total / (double) count);
+
+  }
+
+  return output;
+}
+
+};  // namespace smoothing
+};  // namespace basic_autonomy

--- a/inlanecruising_plugin/CMakeLists.txt
+++ b/inlanecruising_plugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018-2021 LEIDOS.
+# Copyright (C) 2018-2020 LEIDOS.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -31,7 +31,6 @@ set( CATKIN_DEPS
   trajectory_utils
   autoware_msgs
   carma_wm
-  basic_autonomy
   tf
   tf2
   tf2_geometry_msgs
@@ -73,13 +72,13 @@ add_executable( ${PROJECT_NAME}
   src/main.cpp)
 add_library(inlanecruising_plugin_library 
   src/inlanecruising_plugin.cpp
+  src/smoothing/BSpline.cpp
 )
-
-add_dependencies(inlanecruising_plugin_library ${catkin_EXPORTED_TARGETS})
 target_link_libraries(inlanecruising_plugin_library ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(inlanecruising_plugin_library ${catkin_EXPORTED_TARGETS})
 
-add_dependencies(${PROJECT_NAME} inlanecruising_plugin_library ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} inlanecruising_plugin_library ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(${PROJECT_NAME} inlanecruising_plugin_library ${catkin_EXPORTED_TARGETS})
 
 add_library(helper src/helper.cpp)
 target_link_libraries(helper
@@ -119,6 +118,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gmock(${PROJECT_NAME}-test 
     test/test_inlanecruising_plugin_planning.cpp
+    test/test_inlanecruising_plugin.cpp
   )
   target_link_libraries(${PROJECT_NAME}-test inlanecruising_plugin_library ${catkin_LIBRARIES})
 

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_config.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2020-2021 LEIDOS.
+ * Copyright (C) 2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,16 +24,16 @@
 #include <carma_utils/CARMAUtils.h>
 #include <boost/geometry.hpp>
 #include <carma_wm/Geometry.h>
-#include <basic_autonomy/basic_autonomy.h>
 #include <cav_srvs/PlanTrajectory.h>
 #include <carma_wm/WMListener.h>
-#include <carma_debug_msgs/TrajectoryCurvatureSpeeds.h>
 #include <functional>
+#include <inlanecruising_plugin/smoothing/SplineI.h>
 #include "inlanecruising_config.h"
 #include <unordered_set>
 #include <autoware_msgs/Lane.h>
 #include <ros/ros.h>
 #include <carma_debug_msgs/TrajectoryCurvatureSpeeds.h>
+#include <basic_autonomy/helper_functions.h>
 
 namespace inlanecruising_plugin
 {
@@ -77,6 +77,135 @@ public:
   bool onSpin();
 
   /**
+   * \brief Applies the provided speed limits to the provided speeds such that each element is capped at its corresponding speed limit if needed
+   * 
+   * \param speeds The speeds to limit
+   * \param speed_limits The speed limits to apply. Must have the same size as speeds
+   * 
+   * \return The capped speed limits. Has the same size as speeds
+   */ 
+  std::vector<double> apply_speed_limits(const std::vector<double> speeds, const std::vector<double> speed_limits);
+
+  /**
+   * \brief Returns a 2D coordinate frame which is located at p1 and oriented so p2 lies on the +X axis
+   * 
+   * \param p1 The origin point for the frame in the parent frame
+   * \param p2 A point in the parent frame that will define the +X axis relative to p1
+   * 
+   * \return A 2D coordinate frame transform
+   */ 
+  Eigen::Isometry2d compute_heading_frame(const lanelet::BasicPoint2d& p1, const lanelet::BasicPoint2d& p2);
+
+  /**
+   * \brief Reduces the input points to only those points that fit within the provided time boundary
+   * 
+   * \param points The input point speed pairs to reduce
+   * \param time_span The time span in seconds which the output points will fit within
+   * 
+   * \return The subset of points that fit within time_span
+   */ 
+  std::vector<PointSpeedPair> constrain_to_time_boundary(const std::vector<PointSpeedPair>& points, double time_span);
+
+  /**
+   * \brief Method converts a list of lanelet centerline points and current vehicle state into a usable list of trajectory points for trajectory planning
+   * 
+   * \param points The set of points that define the current lane the vehicle is in and are defined based on the request planning maneuvers. 
+   *               These points must be in the same lane as the vehicle and must extend in front of it though it is fine if they also extend behind it. 
+   * \param state The current state of the vehicle
+   * \param state_time The abosolute time which the provided vehicle state corresponds to
+   * 
+   * \return A list of trajectory points to send to the carma planning stack
+   */ 
+  std::vector<cav_msgs::TrajectoryPlanPoint>
+  compose_trajectory_from_centerline(const std::vector<PointSpeedPair>& points, const cav_msgs::VehicleState& state, const ros::Time& state_time);
+
+  /**
+   * \brief Method combines input points, times, orientations, and an absolute start time to form a valid carma platform trajectory
+   * 
+   * NOTE: All input vectors must be the same size. The output vector will take this size.
+   * 
+   * \param points The points in the map frame that the trajectory will follow. Units m
+   * \param times The times which at the vehicle should arrive at the specified points. First point should have a value of 0. Units s
+   * \param yaws The orientation the vehicle should achieve at each point. Units radians
+   * \param startTime The absolute start time which will be used to update the input relative times. Units s
+   * 
+   * \return A list of trajectory points built from the provided inputs.
+   */ 
+  std::vector<cav_msgs::TrajectoryPlanPoint> trajectory_from_points_times_orientations(
+      const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& times,
+      const std::vector<double>& yaws, ros::Time startTime);
+
+  /**
+   * \brief Converts a set of requested LANE_FOLLOWING maneuvers to point speed limit pairs. 
+   * 
+   * \param maneuvers The list of maneuvers to convert
+   * \param max_starting_downtrack The maximum downtrack that is allowed for the first maneuver. This should be set to the vehicle position or earlier.
+   *                               If the first maneuver exceeds this then it's downtrack will be shifted to this value.
+   * 
+   * \param wm Pointer to intialized world model for semantic map access
+   * 
+   * \return List of centerline points paired with speed limits
+   */ 
+  std::vector<PointSpeedPair> maneuvers_to_points(const std::vector<cav_msgs::Maneuver>& maneuvers,
+                                                  double max_starting_downtrack,
+                                                  const carma_wm::WorldModelConstPtr& wm);
+
+  /**
+   * \brief Computes a spline based on the provided points
+   * 
+   * \param basic_points The points to use for fitting the spline
+   * 
+   * \return A spline which has been fit to the provided points
+   */ 
+  std::unique_ptr<smoothing::SplineI> compute_fit(const std::vector<lanelet::BasicPoint2d>& basic_points);
+
+  /**
+   * \brief Returns the speeds of points closest to the lookahead distance.
+   * 
+   * \param points The points in the map frame that the trajectory will follow. Units m
+   * \param speeds Speeds assigned to points that trajectory will follow. Unit m/s
+   * \param lookahead The lookahead distance to obtain future points' speed. Unit m
+   * 
+   * \return A vector of speed values shifted by the lookahead distance.
+   */ 
+
+  std::vector<double> get_lookahead_speed(const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& speeds, const double& lookahead);
+
+  /**
+   * \brief Applies the longitudinal acceleration limit to each point's speed
+   * 
+   * \param downtracks downtrack distances corresponding to each speed
+   * \param curv_speeds vehicle velocity in m/s.
+   * \param accel_limit vehicle longitudinal acceleration in m/s^2.
+   * 
+   * \return optimized speeds for each dowtrack points that satisfies longitudinal acceleration
+   */ 
+  std::vector<double> optimize_speed(const std::vector<double>& downtracks, const std::vector<double>& curv_speeds, double accel_limit);
+
+  /**
+   * \brief Given the curvature fit, computes the curvature at the given step along the curve
+   * 
+   * \param step_along_the_curve Value in double from 0.0 (curvature start) to 1.0 (curvature end) representing where to calculate the curvature
+   * 
+   * \param fit_curve curvature fit
+   * 
+   * \return Curvature (k = 1/r, 1/meter)
+   */ 
+  double compute_curvature_at(const inlanecruising_plugin::smoothing::SplineI& fit_curve, double step_along_the_curve) const;
+
+    /**
+   * \brief Attaches back_distance length of points in front of future points
+   * 
+   * \param points all point speed pairs
+   * \param nearest_pt_index idx of nearest point to the vehicle
+   * \param future_points future points before which to attach the points
+   * \param back_distance number of back distance in meters
+   * 
+   * \return point speed pairs with back distance length of points in front of future points
+   */ 
+  std::vector<PointSpeedPair> attach_back_points(const std::vector<PointSpeedPair>& points, const int nearest_pt_index, 
+                               std::vector<inlanecruising_plugin::PointSpeedPair> future_points, double back_distance) const;
+  /**
    * \brief set the yield service
    * 
    * \param yield_srv input yield service
@@ -91,11 +220,20 @@ public:
    * \return true or falss
    */
   bool validate_yield_plan(const cav_msgs::TrajectoryPlan& yield_plan);
-
-  cav_msgs::VehicleState ending_state_before_buffer_; //state before applying extra points for curvature calculation that are removed later
   
 private:
 
+  /**
+   * \brief Returns the min, and its idx, from the vector of values, excluding given set of values
+   * 
+   * \param values vector of values
+   * 
+   * \param excluded set of excluded values
+   * 
+   * \return minimum value and its idx
+   */ 
+  std::pair<double, size_t> min_with_exclusions(const std::vector<double>& values, const std::unordered_set<size_t>& excluded) const;
+  
   carma_wm::WorldModelConstPtr wm_;
   InLaneCruisingPluginConfig config_;
   PublishPluginDiscoveryCB plugin_discovery_publisher_;
@@ -104,6 +242,7 @@ private:
   cav_msgs::Plugin plugin_discovery_msg_;
   DebugPublisher debug_publisher_;
   carma_debug_msgs::TrajectoryCurvatureSpeeds debug_msg_;
+  cav_msgs::VehicleState ending_state_before_buffer; //state before applying extra points for curvature calculation that are removed later
 
 };
 

--- a/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/inlanecruising_plugin_node.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -63,7 +63,6 @@ public:
                      config.speed_moving_average_window_size);
     pnh.param<int>("curvature_moving_average_window_size", config.curvature_moving_average_window_size,
                      config.curvature_moving_average_window_size);
-    pnh.param<double>("buffer_ending_downtrack", config.buffer_ending_downtrack, config.buffer_ending_downtrack);
     pnh.param<double>("/vehicle_acceleration_limit", config.max_accel, config.max_accel);
     pnh.param<double>("/vehicle_lateral_accel_limit", config.lateral_accel_limit, config.lateral_accel_limit);
     pnh.param<bool>("enable_object_avoidance", config.enable_object_avoidance, config.enable_object_avoidance);

--- a/inlanecruising_plugin/include/inlanecruising_plugin/log/log.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/log/log.h
@@ -1,0 +1,61 @@
+#include <sstream>
+#include <inlanecruising_plugin/inlanecruising_plugin.h>
+
+namespace inlanecruising_plugin
+{
+namespace log
+{
+/**
+ * \brief Helper function to convert a lanelet::BasicPoint2d to a string
+ */ 
+std::string basicPointToStream(lanelet::BasicPoint2d point)
+{
+  std::ostringstream out;
+  out << point.x() << ", " << point.y();
+  return out.str();
+}
+/**
+ * \brief Helper function to convert a PointSpeedPair to a string
+ */ 
+std::string pointSpeedPairToStream(PointSpeedPair point)
+{
+  std::ostringstream out;
+  out << "Point: " << basicPointToStream(point.point) << " Speed: " << point.speed;
+  return out.str();
+}
+
+/**
+ * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is a string returned by func
+ */ 
+template <class T>
+void printDebugPerLine(const std::vector<T>& values, std::function<std::string(T)> func)
+{
+  for (const auto& value : values)
+  {
+    ROS_DEBUG_STREAM(func(value));
+  }
+}
+
+/**
+ * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is a string returned by free_func
+ */ 
+template <class T>
+void printDebugPerLine(const std::vector<T>& values, std::string (*free_func)(T))
+{
+  auto function = static_cast<std::function<std::string(T)>>(free_func);
+  printDebugPerLine(values, function);
+}
+
+/**
+ * \brief Print a ROS_DEBUG_STREAM for each value in values where the printed value is << prefix << value
+ */ 
+void printDoublesPerLineWithPrefix(const std::string& prefix, const std::vector<double>& values)
+{
+  for (const auto& value : values)
+  {
+    ROS_DEBUG_STREAM(prefix << value);
+  }
+}
+
+}  // namespace log
+}  // namespace inlanecruising_plugin

--- a/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/BSpline.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/BSpline.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <carma_wm/Geometry.h>
+#include <inlanecruising_plugin/smoothing/SplineI.h>
+#include <unsupported/Eigen/Splines>
+
+namespace inlanecruising_plugin
+{
+namespace smoothing
+{
+
+  typedef Eigen::Spline<double, 2> Spline2d;
+/**
+ * \brief Realization of SplineI that uses the Eigen::Splines library for interpolation 
+ */ 
+class BSpline : public SplineI
+{
+public:
+  ~BSpline(){};
+  void setPoints(std::vector<lanelet::BasicPoint2d> points) override;
+  lanelet::BasicPoint2d operator()(double t) const override;
+  lanelet::BasicPoint2d first_deriv(double t) const override;
+  lanelet::BasicPoint2d second_deriv(double t) const override;
+private:
+  Spline2d spline_;
+};
+};  // namespace smoothing
+};  // namespace inlanecruising_plugin

--- a/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/SplineI.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/SplineI.h
@@ -1,0 +1,73 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <carma_wm/Geometry.h>
+
+namespace inlanecruising_plugin
+{
+namespace smoothing
+{
+/**
+ * \brief Interface to a spline interpolator that can be used to smoothly interpolate between points
+ */ 
+class SplineI
+{
+public:
+  /**
+   * @brief Virtual destructor to ensure delete safety for pointers to implementing classes
+   *
+   */
+  virtual ~SplineI(){};
+
+  /**
+   * \brief Set key points which the spline will interpolate between
+   * 
+   * \param points The key points
+   */ 
+  virtual void setPoints(std::vector<lanelet::BasicPoint2d> points) = 0;
+  
+    /**
+  *  \brief Get the BasicPoint2d coordinate along the curve at t-th step. 
+   * 
+   * \param t The t-th step to solve the spline at, where t is from 0 (beginning of curve) to 1 (end of curve)
+   * 
+   * \return lanelet::BasicPoint2d with x, y that matches the t-th step along the curve
+   */ 
+  virtual lanelet::BasicPoint2d operator()(double t) const = 0;
+
+  /**
+  *  \brief Get the BasicPoint2d representing the first_deriv along the curve at t-th step. 
+   * 
+   * \param t The t-th step to solve the spline at, where t is from 0 (beginning of curve) to 1 (end of curve)
+   * 
+   * \return lanelet::BasicPoint2d with x, y that matches the first_deriv at t-th step along the curve. This is not partial derivatives
+   */ 
+  virtual lanelet::BasicPoint2d first_deriv(double x) const = 0;
+
+  /**
+  *  \brief Get the BasicPoint2d representing the first_deriv along the curve at t-th step. 
+   * 
+   * \param t The t-th step to solve the spline at, where t is from 0 (beginning of curve) to 1 (end of curve)
+   * 
+   * \return lanelet::BasicPoint2d with x, y that matches the second_deriv at t-th step along the curve. This is not partial derivatives
+   */ 
+  virtual lanelet::BasicPoint2d second_deriv(double x) const = 0;
+};
+};  // namespace smoothing
+};  // namespace inlanecruising_plugin

--- a/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/filters.h
+++ b/inlanecruising_plugin/include/inlanecruising_plugin/smoothing/filters.h
@@ -1,0 +1,77 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <deque>
+#include <algorithm>
+#include <stdexcept>
+namespace inlanecruising_plugin
+{
+namespace smoothing
+{
+
+
+/**
+ * \brief Extremely simplie moving average filter
+ * 
+ * \param input The points to be filtered
+ * \param window_size The number of points to use in the moving window for averaging
+ * 
+ * \return The filterted points
+ */// NEW
+std::vector<double> moving_average_filter(const std::vector<double> input, int window_size, bool ignore_first_point=true)
+{
+  if (window_size % 2 == 0) {
+    throw std::invalid_argument("moving_average_filter window size must be odd");
+  }
+
+  std::vector<double> output;
+  output.reserve(input.size());
+
+  if (input.size() == 0) {
+    return output;
+  }
+
+  int start_index = 0;
+  if (ignore_first_point) {
+    start_index = 1;
+    output.push_back(input[0]);
+  }
+
+  for (int i = start_index; i<input.size(); i++) {
+    
+    
+    double total = 0;
+    int sample_min = std::max(0, i - window_size / 2);
+    int sample_max = std::min((int) input.size() - 1 , i + window_size / 2);
+
+    int count = sample_max - sample_min + 1;
+    std::vector<double> sample;
+    sample.reserve(count);
+    for (int j = sample_min; j <= sample_max; j++) {
+      total += input[j];
+    }
+    output.push_back(total / (double) count);
+
+  }
+
+  return output;
+}
+
+};  // namespace smoothing
+};  // namespace inlanecruising_plugin

--- a/inlanecruising_plugin/launch/inlanecruising_plugin.launch
+++ b/inlanecruising_plugin/launch/inlanecruising_plugin.launch
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2018-2021 LEIDOS.
+  Copyright (C) 2018-2020 LEIDOS.
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at

--- a/inlanecruising_plugin/package.xml
+++ b/inlanecruising_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--  
- Copyright (C) 2018-2021 LEIDOS.
+ Copyright (C) 2018-2020 LEIDOS.
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not
  use this file except in compliance with the License. You may obtain a copy of
@@ -31,10 +31,10 @@
   <depend>carma_utils</depend>
   <depend>autoware_msgs</depend>
   <depend>carma_wm</depend>
-  <depend>basic_autonomy</depend>
   <depend>tf</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend> 
   <depend>trajectory_utils</depend>   
-  <depend>carma_debug_msgs</depend>  
+  <depend>carma_debug_msgs</depend> 
+  <depend>basic_autonomy</depend>   
 </package>

--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,8 +29,11 @@
 #include <Eigen/Geometry>
 #include <Eigen/LU>
 #include <Eigen/SVD>
+#include <inlanecruising_plugin/smoothing/SplineI.h>
+#include <inlanecruising_plugin/smoothing/BSpline.h>
 #include <inlanecruising_plugin/inlanecruising_plugin.h>
-
+#include <inlanecruising_plugin/log/log.h>
+#include <inlanecruising_plugin/smoothing/filters.h>
 
 
 
@@ -78,24 +81,7 @@ bool InLaneCruisingPlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest& r
       break;
     }
   }
-
-  basic_autonomy:: waypoint_generation::DetailedTrajConfig wpg_detail_config;
-  basic_autonomy:: waypoint_generation::GeneralTrajConfig wpg_general_config;
-
-  wpg_general_config = basic_autonomy:: waypoint_generation::compose_general_trajectory_config("inlanecruising",
-                                                                              config_.default_downsample_ratio,
-                                                                              config_.turn_downsample_ratio);
-
-  wpg_detail_config = basic_autonomy:: waypoint_generation::compose_detailed_trajectory_config(config_.trajectory_time_length, 
-                                                                            config_.curve_resample_step_size, config_.minimum_speed, 
-                                                                            config_.max_accel * config_.max_accel_multiplier,
-                                                                            config_.lateral_accel_limit * config_.lat_accel_multiplier, 
-                                                                            config_.speed_moving_average_window_size, 
-                                                                            config_.curvature_moving_average_window_size, config_.back_distance,
-                                                                            config_.buffer_ending_downtrack);
-  
-  auto points_and_target_speeds = basic_autonomy::waypoint_generation::create_geometry_profile(maneuver_plan, std::max((double)0, current_downtrack - config_.back_distance),
-                                                                         wm_, ending_state_before_buffer_, req.vehicle_state, wpg_general_config, wpg_detail_config);
+  auto points_and_target_speeds = maneuvers_to_points(maneuver_plan, std::max((double)0, current_downtrack - config_.back_distance), wm_); // Convert maneuvers to points
 
   ROS_DEBUG_STREAM("points_and_target_speeds: " << points_and_target_speeds.size());
 
@@ -106,17 +92,9 @@ bool InLaneCruisingPlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest& r
   original_trajectory.header.stamp = ros::Time::now();
   original_trajectory.trajectory_id = boost::uuids::to_string(boost::uuids::random_generator()());
 
-  original_trajectory.trajectory_points = basic_autonomy:: waypoint_generation::compose_lanefollow_trajectory_from_path(points_and_target_speeds, 
-                                                                                req.vehicle_state, req.header.stamp, wm_, ending_state_before_buffer_, debug_msg_, 
-                                                                                wpg_detail_config); // Compute the trajectory
+  original_trajectory.trajectory_points = compose_trajectory_from_centerline(points_and_target_speeds, req.vehicle_state, req.header.stamp); // Compute the trajectory
   original_trajectory.initial_longitudinal_velocity = std::max(req.vehicle_state.longitudinal_vel, config_.minimum_speed);
 
-  // Set the planning plugin field name
-  for (auto& p : original_trajectory.trajectory_points) {
-    p.planner_plugin_name = plugin_discovery_msg_.name;
-  }
-  
-  
   if (config_.enable_object_avoidance)
   {
     ROS_DEBUG_STREAM("Activate Object Avoidance");
@@ -171,6 +149,582 @@ bool InLaneCruisingPlugin::plan_trajectory_cb(cav_srvs::PlanTrajectoryRequest& r
   ROS_DEBUG_STREAM("ExecutionTime: " << duration.toSec());
 
   return true;
+}
+
+std::vector<double> InLaneCruisingPlugin::apply_speed_limits(const std::vector<double> speeds,
+                                                             const std::vector<double> speed_limits)
+{
+  ROS_DEBUG_STREAM("Speeds list size: " << speeds.size());
+  ROS_DEBUG_STREAM("SpeedLimits list size: " << speed_limits.size());
+
+  if (speeds.size() != speed_limits.size())
+  {
+    throw std::invalid_argument("Speeds and speed limit lists not same size");
+  }
+  std::vector<double> out;
+  for (size_t i = 0; i < speeds.size(); i++)
+  {
+    out.push_back(std::min(speeds[i], speed_limits[i]));
+  }
+
+  return out;
+}
+
+Eigen::Isometry2d InLaneCruisingPlugin::compute_heading_frame(const lanelet::BasicPoint2d& p1,
+                                                              const lanelet::BasicPoint2d& p2)
+{
+  Eigen::Rotation2Dd yaw(atan2(p2.y() - p1.y(), p2.x() - p1.x()));
+
+  return carma_wm::geometry::build2dEigenTransform(p1, yaw);
+}
+
+
+
+std::pair<double, size_t> InLaneCruisingPlugin::min_with_exclusions(const std::vector<double>& values, const std::unordered_set<size_t>& excluded) const {
+  double min = std::numeric_limits<double>::max();
+  size_t best_idx = -1;
+  for (size_t i = 0; i < values.size(); i++) {
+    if (excluded.find(i) != excluded.end()) {
+      continue;
+    }
+
+    if (values[i] < min) {
+      min = values[i];
+      best_idx = i;
+    }
+  }
+
+  return std::make_pair(min, best_idx);
+}
+
+std::vector<double> InLaneCruisingPlugin::optimize_speed(const std::vector<double>& downtracks, const std::vector<double>& curv_speeds, double accel_limit)
+{
+  if (downtracks.size() != curv_speeds.size())
+  {
+    throw std::invalid_argument("Downtracks and speeds do not have the same size");
+  }
+
+  if (accel_limit <= 0)
+  {
+    throw std::invalid_argument("Accel limits should be positive");
+  }
+
+  bool optimize = true;
+  std::unordered_set<size_t> visited_idx;
+  visited_idx.reserve(curv_speeds.size());
+
+  std::vector<double> output = curv_speeds;
+
+  while (optimize)
+  {
+    auto min_pair = min_with_exclusions(curv_speeds, visited_idx);
+    size_t min_idx = std::get<1>(min_pair);
+    if (min_idx == -1) {
+      break;
+    }
+
+    visited_idx.insert(min_idx); // Mark this point as visited
+
+    double v_i = std::get<0>(min_pair);
+    double x_i = downtracks[min_idx];
+    for (int i = min_idx - 1; i > 0; i--) { // NOTE: Do not use size_t for i type here as -- with > 0 will result in overflow
+                                            //       First point's speed is left unchanged as it is current speed of the vehicle
+      double v_f = curv_speeds[i];
+      double dv = v_f - v_i;
+      
+      double x_f = downtracks[i];
+      double dx = x_f - x_i;
+
+      if(dv > 0) {
+        v_f = std::min(v_f, sqrt(v_i * v_i - 2 * accel_limit * dx)); // inverting accel as we are only visiting deceleration case
+        visited_idx.insert(i);
+      } else if (dv < 0) {
+        break;
+      }
+      output[i] = v_f;
+      v_i = v_f;
+      x_i = x_f;
+    }
+  }
+
+  log::printDoublesPerLineWithPrefix("only_reverse[i]: ", output);
+  
+  output = trajectory_utils::apply_accel_limits_by_distance(downtracks, output, accel_limit, accel_limit);
+  log::printDoublesPerLineWithPrefix("after_forward[i]: ", output);
+
+  return output;
+}
+
+std::vector<PointSpeedPair> InLaneCruisingPlugin::constrain_to_time_boundary(const std::vector<PointSpeedPair>& points,
+                                                                             double time_span)
+{
+  std::vector<lanelet::BasicPoint2d> basic_points;
+  std::vector<double> speeds;
+  basic_autonomy::waypoint_generation::split_point_speed_pairs(points, &basic_points, &speeds);
+
+  std::vector<double> downtracks = carma_wm::geometry::compute_arc_lengths(basic_points);
+
+  size_t time_boundary_exclusive_index =
+      trajectory_utils::time_boundary_index(downtracks, speeds, config_.trajectory_time_length);
+
+  if (time_boundary_exclusive_index == 0)
+  {
+    throw std::invalid_argument("No points to fit in timespan"); 
+  }
+
+  std::vector<PointSpeedPair> time_bound_points;
+  time_bound_points.reserve(time_boundary_exclusive_index);
+
+  if (time_boundary_exclusive_index == points.size())
+  {
+    time_bound_points.insert(time_bound_points.end(), points.begin(),
+                             points.end());  // All points fit within time boundary
+  }
+  else
+  {
+    time_bound_points.insert(time_bound_points.end(), points.begin(),
+                             points.begin() + time_boundary_exclusive_index - 1);  // Limit points by time boundary
+  }
+
+  return time_bound_points;
+}
+
+
+std::vector<cav_msgs::TrajectoryPlanPoint> InLaneCruisingPlugin::compose_trajectory_from_centerline(
+    const std::vector<PointSpeedPair>& points, const cav_msgs::VehicleState& state, const ros::Time& state_time)
+{
+ ROS_DEBUG_STREAM("VehicleState: "
+                   << " x: " << state.X_pos_global << " y: " << state.Y_pos_global << " yaw: " << state.orientation
+                   << " speed: " << state.longitudinal_vel);
+
+  log::printDebugPerLine(points, &log::pointSpeedPairToStream);
+
+  int nearest_pt_index = basic_autonomy::waypoint_generation::get_nearest_index_by_downtrack(points, wm_, state);
+
+  ROS_DEBUG_STREAM("NearestPtIndex: " << nearest_pt_index);
+
+  std::vector<PointSpeedPair> future_points(points.begin() + nearest_pt_index + 1, points.end()); // Points in front of current vehicle position
+  auto time_bound_points = constrain_to_time_boundary(future_points, config_.trajectory_time_length);
+  
+  ROS_DEBUG_STREAM("Got time_bound_points with size:" << time_bound_points.size());
+  log::printDebugPerLine(time_bound_points, &log::pointSpeedPairToStream);
+
+
+  std::vector<PointSpeedPair> back_and_future = attach_back_points(points,nearest_pt_index,time_bound_points, config_.back_distance);
+
+  ROS_DEBUG_STREAM("Got back_and_future points with size" <<back_and_future.size());
+  log::printDebugPerLine(back_and_future, &log::pointSpeedPairToStream);
+
+  std::vector<double> speed_limits;
+  std::vector<lanelet::BasicPoint2d> curve_points;
+  basic_autonomy::waypoint_generation::split_point_speed_pairs(back_and_future, &curve_points, &speed_limits);
+  
+  std::unique_ptr<smoothing::SplineI> fit_curve = compute_fit(curve_points); // Compute splines based on curve points
+  if (!fit_curve)
+  {
+    throw std::invalid_argument("Could not fit a spline curve along the given trajectory!");
+  }
+
+  ROS_DEBUG("Got fit");
+
+  ROS_DEBUG_STREAM("speed_limits.size() " << speed_limits.size());
+
+  std::vector<lanelet::BasicPoint2d> all_sampling_points;
+  all_sampling_points.reserve(1 + curve_points.size() * 2);
+
+  std::vector<double> distributed_speed_limits;
+  distributed_speed_limits.reserve(1 + curve_points.size() * 2);
+
+  // compute total length of the trajectory to get correct number of points 
+  // we expect using curve_resample_step_size
+  std::vector<double> downtracks_raw = carma_wm::geometry::compute_arc_lengths(curve_points);
+
+  int total_step_along_curve = static_cast<int>(downtracks_raw.back() / config_.curve_resample_step_size);
+
+  int current_speed_index = 0;
+  size_t total_point_size = curve_points.size();
+
+  double step_threshold_for_next_speed = (double)total_step_along_curve / (double)total_point_size;
+  double scaled_steps_along_curve = 0.0; // from 0 (start) to 1 (end) for the whole trajectory
+  std::vector<double> better_curvature;
+  better_curvature.reserve(1 + curve_points.size() * 2);
+    
+  for (size_t steps_along_curve = 0; steps_along_curve < total_step_along_curve; steps_along_curve++) // Resample curve at tighter resolution
+  {
+    lanelet::BasicPoint2d p = (*fit_curve)(scaled_steps_along_curve);
+    
+    all_sampling_points.push_back(p);
+    double c = compute_curvature_at((*fit_curve), scaled_steps_along_curve);
+    better_curvature.push_back(c);
+    if ((double)steps_along_curve > step_threshold_for_next_speed)
+    {
+      step_threshold_for_next_speed += (double)total_step_along_curve / (double) total_point_size;
+      current_speed_index ++;
+    }
+    distributed_speed_limits.push_back(speed_limits[current_speed_index]); // Identify speed limits for resampled points
+    scaled_steps_along_curve += 1.0/total_step_along_curve; //adding steps_along_curve_step_size
+  }
+
+  ROS_DEBUG_STREAM("Got sampled points with size:" << all_sampling_points.size());
+  log::printDebugPerLine(all_sampling_points, &log::basicPointToStream);
+
+  std::vector<double> final_yaw_values = carma_wm::geometry::compute_tangent_orientations(all_sampling_points);
+
+  log::printDoublesPerLineWithPrefix("raw_curvatures[i]: ", better_curvature);
+
+  std::vector<double> curvatures = smoothing::moving_average_filter(better_curvature, config_.curvature_moving_average_window_size, false);
+
+  std::vector<double> ideal_speeds =
+      trajectory_utils::constrained_speeds_for_curvatures(curvatures, config_.lateral_accel_limit);
+  
+  log::printDoublesPerLineWithPrefix("curvatures[i]: ", curvatures);
+  log::printDoublesPerLineWithPrefix("ideal_speeds: ", ideal_speeds);
+  log::printDoublesPerLineWithPrefix("final_yaw_values[i]: ", final_yaw_values);
+
+  std::vector<double> constrained_speed_limits = apply_speed_limits(ideal_speeds, distributed_speed_limits);
+  log::printDoublesPerLineWithPrefix("constrained_speed_limits: ", constrained_speed_limits);
+
+  ROS_DEBUG("Processed all points in computed fit");
+
+  if (all_sampling_points.size() == 0)
+  {
+    ROS_WARN_STREAM("No trajectory points could be generated");
+    return {};
+  }
+
+  // Add current vehicle point to front of the trajectory
+
+  nearest_pt_index = basic_autonomy::waypoint_generation::get_nearest_index_by_downtrack(all_sampling_points,wm_, state);
+  ROS_DEBUG_STREAM("Current state's nearest_pt_index: " << nearest_pt_index);
+  ROS_DEBUG_STREAM("Curvature right now: " << better_curvature[nearest_pt_index] << ", at state x: " << state.X_pos_global << ", state y: " << state.Y_pos_global);
+  ROS_DEBUG_STREAM("Corresponding to point: x: " << all_sampling_points[nearest_pt_index].x() << ", y:" << all_sampling_points[nearest_pt_index].y());
+
+  int buffer_pt_index = basic_autonomy::waypoint_generation::get_nearest_index_by_downtrack(all_sampling_points,wm_, ending_state_before_buffer);
+  ROS_DEBUG_STREAM("Ending state's index before applying buffer (buffer_pt_index): " << buffer_pt_index);
+  ROS_DEBUG_STREAM("Corresponding to point: x: " << all_sampling_points[buffer_pt_index].x() << ", y:" << all_sampling_points[buffer_pt_index].y());
+  
+  if (nearest_pt_index + 1 >= buffer_pt_index)
+  {
+    ROS_WARN_STREAM("Current state is at or passed the planned end distance. Couldn't generate trajectory");
+    return {};
+  }
+  //drop buffer points here
+  std::vector<lanelet::BasicPoint2d> future_basic_points(all_sampling_points.begin() + nearest_pt_index + 1,
+                                            all_sampling_points.begin()+ buffer_pt_index);  // Points in front of current vehicle position
+
+  std::vector<double> future_speeds(constrained_speed_limits.begin() + nearest_pt_index + 1,
+                                            constrained_speed_limits.begin() + buffer_pt_index);  // Points in front of current vehicle position
+  std::vector<double> future_yaw(final_yaw_values.begin() + nearest_pt_index + 1,
+                                            final_yaw_values.begin() + buffer_pt_index);  // Points in front of current vehicle position
+  std::vector<double>  final_actual_speeds = future_speeds;
+  all_sampling_points = future_basic_points;
+  final_yaw_values = future_yaw;
+  ROS_DEBUG_STREAM("Trimmed future points to size: " << future_basic_points.size() );
+
+  lanelet::BasicPoint2d cur_veh_point(state.X_pos_global, state.Y_pos_global);
+
+  all_sampling_points.insert(all_sampling_points.begin(),
+                             cur_veh_point);  // Add current vehicle position to front of sample points
+
+  final_actual_speeds.insert(final_actual_speeds.begin(), state.longitudinal_vel);
+
+  final_yaw_values.insert(final_yaw_values.begin(), state.orientation);
+
+  // Compute points to local downtracks
+  std::vector<double> downtracks = carma_wm::geometry::compute_arc_lengths(all_sampling_points);
+
+  // Apply accel limits
+  final_actual_speeds = optimize_speed(downtracks, final_actual_speeds, config_.max_accel);
+
+  log::printDoublesPerLineWithPrefix("postAccel[i]: ", final_actual_speeds);
+
+  final_actual_speeds = smoothing::moving_average_filter(final_actual_speeds, config_.speed_moving_average_window_size);
+  log::printDoublesPerLineWithPrefix("post_average[i]: ", final_actual_speeds);
+
+  for (auto& s : final_actual_speeds)  // Limit minimum speed. TODO how to handle stopping?
+  {
+    s = std::max(s, config_.minimum_speed);
+  }
+
+  log::printDoublesPerLineWithPrefix("post_min_speed[i]: ", final_actual_speeds);
+
+  // Convert speeds to times
+  std::vector<double> times;
+  trajectory_utils::conversions::speed_to_time(downtracks, final_actual_speeds, &times);
+
+  log::printDoublesPerLineWithPrefix("times[i]: ", times);
+  
+  // Build trajectory points
+  std::vector<cav_msgs::TrajectoryPlanPoint> traj_points =
+      trajectory_from_points_times_orientations(all_sampling_points, times, final_yaw_values, state_time); 
+
+  if (config_.publish_debug) {
+    carma_debug_msgs::TrajectoryCurvatureSpeeds msg;
+    msg.velocity_profile = final_actual_speeds;
+    msg.relative_downtrack = downtracks;
+    msg.tangent_headings = final_yaw_values;
+    std::vector<double> aligned_speed_limits(constrained_speed_limits.begin() + nearest_pt_index,
+                                            constrained_speed_limits.end());
+    msg.speed_limits = aligned_speed_limits;
+    std::vector<double> aligned_curvatures(curvatures.begin() + nearest_pt_index,
+                                            curvatures.end());
+    msg.curvatures = aligned_curvatures;
+    msg.lat_accel_limit = config_.lateral_accel_limit;
+    msg.lon_accel_limit = config_.max_accel;
+    msg.starting_state = state;
+    debug_msg_ = msg;
+  }
+  return traj_points;
+}
+
+
+std::vector<cav_msgs::TrajectoryPlanPoint> InLaneCruisingPlugin::trajectory_from_points_times_orientations(
+    const std::vector<lanelet::BasicPoint2d>& points, const std::vector<double>& times, const std::vector<double>& yaws,
+    ros::Time startTime)
+{
+  if (points.size() != times.size() || points.size() != yaws.size())
+  {
+    throw std::invalid_argument("All input vectors must have the same size");
+  }
+
+  std::vector<cav_msgs::TrajectoryPlanPoint> traj;
+  traj.reserve(points.size());
+
+  for (int i = 0; i < points.size(); i++)
+  {
+    cav_msgs::TrajectoryPlanPoint tpp;
+    ros::Duration relative_time(times[i]);
+    tpp.target_time = startTime + relative_time;
+    tpp.x = points[i].x();
+    tpp.y = points[i].y();
+    tpp.yaw = yaws[i];
+
+    tpp.controller_plugin_name = "default";
+    tpp.planner_plugin_name = plugin_discovery_msg_.name;
+
+    traj.push_back(tpp);
+  }
+
+  return traj;
+}
+
+std::vector<PointSpeedPair> InLaneCruisingPlugin::attach_back_points(const std::vector<PointSpeedPair>& points, 
+                          const int nearest_pt_index, std::vector<inlanecruising_plugin::PointSpeedPair> future_points, double back_distance) const
+{
+  std::vector<PointSpeedPair> back_and_future;
+  back_and_future.reserve(points.size());
+  double total_dist = 0;
+  int min_i = 0;
+  for (int i = nearest_pt_index; i > 0; --i) { 
+    min_i = i;
+    total_dist += lanelet::geometry::distance2d(points[i].point, points[i-1].point);
+  
+    if (total_dist > back_distance) {
+      break;
+    }
+  }
+
+  back_and_future.insert(back_and_future.end(), points.begin() + min_i, points.begin() + nearest_pt_index + 1);
+  back_and_future.insert(back_and_future.end(), future_points.begin(), future_points.end());
+  return back_and_future;
+}
+
+
+std::vector<PointSpeedPair> InLaneCruisingPlugin::maneuvers_to_points(const std::vector<cav_msgs::Maneuver>& maneuvers,
+                                                                      double max_starting_downtrack,
+                                                                      const carma_wm::WorldModelConstPtr& wm)
+{
+  std::vector<PointSpeedPair> points_and_target_speeds;
+  std::unordered_set<lanelet::Id> visited_lanelets;
+
+  bool first = true;
+  ROS_DEBUG_STREAM("VehDowntrack: " << max_starting_downtrack);
+  for (const auto& manuever : maneuvers)
+  {
+    if (manuever.type != cav_msgs::Maneuver::LANE_FOLLOWING)
+    {
+      throw std::invalid_argument("In-Lane Cruising does not support this maneuver type");
+    }
+
+    cav_msgs::LaneFollowingManeuver lane_following_maneuver = manuever.lane_following_maneuver;
+
+    double starting_downtrack = lane_following_maneuver.start_dist;
+    if (first)
+    {
+      if (starting_downtrack > max_starting_downtrack)
+      {
+        starting_downtrack = max_starting_downtrack;
+      }
+      first = false;
+    }
+
+    ROS_DEBUG_STREAM("Used downtrack: " << starting_downtrack);
+
+    auto lanelets = wm->getLaneletsBetween(starting_downtrack, lane_following_maneuver.end_dist + config_.buffer_ending_downtrack, true, true);
+
+    if (lanelets.empty())
+    {
+      ROS_ERROR_STREAM("Detected no lanelets between starting_downtrack: " << starting_downtrack  << ", and lane_following_maneuver.end_dist: " << lane_following_maneuver.end_dist);
+      throw std::invalid_argument("Detected no lanelets between starting_downtrack and end_dist");
+    }
+
+    ROS_DEBUG_STREAM("Maneuver");
+
+    lanelet::BasicLineString2d downsampled_centerline;
+    downsampled_centerline.reserve(200);
+
+    // getLaneletsBetween is inclusive lanelets between its two boundaries
+    // which may return lanechange lanelets, so 
+    // exclude lanechanges and plan for only the straight part
+    int curr_idx = 0;
+    auto following_lanelets = wm->getMapRoutingGraph()->following(lanelets[curr_idx]);
+    lanelet::ConstLanelets straight_lanelets;
+
+    if (lanelets.size() <= 1) // no lane change anyways if only size 1
+    {
+      ROS_DEBUG_STREAM("Detected one straight lanelet Id: " << lanelets[curr_idx].id());
+      straight_lanelets = lanelets;
+    }
+    else
+    {
+      // skip all lanechanges until lane follow starts
+      while (curr_idx + 1 < lanelets.size() && 
+              std::find(following_lanelets.begin(),following_lanelets.end(), lanelets[curr_idx + 1]) == following_lanelets.end())
+      {
+        ROS_DEBUG_STREAM("As there were no directly following lanelets after this, skipping lanelet id: " << lanelets[curr_idx].id());
+        curr_idx ++;
+        following_lanelets = wm->getMapRoutingGraph()->following(lanelets[curr_idx]);
+      }
+
+      ROS_DEBUG_STREAM("Added lanelet Id for lane follow: " << lanelets[curr_idx].id());
+      // guaranteed to have at least one "straight" lanelet (e.g the last one in the list)
+      straight_lanelets.push_back(lanelets[curr_idx]);
+
+      // add all lanelets on the straight road until next lanechange
+      while (curr_idx + 1 < lanelets.size() && 
+              std::find(following_lanelets.begin(),following_lanelets.end(), lanelets[curr_idx + 1]) != following_lanelets.end())
+      {
+        curr_idx++;
+        ROS_DEBUG_STREAM("Added lanelet Id forlane follow: " << lanelets[curr_idx].id());
+        straight_lanelets.push_back(lanelets[curr_idx]);
+        following_lanelets = wm->getMapRoutingGraph()->following(lanelets[curr_idx]);
+      }
+    }
+    
+    for (auto l : straight_lanelets)
+    {
+      ROS_DEBUG_STREAM("Processing lanelet ID: " << l.id());
+      if (visited_lanelets.find(l.id()) == visited_lanelets.end())
+      {
+
+        bool is_turn = false;
+        if(l.hasAttribute("turn_direction")) {
+          std::string turn_direction = l.attribute("turn_direction").value();
+          is_turn = turn_direction.compare("left") == 0 || turn_direction.compare("right") == 0;
+        }
+        
+        lanelet::BasicLineString2d centerline = l.centerline2d().basicLineString();
+        lanelet::BasicLineString2d downsampled_points;
+        if (is_turn) {
+          downsampled_points = carma_utils::containers::downsample_vector(centerline, config_.turn_downsample_ratio);
+        } else {
+          downsampled_points = carma_utils::containers::downsample_vector(centerline, config_.default_downsample_ratio);
+        }
+        downsampled_centerline = carma_wm::geometry::concatenate_line_strings(downsampled_centerline, downsampled_points);
+        visited_lanelets.insert(l.id());
+      }
+    }
+
+
+    first = true;
+    for (auto p : downsampled_centerline)
+    {
+      if (first && points_and_target_speeds.size() != 0)
+      {
+        first = false;
+        continue;  // Skip the first point if we have already added points from a previous maneuver to avoid duplicates
+      }
+      PointSpeedPair pair;
+      pair.point = p;
+      pair.speed = lane_following_maneuver.end_speed;
+      points_and_target_speeds.push_back(pair);
+    }
+  }
+    // Here we are limiting the trajectory length to the given length by maneuver end dist as opposed to the end of lanelets involved.
+    double starting_route_downtrack = wm_->routeTrackPos(points_and_target_speeds.front().point).downtrack;
+    double ending_downtrack = maneuvers.back().lane_following_maneuver.end_dist;
+
+    if(ending_downtrack + config_.buffer_ending_downtrack < wm_->getRouteEndTrackPos().downtrack){
+      ending_downtrack = ending_downtrack + config_.buffer_ending_downtrack;
+    }
+    else
+    {
+      ending_downtrack = wm_->getRouteEndTrackPos().downtrack;
+    } 
+    
+    size_t max_i = points_and_target_speeds.size() - 1;
+    size_t unbuffered_idx = points_and_target_speeds.size() - 1;
+    bool found_unbuffered_idx = false;
+    double dist_accumulator = starting_route_downtrack;
+    lanelet::BasicPoint2d prev_point;
+
+    for (int i = 0; i < points_and_target_speeds.size(); i ++) {
+      auto current_point = points_and_target_speeds[i].point;
+      if (i == 0) {
+        prev_point = current_point;
+        continue;
+      }
+
+      double delta_d = lanelet::geometry::distance2d(prev_point, current_point);
+      ROS_DEBUG_STREAM("Index i: " << i << ", delta_d: " << delta_d << ", dist_accumulator:" << dist_accumulator <<", current_point.x():" << current_point.x() << 
+        "current_point.y():" << current_point.y());
+      dist_accumulator += delta_d;
+      if (dist_accumulator > maneuvers.back().lane_following_maneuver.end_dist && !found_unbuffered_idx)
+      {
+        unbuffered_idx = i - 1;
+        ROS_DEBUG_STREAM("Found index unbuffered_idx at: " << unbuffered_idx);
+        found_unbuffered_idx = true;
+      }
+      if (dist_accumulator > ending_downtrack) {
+        max_i = i - 1;
+        ROS_DEBUG_STREAM("Max_i breaking at: i: " << i << ", max_i: " << max_i);
+        break;
+      }
+      prev_point = current_point;
+    }
+    ending_state_before_buffer.X_pos_global = points_and_target_speeds[unbuffered_idx].point.x();
+    ending_state_before_buffer.Y_pos_global = points_and_target_speeds[unbuffered_idx].point.y();
+    ROS_DEBUG_STREAM("Here ending_state_before_buffer.X_pos_global: " << ending_state_before_buffer.X_pos_global << 
+      ", and Y_pos_global" << ending_state_before_buffer.Y_pos_global);
+
+    std::vector<PointSpeedPair> constrained_points(points_and_target_speeds.begin(), points_and_target_speeds.begin() + max_i);
+    return constrained_points;
+}
+
+std::unique_ptr<smoothing::SplineI>
+InLaneCruisingPlugin::compute_fit(const std::vector<lanelet::BasicPoint2d>& basic_points)
+{
+  if (basic_points.size() < 4)
+  {
+    ROS_WARN_STREAM("Insufficient Spline Points");
+    return nullptr;
+  }
+
+  std::unique_ptr<smoothing::SplineI> spl = std::make_unique<smoothing::BSpline>();
+  
+  spl->setPoints(basic_points);
+
+  return spl;
+}
+
+double InLaneCruisingPlugin::compute_curvature_at(const inlanecruising_plugin::smoothing::SplineI& fit_curve, double step_along_the_curve) const
+{
+  lanelet::BasicPoint2d f_prime_pt = fit_curve.first_deriv(step_along_the_curve);
+  lanelet::BasicPoint2d f_prime_prime_pt = fit_curve.second_deriv(step_along_the_curve);
+  // Convert to 3d vector to do 3d vector operations like cross.
+  Eigen::Vector3d f_prime = {f_prime_pt.x(), f_prime_pt.y(), 0};
+  Eigen::Vector3d f_prime_prime = {f_prime_prime_pt.x(), f_prime_prime_pt.y(), 0};
+  return (f_prime.cross(f_prime_prime)).norm()/(pow(f_prime.norm(),3));
 }
 
 void InLaneCruisingPlugin::set_yield_client(ros::ServiceClient& client)

--- a/inlanecruising_plugin/src/main.cpp
+++ b/inlanecruising_plugin/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/inlanecruising_plugin/src/smoothing/BSpline.cpp
+++ b/inlanecruising_plugin/src/smoothing/BSpline.cpp
@@ -1,0 +1,37 @@
+#include <inlanecruising_plugin/smoothing/BSpline.h>
+
+namespace inlanecruising_plugin
+{
+namespace smoothing
+{
+void BSpline::setPoints(std::vector<lanelet::BasicPoint2d> points)
+{
+  Eigen::MatrixXd matrix_points(2, points.size());
+  int row_index = 0;
+  for(auto const point : points){
+      matrix_points.col(row_index) << point.x(), point.y();
+      row_index++;
+  }
+  spline_ = Eigen::SplineFitting<Spline2d>::Interpolate(matrix_points,3 );
+}
+lanelet::BasicPoint2d BSpline::operator()(double t) const
+{
+  Eigen::VectorXd values = spline_(t);
+  lanelet::BasicPoint2d pt = {values.x(), values.y()};
+  return pt;
+}
+
+lanelet::BasicPoint2d  BSpline::first_deriv(double t) const {
+  Eigen::Array2Xd v = spline_.derivatives(t, 1);
+  lanelet::BasicPoint2d  output = {v(2), v(3)};
+  return output;
+}
+
+lanelet::BasicPoint2d  BSpline::second_deriv(double t) const {
+  Eigen::Array2Xd v = spline_.derivatives(t, 2);
+  lanelet::BasicPoint2d  output = {v(4), v(5)};
+  return output;
+}
+
+};  // namespace smoothing
+};  // namespace inlanecruising_plugin

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -611,7 +611,7 @@ TEST(InLaneCruisingPluginTest, attach_back_points)
 
   int nearest_pt_index = 2;
 
-  auto result = plugin.attach_past_points(points, future_points, nearest_pt_index, 1.5);
+  auto result = plugin.attach_back_points(points, nearest_pt_index, future_points, 1.5);
 
   ASSERT_EQ(points.size()  -1, result.size());
   ASSERT_NEAR(1.0, result[0].point.x(), 0.0000001);

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2019-2020 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -51,9 +51,13 @@
 #include <carma_utils/containers/containers.h>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
 #include <Eigen/LU>
 #include <Eigen/SVD>
+#include <inlanecruising_plugin/smoothing/SplineI.h>
+#include <inlanecruising_plugin/smoothing/BSpline.h>
+#include <inlanecruising_plugin/inlanecruising_plugin.h>
+#include <inlanecruising_plugin/log/log.h>
+#include <inlanecruising_plugin/smoothing/filters.h>
 #include <unordered_set>
 
 
@@ -273,7 +277,7 @@ TEST(WaypointGeneratorTest, DISABLED_test_compute_fit_full_generation)
     // ROS_INFO_STREAM("Original point: x: " << route_geometry[i].x() << "y: " << route_geometry[i].y());
   }
 
-  std::unique_ptr<basic_autonomy::smoothing::SplineI> fit_curve = basic_autonomy:: waypoint_generation::compute_fit(downsampled_points);
+  std::unique_ptr<smoothing::SplineI> fit_curve = inlc.compute_fit(downsampled_points);
   
   std::vector<lanelet::BasicPoint2d> spline_points;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR reverts inlanecruising_plugin to the version from 3.7.2 after it was found the basic_autonomy refactor for that component introduced numerous bugs. Additionally, this PR fixes numerous linker errors in basic_autonomy caused by non-inline free functions in header files which resulted in duplicate compilation unit declarations on linkage to that library. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1461
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functional workzone use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacifica at TFHRC both east and west bound WZ use case. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
