### PR TITLE
Fix/spline exception

### DIFF
--- a/basic_autonomy/include/basic_autonomy/basic_autonomy.h
+++ b/basic_autonomy/include/basic_autonomy/basic_autonomy.h
@@ -61,6 +61,7 @@ namespace basic_autonomy
         {
             lanelet::BasicPoint2d point;
             double speed = 0;
+            lanelet::Id lanelet_id = 0;
         };
 
         struct GeneralTrajConfig

--- a/basic_autonomy/include/basic_autonomy/basic_autonomy.h
+++ b/basic_autonomy/include/basic_autonomy/basic_autonomy.h
@@ -61,7 +61,6 @@ namespace basic_autonomy
         {
             lanelet::BasicPoint2d point;
             double speed = 0;
-            lanelet::Id lanelet_id = 0;
         };
 
         struct GeneralTrajConfig

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -237,10 +237,10 @@ namespace basic_autonomy
                     auto new_point(current_point.x() + delta_point.x(), current_point.y() + delta_point.y());
 
                     PointSpeedPair new_pair;
-                    pair.point = new_point;
-                    pair.speed = points_and_target_speeds.back().speed;
+                    new_pair.point = new_point;
+                    new_pair.speed = points_and_target_speeds.back().speed;
 
-                    points_and_target_speeds.push_back(pair);
+                    points_and_target_speeds.push_back(new_pair);
                 }
 
 

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -198,7 +198,7 @@ namespace basic_autonomy
             lanelet::BasicPoint2d prev_point;
 
             
-
+            boost::optional<lanelet::BasicPoint2d> delta_point;
             for (size_t i = 0; i < points_and_target_speeds.size(); ++i) {
                 auto current_point = points_and_target_speeds[i].point;
                 
@@ -233,8 +233,12 @@ namespace basic_autonomy
 
                     ROS_DEBUG_STREAM("Extending trajectory using buffer beyond end of target lanelet");
 
-                    auto delta_point = (current_point - prev_point) * 0.25; // Use a smaller step size then default to help ensure enough points are generated
-                    auto new_point(current_point.x() + delta_point.x(), current_point.y() + delta_point.y());
+                    if (!delta_point) { // Set the step size based on last two points
+                        delta_point = (current_point - prev_point) * 0.25; // Use a smaller step size then default to help ensure enough points are generated;
+                    }
+
+                    // Create an extrapolated new point 
+                    auto new_point = current_point + delta_point;
 
                     PointSpeedPair new_pair;
                     new_pair.point = new_point;

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -226,8 +226,11 @@ namespace basic_autonomy
                 }
 
                 // If there are no more points to add but we haven't reached the ending downtrack then get the following lanelet and keep iterating
