### PR TITLE
IHP2 integration test improvements from 12/22 final run

### DIFF
--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -317,9 +317,9 @@ namespace platoon_strategic_ihp
 
 
             /**
-            * \brief Function to determin if a vehicle is in the front of hose vehicle
+            * \brief Function to determine if a target vehicle is in the front of host vehicle
             *
-            * \param downtrack vehicle downtrack
+            * \param downtrack target vehicle downtrack distance relative to host's route (m)
             *
             * \return true or false
             */
@@ -330,7 +330,7 @@ namespace platoon_strategic_ihp
             *
             * \param llt inout lanelet
             *
-            * \return speed limit value
+            * \return speed limit value (m/s)
             */
             double findSpeedLimit(const lanelet::ConstLanelet& llt);
             
@@ -626,7 +626,7 @@ namespace platoon_strategic_ihp
             int maxPlatoonSize_ = 10;
             double vehicleLength_ = 5.0;
             int infoMessageInterval_ = 200; // ms
-            long lastHeartBeatTime = 0.0;
+            long prevHeartBeatTime_ = 0.0;
             int statusMessageInterval_ = 100; // ms
             int NEGOTIATION_TIMEOUT = 5000;  // ms
             int noLeaderUpdatesCounter = 0;

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -636,10 +636,10 @@ namespace platoon_strategic_ihp
             double desiredJoinTimeGap = 4.0; // s
 
             // Threshold for determining if vehicle is stopped; non-zero allows for measurement noise
-            const double STOPPED_SPEED = 0.05 // m/s
+            const double STOPPED_SPEED = 0.05; // m/s
 
             // Strategy types
-            const std::string MOBILITY_STRATEGY = "Carma/Platooning";
+            const std::string PLATOONING_STRATEGY = "Carma/Platooning";
             const std::string OPERATION_INFO_TYPE = "INFO";
             const std::string OPERATION_STATUS_TYPE = "STATUS";
             

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -635,6 +635,8 @@ namespace platoon_strategic_ihp
             double desiredJoinGap = 30.0; // m
             double desiredJoinTimeGap = 4.0; // s
 
+            // Threshold for determining if vehicle is stopped; non-zero allows for measurement noise
+            const double STOPPED_SPEED = 0.05 // m/s
 
             // Strategy types
             const std::string MOBILITY_STRATEGY = "Carma/Platooning";


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Several small changes to platooning IHP strategic plugin:
* Fixed mob_op_cb_leader() to properly use target platoon's rear location to determine if target platoon is in front of host (was using front vehicle DTD)
* mob_op_cb_leader() was trying to use pm_ info to get target platoon rear, but pm_ refers to the host, not the target platoon.
* Fixed run_leader() to only publish INFO messages if vehicle is in motion.
* Fixed mob_op_cb() and mob_req_cb() to ignore any incoming messages if vehicle is not in motion.  This will prevent generation of mob_req or mob_resp messages or anything else to begin forming a platoon while stopped.
* Fixed mob_op_cb() and mob_req_cb() to ignore any incoming messages that aren't tagged with the platooning strategy.  Testing on 12/22 was occurring while another developer was testing another Carma vehicle with a TSMO stop intersection strategy, and our platooning vehicles were trying to process all those messages but should not be.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Two platooning vehicles were having a hard time forming a platoon due to mis-communication about which was in front and when they should begin the process.

## How Has This Been Tested?

Built the code locally.  No testing yet.  After this merge to the integration feature branch it will be ready for integration testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
