### PR TITLE
Platooning control plugin handles control switchover

### DIFF
--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -81,6 +81,8 @@ namespace platoon_control
 
 			// Variables
 			PlatoonLeaderInfo platoon_leader_;
+			long prev_input_time_ = 0;				//timestamp of the previous trajectory plan input received
+			long consecutive_input_counter_ = 0;	//num inputs seen without a timeout
 
 			// callback function for pose
 			void pose_cb(const geometry_msgs::PoseStampedConstPtr& msg);

--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -104,12 +104,8 @@ namespace platoon_control
 
 			double getTrajectorySpeed(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory_points);
 
-
-			
-
         	// Plugin discovery message
         	cav_msgs::Plugin plugin_discovery_msg_;
-
 
         	// ROS Subscriber
         	ros::Subscriber trajectory_plan_sub;
@@ -122,12 +118,5 @@ namespace platoon_control
         	ros::Publisher plugin_discovery_pub_;
 			ros::Publisher platoon_info_pub_;
 			ros::Timer discovery_pub_timer_;
-			
-			
-
-
-
-
-    
     };
 }

--- a/platooning_control/include/platoon_control_config.h
+++ b/platooning_control/include/platoon_control_config.h
@@ -36,12 +36,14 @@ struct PlatooningControlPluginConfig
   int cmdTmestamp = 100;
   double integratorMax = 100;
   double integratorMin = -100;
-  double Kdd = 4.5;                             //coeficient for smooth steering
+  double Kdd = 4.5;                             //coefficient for smooth steering
   double wheelBase = 3.09;
   double lowpassGain = 0.5;
   double lookaheadRatio = 2.0;
   double minLookaheadDist = 6.0;
   std::string vehicleID = "DEFAULT_VEHICLE_ID";         // Vehicle id is the license plate of the vehicle
+  int     shutdownTimeout = 200;                // ms 
+  int     ignoreInitialInputs = 0;              // num inputs to throw away after startup
   
   
   friend std::ostream& operator<<(std::ostream& output, const PlatooningControlPluginConfig& c)
@@ -66,6 +68,8 @@ struct PlatooningControlPluginConfig
            << "lookaheadRatio: " << c.lookaheadRatio << std::endl
            << "minLookaheadDist: " << c.minLookaheadDist << std::endl
            << "vehicleID: " << c.vehicleID << std::endl
+           << "shutdownTimeout: " << c.shutdownTimeout << std::endl
+           << "ignoreInitialInputs: " << c.ignoreInitialInputs << std::endl
            << "}" << std::endl;
     return output;
   }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Enhanced the platooning control plugin to cooperate with other control plugins to accommodate the fact that all control plugins publish their output on a common ros topic, and this topic is only intended to carry data from a single controller at a time.  When trajectory executor switches from one control plugin to another, we want the old one to stop publishing.  However, it needs to wait some amount of time since it is spinning faster than the producer of its input trajectory data. Since this input data is not guaranteed to arrive at a precise interval, the control plugin needs to wait for a conservative timeout period before deciding that the input stream has dried up.

Note: architecture documentation is to be updated at a later time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
PR #1647 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ensures a control plugin stops publishing output data when another control plugin takes over.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet tested - this PR is for integration testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