-                if (i == points_and_target_speeds.size() - 1 && dist_accumulator < ending_downtrack)
+                if (i == points_and_target_speeds.size() - 1) // dist_accumulator < ending_downtrack is guaranteed by earlier conditional
                 {
+
+                    ROS_DEBUG_STREAM("Extending trajectory using buffer beyond end of target lanelet");
+
                     auto lane_ids = maneuvers.back().lane_following_maneuver.lane_ids;
 
                     if (lane_ids.empty()) {
@@ -529,7 +532,7 @@ namespace basic_autonomy
             back_and_future.reserve(points_set.size());
             double total_dist = 0;
             int min_i = 0;
-            for (int i = nearest_pt_index; i > 0; --i)
+            for (int i = nearest_pt_index; i >= 0; --i) // int must be used here to avoid overflow when i = 0
             {
                 min_i = i;
                 total_dist += lanelet::geometry::distance2d(points_set[i].point, points_set[i - 1].point);

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -251,13 +251,12 @@ namespace basic_autonomy
 
                     }
                     else {
-                        ROS_WARN_STREAM("No following lanelets found for lanelet: " << lanelets[0].id());
+                        ROS_WARN_STREAM("No following lanelets found for lanelet: " << current_lanelet.id());
                     }
                 }
 
 
                 prev_point = current_point;
-                i++;
             }
 
             ending_state_before_buffer.X_pos_global = points_and_target_speeds[unbuffered_idx].point.x();

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -228,14 +228,14 @@ namespace basic_autonomy
                 // If there are no more points to add but we haven't reached the ending downtrack then get the following lanelet and keep iterating
                 if (i == points_and_target_speeds.size() - 1 && dist_accumulator < ending_downtrack)
                 {
-                    auto lane_ids = wm->getMap()->laneletLayer.get(maneuvers.back().lane_following_maneuver.lane_ids;
+                    auto lane_ids = maneuvers.back().lane_following_maneuver.lane_ids;
 
                     if (lane_ids.empty()) {
                         ROS_ERROR_STREAM("Lane following lanelet list is not populated");
                         break;
                     }
 
-                    auto current_lanelet = wm->getMap()->laneletLayer.get(lane_ids.back());
+                    auto current_lanelet = wm->getMap()->laneletLayer.get(stoi(lane_ids.back()));
 
                     // Since we should only be in this case if we are adding buffer points the choice of following lanelet is irrelevant 
                     // so we just accept the first one

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -238,7 +238,7 @@ namespace basic_autonomy
                     }
 
                     // Create an extrapolated new point 
-                    auto new_point = current_point + delta_point;
+                    auto new_point = current_point + delta_point.get();
 
                     PointSpeedPair new_pair;
                     new_pair.point = new_point;

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -199,7 +199,7 @@ namespace basic_autonomy
 
             
 
-            for (size_t i = 0; i < points_and_target_speeds.size(); ++i)
+            for (size_t i = 0; i < points_and_target_speeds.size(); ++i) {
                 auto current_point = points_and_target_speeds[i].point;
                 
                 if (i == 0) {
@@ -228,7 +228,14 @@ namespace basic_autonomy
                 // If there are no more points to add but we haven't reached the ending downtrack then get the following lanelet and keep iterating
                 if (i == points_and_target_speeds.size() - 1 && dist_accumulator < ending_downtrack)
                 {
-                    auto current_lanelet = wm->getMap()->laneletLayer.get(maneuvers.back().lane_following_maneuver.lanelet_ids.back());
+                    auto lane_ids = wm->getMap()->laneletLayer.get(maneuvers.back().lane_following_maneuver.lane_ids;
+
+                    if (lane_ids.empty()) {
+                        ROS_ERROR_STREAM("Lane following lanelet list is not populated");
+                        break;
+                    }
+
+                    auto current_lanelet = wm->getMap()->laneletLayer.get(lane_ids.back());
 
                     // Since we should only be in this case if we are adding buffer points the choice of following lanelet is irrelevant 
                     // so we just accept the first one
@@ -238,7 +245,7 @@ namespace basic_autonomy
                     {
                         // add centerline of following lanelet to points_and_target_speeds
                         auto centerline_points_and_speeds = lanelet::utils::transform(following_lanelets[0].centerline2d(), 
-                            [](const auto& p) 
+                            [&points_and_target_speeds](const auto& p) 
                             { 
                                 PointSpeedPair pair;
                                 pair.point = p.basicPoint2d();

--- a/basic_autonomy/test/test_waypoint_generation.cpp
+++ b/basic_autonomy/test/test_waypoint_generation.cpp
@@ -22,12 +22,10 @@
 #include <math.h>
 #include <tf/LinearMath/Vector3.h>
 #include <carma_wm/WMTestLibForGuidance.h>
-#include <lanelet2_extension/io/autoware_osm_parser.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_io/Io.h>
 #include <lanelet2_io/io_handlers/Factory.h>
 #include <lanelet2_io/io_handlers/Writer.h>
-#include <lanelet2_extension/projection/local_frame_projector.h>
 #include <lanelet2_core/geometry/LineString.h>
 #include <string>
 #include <sstream>

--- a/basic_autonomy/test/test_waypoint_generation.cpp
+++ b/basic_autonomy/test/test_waypoint_generation.cpp
@@ -27,6 +27,8 @@
 #include <lanelet2_io/io_handlers/Factory.h>
 #include <lanelet2_io/io_handlers/Writer.h>
 #include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_extension/projection/local_frame_projector.h>
+#include <lanelet2_extension/io/autoware_osm_parser.h>
 #include <string>
 #include <sstream>
 #include <ros/package.h>

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
@@ -34,7 +34,8 @@
 #include <carma_utils/containers/containers.h>
 #include <tf/LinearMath/Vector3.h>
 
-
+#include <lanelet2_extension/projection/local_frame_projector.h>
+#include <lanelet2_extension/io/autoware_osm_parser.h>
 #include <ros/ros.h>
 #include <string>
 #include <algorithm>

--- a/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
+++ b/inlanecruising_plugin/test/test_inlanecruising_plugin_planning.cpp
@@ -27,8 +27,6 @@
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/primitives/Traits.h>
 #include <lanelet2_extension/traffic_rules/CarmaUSTrafficRules.h>
-#include <lanelet2_extension/projection/local_frame_projector.h>
-#include <lanelet2_extension/io/autoware_osm_parser.h>
 #include <carma_wm/MapConformer.h>
 #include <carma_wm/CARMAWorldModel.h>
 #include <ros/console.h>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Proposed fix for exception from lack of buffer in inlane-cruising (from basic autonomy). This PR does two things, it adds an extra buffer enforcement that can run beyond the end of a lanelet via extrapolation. In addition, it removes some unnecessary index -1 commands which were reducing sufficiently sized buffers just under the required 4 points. 
<!--- Describe your changes in detail -->

## Related Issue
Mitigation for https://github.com/usdot-fhwa-stol/carma-platform/issues/1506
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working RWM use case on Elise release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested at TFHRC for multiple runs using Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
