### PR TITLE
add additional points to lc geom

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -870,6 +870,14 @@ namespace basic_autonomy
             lanelet::BasicLineString2d new_points = create_lanechange_path(lanelets_in_path[lane_change_iteration],lanelets_in_path[lane_change_iteration + 1]);
             centerline_points.insert(centerline_points.end(), new_points.begin(), new_points.end());
 
+            //Add points from following lanelet to provide sufficient distance for adding buffer
+            auto following_lanelets = wm->getMapRoutingGraph()->following(lanelets_in_path[lane_change_iteration + 1], false);
+            if(!following_lanelets.empty()){
+                //Arbitrarily choosing first following lanelet for buffer since points are only being used to fit spline
+                centerline_points.insert(centerline_points.end(), following_lanelets.front().centerline2d().basicLineString().begin(), 
+                                                                            following_lanelets[0].centerline2d().basicLineString().end());
+            }
+
             std::vector<lanelet::BasicPoint2d> centerline_as_vector(centerline_points.begin(), centerline_points.end());
 
             return centerline_as_vector;

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -875,8 +875,8 @@ namespace basic_autonomy
             if(!following_lanelets.empty()){
                 //Arbitrarily choosing first following lanelet for buffer since points are only being used to fit spline
                 auto following_lanelet_centerline = following_lanelets.front().centerline2d().basicLineString();
-                centerline_points.insert(centerline_points.end(), following_lanelets.front().centerline2d().basicLineString().begin(), 
-                                                                            following_lanelets[0].centerline2d().basicLineString().end());
+                centerline_points.insert(centerline_points.end(), following_lanelet_centerline.begin(), 
+                                                                            following_lanelet_centerline.end());
             }
 
             std::vector<lanelet::BasicPoint2d> centerline_as_vector(centerline_points.begin(), centerline_points.end());

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -874,6 +874,7 @@ namespace basic_autonomy
             auto following_lanelets = wm->getMapRoutingGraph()->following(lanelets_in_path[lane_change_iteration + 1], false);
             if(!following_lanelets.empty()){
                 //Arbitrarily choosing first following lanelet for buffer since points are only being used to fit spline
+                auto following_lanelet_centerline = following_lanelets.front().centerline2d().basicLineString();
                 centerline_points.insert(centerline_points.end(), following_lanelets.front().centerline2d().basicLineString().begin(), 
                                                                             following_lanelets[0].centerline2d().basicLineString().end());
             }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fix for input vector is empty exception thrown at the end of a lanechange. 
## Description
The method proposed adds centerline points from the lanelet following the last lanelet in lane change. 

<!--- Describe your changes in detail -->

## Related Issue
Issue #1507 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
