### PR TITLE
Set cmv_id in port_drayage_plugin to vehicle_id parameter

### DIFF
--- a/port_drayage_plugin/config/params.yml
+++ b/port_drayage_plugin/config/params.yml
@@ -1,5 +1,4 @@
 stop_speed_epsilon: 1.0
-cmv_id: "123" # Test value; CARMA Streets expects cmv_id to be an unsigned long (32-bit unsigned integer)
 cargo_id: "" # Test value (Empty string indicates the vehicle is not carrying cargo); CARMA Streets expects cargo_id to be a string
 enable_port_drayage: false # bool: Flag to activate and deactivate port drayage operations. If false, state machine will remain INACTIVE.
 starting_at_staging_area: true # bool: Flag indicating CMV's first destination; 'true' indicates Staging Area Entrance; 'false' indicates Port Entrance.

--- a/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
+++ b/port_drayage_plugin/include/port_drayage_plugin/port_drayage_worker.h
@@ -139,7 +139,7 @@ namespace port_drayage_plugin
             OperationID _enter_staging_area_operation{OperationID::ENTER_STAGING_AREA};
             OperationID _enter_port_operation{OperationID::ENTER_PORT};
             OperationID _holding_area_operation{OperationID::HOLDING_AREA};
-            unsigned long _cmv_id;
+            std::string _cmv_id;
             std::string _cargo_id; // Empty if CMV is not currently carrying cargo
             std::function<void(cav_msgs::MobilityOperation)> _publish_mobility_operation;
             std::function<void(cav_msgs::UIInstructions)> _publish_ui_instructions;
