### PR TITLE
Update install.sh to source catkin setup.bash before autoware.ai ROS2 setup.bash

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -41,8 +41,8 @@ echo "Build of ROS1 CARMA Components Complete"
 # ROS2 installation
 ###
 # Source the ROS2 autoware installation
-source /opt/autoware.ai/ros/install_ros2/setup.bash
 source /home/carma/catkin/setup.bash
+source /opt/autoware.ai/ros/install_ros2/setup.bash
 
 cd ~/carma_ws
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This update causes the catkin setup.bash file to be sourced before the autoware.ai ROS2 setup.bash is sourced. By sourcing the setup.bash files in this order, a failure is avoided when building ROS2 packages that require catkin.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A carma-platform image containing ROS2 packages that require catkin was successfully built with this update.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
