### PR TITLE
Potential ILC 32-bit range exception fix correlation to lanechange geometry creation

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -902,7 +902,7 @@ namespace basic_autonomy
             if(!following_lanelets.empty()){
                 //Arbitrarily choosing first following lanelet for buffer since points are only being used to fit spline
                 auto following_lanelet_centerline = following_lanelets.front().centerline2d().basicLineString();
-                centerline_points.insert(centerline_points.end(), following_lanelet_centerline.begin(), 
+                centerline_points.insert(centerline_points.end(), following_lanelet_centerline.begin() + 1, 
                                                                             following_lanelet_centerline.end());
             }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
At ATEF, we were running into this "duration is out of 32-bit range" (from vehicle state having a speed of -nan in ILC logs) ~1-2 seconds after starting the lane change. From our experience, this could actually come from lane change's faulty logic as the state with erroneous speed can be sent to ILC through plan_delegator. This could be related to a small bug in CLC where it is creating extra lane_follow geometry behind the lane change to avoid running out of points that is creating duplicate points when attaching lanelets (last and first points of the two lanelets).

This is only a potential fix, as the duplicate points very well be removed through downsampling or getting the nearest point of end_dist. However, using +1 point is definitely the correct approach even if unrelated

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/pull/1515
https://github.com/usdot-fhwa-stol/carma-platform/issues/1521

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Not yet.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
