### PR TITLE
Feature/ihp strategic maneuver update

### DIFF
--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -57,6 +57,9 @@ namespace platoon_control
 
 			// find the point correspoding to the lookahead distance
 			cav_msgs::TrajectoryPlanPoint getLookaheadTrajectoryPoint(cav_msgs::TrajectoryPlan trajectory_plan);
+
+			// timer callback for control signal publishers
+			bool controlTimerCb();
 			
 			// local copy of pose
         	geometry_msgs::PoseStamped pose_msg_;
@@ -64,6 +67,8 @@ namespace platoon_control
 			// current speed (in m/s)
 			double current_speed_ = 0.0;
 			double trajectory_speed_ = 0.0;
+
+			cav_msgs::TrajectoryPlan latest_trajectory_;
 
         
         private:
@@ -95,6 +100,7 @@ namespace platoon_control
 			void currentTwist_cb(const geometry_msgs::TwistStamped::ConstPtr& twist);
 
 			double getTrajectorySpeed(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory_points);
+
 
 			
 

--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -59,6 +59,7 @@ namespace platoon_control
 			cav_msgs::TrajectoryPlanPoint getLookaheadTrajectoryPoint(cav_msgs::TrajectoryPlan trajectory_plan);
 
 			// timer callback for control signal publishers
+			// returns true if control signals are correctly calculated.
 			bool controlTimerCb();
 			
 			// local copy of pose

--- a/platooning_control/src/platoon_control.cpp
+++ b/platooning_control/src/platoon_control.cpp
@@ -218,7 +218,7 @@ namespace platoon_control
 
     void PlatoonControlPlugin::generateControlSignals(const cav_msgs::TrajectoryPlanPoint& first_trajectory_point, const cav_msgs::TrajectoryPlanPoint& lookahead_point){
 
-        pcw_.setCurrentSpeed(trajectory_speed_);
+        pcw_.setCurrentSpeed(trajectory_speed_); //TODO why this and not the actual vehicle speed?  Method name suggests different use than this.
         // pcw_.setCurrentSpeed(current_speed_);
         pcw_.setLeader(platoon_leader_);
     	pcw_.generateSpeed(first_trajectory_point);
@@ -243,9 +243,11 @@ namespace platoon_control
         double t1 = (trajectory_points[trajectory_points.size()-1].target_time.toSec() - trajectory_points[0].target_time.toSec());
 
         double avg_speed = d1/t1;
+        ROS_DEBUG_STREAM("trajectory_points size = " << trajectory_points.size() << ", d1 = " << d1 << ", t1 = " << t1 << ", avg_speed = " << avg_speed);
 
         for(size_t i = 0; i < trajectory_points.size() - 2; i++ )
-        {            double dx = trajectory_points[i + 1].x - trajectory_points[i].x;
+        {            
+            double dx = trajectory_points[i + 1].x - trajectory_points[i].x;
             double dy = trajectory_points[i + 1].y - trajectory_points[i].y;
             double d = sqrt(dx*dx + dy*dy); 
             double t = (trajectory_points[i + 1].target_time.toSec() - trajectory_points[i].target_time.toSec());
@@ -259,7 +261,7 @@ namespace platoon_control
         ROS_DEBUG_STREAM("trajectory speed: " << trajectory_speed);
         ROS_DEBUG_STREAM("avg trajectory speed: " << avg_speed);
 
-        return avg_speed;
+        return avg_speed; //TODO: why are 2 speeds being calculated? Which should be returned?
 
     }
 

--- a/platooning_control/src/platoon_control.cpp
+++ b/platooning_control/src/platoon_control.cpp
@@ -87,7 +87,7 @@ namespace platoon_control
 
 
         ros::Timer control_pub_timer_ = pnh_->createTimer(
-            ros::Duration(ros::Rate(10.0)),
+            ros::Duration(ros::Rate(30.0)),
             [this](const auto&) {controlTimerCb();});    
     }
 
@@ -100,12 +100,12 @@ namespace platoon_control
     bool PlatoonControlPlugin::controlTimerCb()
     {
 
-        cav_msgs::TrajectoryPlanPoint first_trajectory_point = latest_trajectory_.trajectory_points[1]; // TODO this variable appears to be misnamed. It is the second trajectory point
+        cav_msgs::TrajectoryPlanPoint second_trajectory_point = latest_trajectory_.trajectory_points[1]; 
         cav_msgs::TrajectoryPlanPoint lookahead_point = getLookaheadTrajectoryPoint(latest_trajectory_);
 
         trajectory_speed_ = getTrajectorySpeed(latest_trajectory_.trajectory_points);
         
-        generateControlSignals(first_trajectory_point, lookahead_point); // TODO this should really be called on a timer against that last trajectory so 30Hz control loop can be achieved
+        generateControlSignals(second_trajectory_point, lookahead_point); 
 
         return true;
     }   


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
In this PR, the following modifications are done:
- Maneuver generation is updated to always generate maneuvers with minimum 15 sec length.
- Logs added to control plugin.
- Platooning Control plugin updated to generate control signals at 10 hz
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
to resolve sudden steering behavior when control plugin is switched from pure pursuit to platooning

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
