### PR TITLE
Feature/ihp john1

### DIFF
--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -130,6 +130,14 @@ namespace platoon_strategic_ihp
         void updateHostPose(const double downtrack, const double crosstrack);
 
         /**
+         * \brief Stores the latest info on host vehicle's command & actual speeds
+         * 
+         * \param cmdSpeed current commanded speed, m/s
+         * \param actualSpeed current measured speed, m/s
+         */
+        void updateHostSpeeds(const double cmdSpeed, const double actualSpeed);
+
+        /**
         * \brief Update platoon members information
         * 
         * \param senderId static id of the broadcasting vehicle

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -55,10 +55,17 @@ namespace platoon_strategic_ihp
     // Update the location of the host in the vector of platoon members
     void PlatoonManager::updateHostPose(const double downtrack, const double crosstrack)
     {
+        ROS_DEBUG_STREAM("Host (index " << hostPosInPlatoon_ << "): downtrack = " << downtrack << ", crosstrack = " << crosstrack);
         platoon[hostPosInPlatoon_].vehiclePosition = downtrack;
         //TODO:  store crosstrack when it becomes a member of the PlatoonMember struct
     }
 
+    // Update the speed info of the host in the vector of platoon members
+    void PlatoonManager::updateHostSpeeds(const double cmdSpeed, const double actualSpeed)
+    {
+        platoon[hostPosInPlatoon_].commandSpeed = cmdSpeed;
+        platoon[hostPosInPlatoon_].vehicleSpeed = actualSpeed;
+    }
 
     // Update/add one member's information from STATUS messages, update platoon ID if needed. Ignore if message is from other platoons. 
     void PlatoonManager::memberUpdates(const std::string& senderId, const std::string& platoonId, const std::string& params, const double& DtD){

--- a/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
@@ -1886,8 +1886,9 @@ namespace platoon_strategic_ihp
     {
         plugin_discovery_publisher_(plugin_discovery_msg_);
         
-        // Update the platoon manager for host's current location
+        // Update the platoon manager for host's current location & speeds
         pm_.updateHostPose(current_downtrack_, current_crosstrack_);
+        pm_.updateHostSpeeds(current_speed_, command_speed_);
 
         if (pm_.current_platoon_state == PlatoonState::LEADER)
         {

--- a/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
@@ -1888,7 +1888,7 @@ namespace platoon_strategic_ihp
         
         // Update the platoon manager for host's current location & speeds
         pm_.updateHostPose(current_downtrack_, current_crosstrack_);
-        pm_.updateHostSpeeds(current_speed_, command_speed_);
+        pm_.updateHostSpeeds(current_speed_, cmd_speed_);
 
         if (pm_.current_platoon_state == PlatoonState::LEADER)
         {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Ensures that the host's record of its own speed and speed command are being updated each time step in the list of platoon members.

## Related Issue
None

## Motivation and Context
Mobility messages being broadcast have inconsistent or incorrect speed info.

## How Has This Been Tested?
No testing yet.  This PR is to support integration test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
