### PR TITLE
Fix applied update to maneuver downtracks

### DIFF
--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -71,6 +71,11 @@ namespace plan_delegator
         if (isManeuverPlanValid(plan))
         {
             latest_maneuver_plan_ = *plan;
+            
+            // Update the starting and ending downtracks associated with each maneuver 
+            for (auto& maneuver : latest_maneuver_plan_.maneuvers) {
+                updateManeuverDistances(maneuver);
+            }
         }
         else {
             ROS_WARN_STREAM("Received empty plan, no maneuvers found in plan ID " << plan->maneuver_plan_id);
@@ -193,8 +198,6 @@ namespace plan_delegator
                 ++current_maneuver_index;
                 continue;
             }
-
-            updateManeuverDistances(maneuver);
             
             lanelet::BasicPoint2d current_loc(latest_pose_.pose.position.x, latest_pose_.pose.position.y);
             double current_downtrack = wm_->routeTrackPos(current_loc).downtrack;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes an update to plan_delegator by updating the starting and ending downtracks of each maneuver in a received maneuver plan only once (at the moment the maneuver plan is received). Previously, the starting and ending downtracks of each maneuver were being updated with each spin/tick of plan_delegator, causing the starting and ending downtracks of each maneuver to be repeatedly decreased. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prior to this fix, the CARMA System came to a stop too early at the end of its route, and steering was jerky in curves.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the White Truck at ATEF.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