@@ -161,7 +161,7 @@ namespace port_drayage_plugin
             /**
              * \brief Standard constructor for the PortDrayageWorker
              * 
-             * \param cmv_id The Carrier Motor Vehicle ID (an unsigned long) for the host
+             * \param cmv_id The Carrier Motor Vehicle ID for the host
              * vehicle
              * 
              * \param cargo_id The identification string for the cargo carried
@@ -192,7 +192,7 @@ namespace port_drayage_plugin
              * the implementation of this class.
              */
             PortDrayageWorker(
-                unsigned long cmv_id,
+                std::string cmv_id,
                 std::string cargo_id,
                 std::string host_id,
                 bool starting_at_staging_area,
@@ -210,7 +210,7 @@ namespace port_drayage_plugin
                 _set_active_route(call_set_active_route_client),
                 _stop_speed_epsilon(stop_speed_epsilon),
                 _enable_port_drayage(enable_port_drayage) {
-                    initialize();       
+                    initialize();    
                 };
 
             /**

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -39,7 +39,7 @@ namespace port_drayage_plugin
         bool enable_port_drayage;
         _pnh->param<bool>("enable_port_drayage", enable_port_drayage, false);
         std::string cmv_id;
-        _pnh->getParam("vehicle_id", cmv_id);
+        _pnh->getParam("/vehicle_id", cmv_id);
 
         ros::Publisher outbound_mob_op = _nh->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
         _outbound_mobility_operations_publisher = std::make_shared<ros::Publisher>(outbound_mob_op);

--- a/port_drayage_plugin/src/port_drayage_plugin.cpp
+++ b/port_drayage_plugin/src/port_drayage_plugin.cpp
@@ -38,12 +38,8 @@ namespace port_drayage_plugin
         _pnh->param<bool>("starting_at_staging_area", starting_at_staging_area, true);
         bool enable_port_drayage;
         _pnh->param<bool>("enable_port_drayage", enable_port_drayage, false);
-
-        // Read in 'cmv_id' parameter as a string, then convert to an unsigned long before initializing the PortDrayageWorker object
-        std::string cmv_id_string;
-        _pnh->param<std::string>("cmv_id", cmv_id_string, "0");
-        unsigned long cmv_id = std::stoul(cmv_id_string);
-
+        std::string cmv_id;
+        _pnh->getParam("vehicle_id", cmv_id);
 
         ros::Publisher outbound_mob_op = _nh->advertise<cav_msgs::MobilityOperation>("outgoing_mobility_operation", 5);
         _outbound_mobility_operations_publisher = std::make_shared<ros::Publisher>(outbound_mob_op);

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -80,6 +80,7 @@ namespace port_drayage_plugin
     }
 
     void PortDrayageWorker::initialize() {
+        ROS_WARN_STREAM("cmv_id is " << _cmv_id);
         _pdsm.set_on_arrived_at_destination_callback(std::bind(&PortDrayageWorker::on_arrived_at_destination, this));
         _pdsm.set_on_received_new_destination_callback(std::bind(&PortDrayageWorker::on_received_new_destination, this));
     }
@@ -261,8 +262,7 @@ namespace port_drayage_plugin
             std::istringstream strategy_params_ss(msg->strategy_params);
             boost::property_tree::json_parser::read_json(strategy_params_ss, pt);
 
-            // Note: Size of 'unsigned long' is implementation/compiler/architecture specific. Behavior may be undefined if code is run on something with size of 'unsigned long' smaller than 4 bytes.
-            unsigned long mobility_operation_cmv_id = pt.get<unsigned long>("cmv_id");
+            std::string mobility_operation_cmv_id = pt.get<std::string>("cmv_id");
 
             // Check if the received MobilityOperation message is intended for this vehicle's cmv_id   
             if(mobility_operation_cmv_id == _cmv_id) {

--- a/port_drayage_plugin/src/port_drayage_worker.cpp
+++ b/port_drayage_plugin/src/port_drayage_worker.cpp
@@ -80,7 +80,6 @@ namespace port_drayage_plugin
     }
 
     void PortDrayageWorker::initialize() {
-        ROS_WARN_STREAM("cmv_id is " << _cmv_id);
         _pdsm.set_on_arrived_at_destination_callback(std::bind(&PortDrayageWorker::on_arrived_at_destination, this));
         _pdsm.set_on_received_new_destination_callback(std::bind(&PortDrayageWorker::on_received_new_destination, this));
     }

--- a/port_drayage_plugin/test/test_port_drayage_plugin.cpp
+++ b/port_drayage_plugin/test/test_port_drayage_plugin.cpp
@@ -34,7 +34,7 @@ TEST(PortDrayageTest, testComposeArrivalMessage)
     // Test initial arrival message for pdw initialized with cargo with the Staging Area Entrance as its first destination
     ros::Time::init();
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID 
+        "DOT-11111", // CMV ID 
         "321", // Cargo ID 
         "TEST_CARMA_HOST_ID", // Host ID
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -76,13 +76,13 @@ TEST(PortDrayageTest, testComposeArrivalMessage)
     ptree pt;
     boost::property_tree::json_parser::read_json(strstream, pt);
 
-    unsigned long cmv_id = pt.get<unsigned long>("cmv_id");
+    std::string cmv_id = pt.get<std::string>("cmv_id");
     std::string operation = pt.get<std::string>("operation");
     bool has_cargo = pt.get<bool>("cargo");
     double vehicle_longitude = pt.get<double>("location.longitude");
     double vehicle_latitude = pt.get<double>("location.latitude");
 
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("DOT-11111", cmv_id);
     ASSERT_EQ("ENTER_STAGING_AREA", operation);
     ASSERT_EQ(pt.count("action_id"), 0);
     ASSERT_TRUE(has_cargo);
@@ -91,7 +91,7 @@ TEST(PortDrayageTest, testComposeArrivalMessage)
 
     // Test initial arrival message for pdw initialized without cargo with the Port Entrance as its first destination
     port_drayage_plugin::PortDrayageWorker pdw2{
-        123, // CMV ID 
+        "123", // CMV ID 
         "", // Cargo ID 
         "TEST_CARMA_HOST_ID", 
         false, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -116,13 +116,13 @@ TEST(PortDrayageTest, testComposeArrivalMessage)
     ptree pt2;
     boost::property_tree::json_parser::read_json(strstream2, pt2);
 
-    unsigned long cmv_id2 = pt2.get<unsigned long>("cmv_id");
+    std::string cmv_id2 = pt2.get<std::string>("cmv_id");
     std::string operation2 = pt2.get<std::string>("operation");
     bool has_cargo2 = pt2.get<bool>("cargo");
     double vehicle_longitude2 = pt2.get<double>("location.longitude");
     double vehicle_latitude2 = pt2.get<double>("location.latitude");
 
-    ASSERT_EQ(123, cmv_id2);
+    ASSERT_EQ("123", cmv_id2);
     ASSERT_EQ(0, pt2.count("cargo_id")); // Broadcasted arrival message should not include cargo_id since vehicle is not carrying cargo
     ASSERT_EQ("ENTER_PORT", operation2);
     ASSERT_FALSE(has_cargo2); // False since vehicle is not currently carrying cargo
@@ -134,7 +134,7 @@ TEST(PortDrayageTest, testCheckStop1)
 {
     ros::Time::init();
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID
+        "123", // CMV ID
         "321", // Cargo ID
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -167,7 +167,7 @@ TEST(PortDrayageTest, testCheckStop2)
 {
     ros::Time::init();
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID 
+        "123", // CMV ID 
         "321", // Cargo ID
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -200,7 +200,7 @@ TEST(PortDrayageTest, testCheckStop3)
 {
     ros::Time::init();
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID
+        "123", // CMV ID
         "321", // Cargo ID 
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -234,7 +234,7 @@ TEST(PortDrayageTest, testCheckStop4)
 {
     ros::Time::init();
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID
+        "123", // CMV ID
         "321", // Cargo ID 
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -291,10 +291,10 @@ TEST(PortDrayageTest, testStateMachine1)
 // Test communication between PortDrayageWorker and PortDrayageStateMachine for State Machine flow
 TEST(PortDrayageTest, testPortDrayageStateMachine2)
 {
-    // Create PortDrayageWorker object with _cmv_id of 123 and no cargo
+    // Create PortDrayageWorker object with _cmv_id of "123" and no cargo
     //std::function<void(cav_msgs::MobilityOperation)> fun = [](cav_msgs::MobilityOperation){return;};
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID 
+        "123", // CMV ID 
         "", // Cargo ID; empty string indicates CMV begins without no cargo
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -482,7 +482,7 @@ TEST(PortDrayageTest, testComposeSetActiveRouteRequest)
 {
     // Create PortDrayageWorker object with _cmv_id of "123"
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, 
+        "123", 
         "TEST_CARGO_ID", 
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -517,9 +517,9 @@ TEST(PortDrayageTest, testComposeSetActiveRouteRequest)
 // Test Case for testing all potential inbound Port Drayage MobilityOperation messages
 TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
 {
-    // Create PortDrayageWorker object with cmv_id of 123 that is not carrying cargo
+    // Create PortDrayageWorker object with cmv_id of "123" that is not carrying cargo
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, // CMV ID 
+        "123", // CMV ID 
         "", // Cargo ID; empty string indicates the CMV is not carrying cargo
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance
@@ -608,7 +608,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt;
     boost::property_tree::json_parser::read_json(strstream, pt);
 
-    unsigned long cmv_id = pt.get<unsigned long>("cmv_id");
+    std::string cmv_id = pt.get<std::string>("cmv_id");
     std::string cargo_id = pt.get<std::string>("cargo_id");
     bool has_cargo = pt.get<bool>("cargo");
     std::string action_id = pt.get<std::string>("action_id");
@@ -620,7 +620,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg.header.sender_id);
     ASSERT_FALSE(msg.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_FALSE(has_cargo);
     ASSERT_EQ("321", cargo_id); 
     ASSERT_EQ("PICKUP", operation);
@@ -657,7 +657,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt2;
     boost::property_tree::json_parser::read_json(strstream2, pt2);
 
-    cmv_id = pt2.get<unsigned long>("cmv_id");
+    cmv_id = pt2.get<std::string>("cmv_id");
     cargo_id = pt2.get<std::string>("cargo_id");
     has_cargo = pt2.get<bool>("cargo");
     action_id = pt2.get<std::string>("action_id");
@@ -669,7 +669,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg2.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg2.header.sender_id);
     ASSERT_FALSE(msg2.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("321", cargo_id);
     ASSERT_EQ("EXIT_STAGING_AREA", operation);
@@ -706,7 +706,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt3;
     boost::property_tree::json_parser::read_json(strstream3, pt3);
 
-    cmv_id = pt3.get<unsigned long>("cmv_id");
+    cmv_id = pt3.get<std::string>("cmv_id");
     has_cargo = pt3.get<bool>("cargo");
     cargo_id = pt3.get<std::string>("cargo_id");
     action_id = pt3.get<std::string>("action_id");
@@ -718,7 +718,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg3.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg3.header.sender_id);
     ASSERT_FALSE(msg3.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("321", cargo_id);
     ASSERT_EQ("ENTER_PORT", operation);
@@ -755,7 +755,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt4;
     boost::property_tree::json_parser::read_json(strstream4, pt4);
 
-    cmv_id = pt4.get<unsigned long>("cmv_id");
+    cmv_id = pt4.get<std::string>("cmv_id");
     cargo_id = pt4.get<std::string>("cargo_id");
     has_cargo = pt4.get<bool>("cargo");
     action_id = pt4.get<std::string>("action_id");
@@ -767,7 +767,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg4.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg4.header.sender_id);
     ASSERT_FALSE(msg4.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("321", cargo_id);
     ASSERT_EQ("DROPOFF", operation);
@@ -803,7 +803,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt5;
     boost::property_tree::json_parser::read_json(strstream5, pt5);
 
-    cmv_id = pt5.get<unsigned long>("cmv_id");
+    cmv_id = pt5.get<std::string>("cmv_id");
     cargo_id = pt5.get<std::string>("cargo_id");
     has_cargo = pt5.get<bool>("cargo");
     action_id = pt5.get<std::string>("action_id");
@@ -815,7 +815,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg5.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg5.header.sender_id);
     ASSERT_FALSE(msg5.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_FALSE(has_cargo);
     ASSERT_EQ("422", cargo_id);
     ASSERT_EQ("PICKUP", operation);
@@ -851,7 +851,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt6;
     boost::property_tree::json_parser::read_json(strstream6, pt6);
 
-    cmv_id = pt6.get<unsigned long>("cmv_id");
+    cmv_id = pt6.get<std::string>("cmv_id");
     cargo_id = pt6.get<std::string>("cargo_id");
     has_cargo = pt6.get<bool>("cargo");
     action_id = pt6.get<std::string>("action_id");
@@ -863,7 +863,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg6.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg6.header.sender_id);
     ASSERT_FALSE(msg6.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("422", cargo_id);
     ASSERT_EQ("PORT_CHECKPOINT", operation);
@@ -899,7 +899,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt7;
     boost::property_tree::json_parser::read_json(strstream7, pt7);
 
-    cmv_id = pt7.get<unsigned long>("cmv_id");
+    cmv_id = pt7.get<std::string>("cmv_id");
     cargo_id = pt7.get<std::string>("cargo_id");
     has_cargo = pt7.get<bool>("cargo");
     action_id = pt7.get<std::string>("action_id");
@@ -911,7 +911,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg7.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg7.header.sender_id);
     ASSERT_FALSE(msg7.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("422", cargo_id);
     ASSERT_EQ("HOLDING_AREA", operation);
@@ -947,7 +947,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt8;
     boost::property_tree::json_parser::read_json(strstream8, pt8);
 
-    cmv_id = pt8.get<unsigned long>("cmv_id");
+    cmv_id = pt8.get<std::string>("cmv_id");
     cargo_id = pt8.get<std::string>("cargo_id");
     has_cargo = pt8.get<bool>("cargo");
     action_id = pt8.get<std::string>("action_id");
@@ -959,7 +959,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg8.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg8.header.sender_id);
     ASSERT_FALSE(msg8.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("422", cargo_id);
     ASSERT_EQ("EXIT_PORT", operation);
@@ -995,7 +995,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ptree pt9;
     boost::property_tree::json_parser::read_json(strstream9, pt9);
 
-    cmv_id = pt9.get<unsigned long>("cmv_id");
+    cmv_id = pt9.get<std::string>("cmv_id");
     cargo_id = pt9.get<std::string>("cargo_id");
     has_cargo = pt9.get<bool>("cargo");
     action_id = pt9.get<std::string>("action_id");
@@ -1007,7 +1007,7 @@ TEST(PortDrayageTest, testInboundAndComposedMobilityOperation)
     ASSERT_EQ("carma/port_drayage", msg9.strategy);
     ASSERT_EQ("TEST_CARMA_HOST_ID", msg9.header.sender_id);
     ASSERT_FALSE(msg9.strategy_params.empty());
-    ASSERT_EQ(123, cmv_id);
+    ASSERT_EQ("123", cmv_id);
     ASSERT_TRUE(has_cargo);
     ASSERT_EQ("422", cargo_id);
     ASSERT_EQ("ENTER_STAGING_AREA", operation);
@@ -1020,7 +1020,7 @@ TEST(PortDrayageTest, testComposeUIInstructions)
 {
     // Create PortDrayageWorker object with _cmv_id of "123"
     port_drayage_plugin::PortDrayageWorker pdw{
-        123, 
+        "123", 
         "", // Empty string indicates CMV is not carrying cargo 
         "TEST_CARMA_HOST_ID", 
         true, // Flag indicating CMV's first destination; 'true' is Staging Area Entrance, 'false' is Port Entrance


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR update port_drayage_plugin to set its cmv_id using the 'vehicle_id' global parameter, which includes the vehicle's license plate information. As part of this update, cmv_id within port_drayage_plugin has been changed from an unsigned long to a string. Similarly, V2XHub expects cmv_id to be a string value.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and tested locally with development config; also unit tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
