### PR TITLE
Fix name for Route package's 'cte_max_count' parameter

### DIFF
--- a/route/src/route.cpp
+++ b/route/src/route.cpp
@@ -48,7 +48,7 @@ namespace route {
         int cte_count_max;
         pnh_->getParam("max_crosstrack_error", ct_error);
         pnh_->getParam("destination_downtrack_range", dt_range);
-        pnh_->getParam("cte_count_max", cte_count_max);
+        pnh_->getParam("cte_max_count", cte_count_max);
         rg_worker_.set_ctdt_param(ct_error, dt_range);
         rg_worker_.set_CTE_dist(ct_error);
         rg_worker_.set_CTE_count_max(cte_count_max);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes a mis-match between the 'cte_max_count' parameter in the Route package's configuration file, and the parameter name used to access it in the package's route.cpp file. With this change, the Route package now uses the config file parameter value, rather than the value of an uninitialized integer.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #1608 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the Red Truck at ATEF.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
