### PR TITLE
Add localization_manager fault when GNSS data timesout and in a GNSS …

### DIFF
--- a/localization_manager/config/parameters.yaml
+++ b/localization_manager/config/parameters.yaml
@@ -24,6 +24,10 @@ auto_initialization_timeout: 30000
 # Units: ms
 gnss_only_operation_timeout: 20000
 
+# Integer: GNSS Data timeout. If exceeded the system will assume the GNSS is no longer functional. 
+# Units: ms
+gnss_data_timeout: 500
+
 # Integer: Maximum allowed number of sequential timesteps to let lidar initialize before switching to GPS only mode
 # NOTE: Only used in GNSS only with NDT initialization mode
 # Units: Int

--- a/localization_manager/include/localization_manager/LocalizationManagerConfig.h
+++ b/localization_manager/include/localization_manager/LocalizationManagerConfig.h
@@ -39,6 +39,8 @@ struct LocalizationManagerConfig
   //! Integer: Maximum allowed number of sequential timesteps to let lidar initialize before switching to GPS only mode
   //! NOTE: Only used in GNSS only with NDT initialization mode
   int sequential_timesteps_until_gps_operation = 5;
+  //! GNSS Data timeout. If exceeded the system will assume the GNSS is no longer functional. Units are ms
+  int gnss_data_timeout = 500;
   //! Localization mode to use
   LocalizerMode localization_mode = LocalizerMode::AUTO_WITHOUT_TIMEOUT;
 };

--- a/localization_manager/include/localization_manager/LocalizationTypes.h
+++ b/localization_manager/include/localization_manager/LocalizationTypes.h
@@ -69,6 +69,7 @@ enum class LocalizationSignal
   TIMEOUT,
   LIDAR_SENSOR_FAILURE,
   LIDAR_INITIALIZED_SWITCH_TO_GPS,
+  GNSS_DATA_TIMEOUT
 };
 /**
  * \brief Stream operator for LocalizationSignal enum.

--- a/localization_manager/src/LocalizationManager.cpp
+++ b/localization_manager/src/LocalizationManager.cpp
@@ -243,6 +243,12 @@ void LocalizationManager::posePubTick(const ros::TimerEvent& te)
     }
   }
 
+  // check if last gnss time stamp is older than threshold and send the corresponding signal
+  if (last_raw_gnss_value_ && ros::Time::now() - last_raw_gnss_value_->header.stamp > ros::Duration(config_.gnss_data_timeout / 1000.0))
+  {
+    transition_table_.signal(LocalizationSignal::GNSS_DATA_TIMEOUT);
+  }
+
   // Used in LocalizerMode::GNSS_WITH_NDT_INIT 
   // If the state is not Operational with good NDT, or already using GPS only, we reset the counter
   if (transition_table_.getState() != LocalizationState::OPERATIONAL && 

--- a/localization_manager/src/LocalizationTransitionTable.cpp
+++ b/localization_manager/src/LocalizationTransitionTable.cpp
@@ -188,6 +188,8 @@ void LocalizationTransitionTable::signalWhenDEGRADED_NO_LIDAR_FIX(LocalizationSi
         setAndLogState(LocalizationState::AWAIT_MANUAL_INITIALIZATION, signal);
       }
       break;
+    case LocalizationSignal::GNSS_DATA_TIMEOUT:
+      throw std::runtime_error("GNSS_DATA_TIMEOUT occurred while in DEGRADED_NO_LIDAR_FIX state. Localization cannot recover");
     default:
       logDebugSignal(signal);
       break;

--- a/localization_manager/src/LocalizationTypes.cpp
+++ b/localization_manager/src/LocalizationTypes.cpp
@@ -58,6 +58,7 @@ std::ostream& operator<<(std::ostream& os, LocalizationSignal s)
     case LocalizationSignal::TIMEOUT  : os << "TIMEOUT"; break;
     case LocalizationSignal::LIDAR_SENSOR_FAILURE  : os << "LIDAR_SENSOR_FAILURE"; break;
     case LocalizationSignal::LIDAR_INITIALIZED_SWITCH_TO_GPS  : os << "LIDAR_INITIALIZED_SWITCH_TO_GPS"; break;
+    case LocalizationSignal::GNSS_DATA_TIMEOUT  : os << "GNSS_DATA_TIMEOUT"; break;
     default: os.setstate(std::ios_base::failbit);
   }  // clang-format on
   return os;

--- a/localization_manager/src/localizer_node.cpp
+++ b/localization_manager/src/localizer_node.cpp
@@ -73,6 +73,8 @@ void Localizer::run()
                   config.gnss_only_operation_timeout);
   pnh_.param<int>("sequential_timesteps_until_gps_operation", config.sequential_timesteps_until_gps_operation,
                   config.sequential_timesteps_until_gps_operation);
+  pnh_.param<int>("gnss_data_timeout", config.gnss_data_timeout,
+                  config.gnss_data_timeout);
 
   int localization_mode;
   pnh_.param<int>("localization_mode", localization_mode, 0);


### PR DESCRIPTION
…only state.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the localization_manager to have a timeout for the GNSS data when in the DEGRADED_NO_LIDAR_FIX state. If this occurs then an exception is thrown. This exception should cause a FATAL system_alert to be sent to the health_monitor and result in a system shutdown. 
<!--- Describe your changes in detail -->

## Related Issue
Fixes https://github.com/usdot-fhwa-stol/carma-platform/issues/1543
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Sensor failure cases still handled in alternative localization modes
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Added unit test and all existing tests passed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
