### PR TITLE
CARMA Web UI - Traffic signal phase and timing display not working

### DIFF
--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -385,7 +385,7 @@ public:
   /*! \brief populate upcoming_intersection_ids_ from local traffic lanelet ids
   @param current_lanelet vehicle location
    */
-  void updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_lanelet);
+  void updateUpcomingSGIntersectionIds();
 
   visualization_msgs::MarkerArray tcm_marker_array_;
   cav_msgs::TrafficControlRequestPolygon tcr_polygon_;

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -383,7 +383,6 @@ public:
   void publishLightId();
 
   /*! \brief populate upcoming_intersection_ids_ from local traffic lanelet ids
-  @param current_lanelet vehicle location
    */
   void updateUpcomingSGIntersectionIds();
 

--- a/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
+++ b/carma_wm_ctrl/include/carma_wm_ctrl/WMBroadcaster.h
@@ -382,6 +382,11 @@ public:
    */
   void publishLightId();
 
+  /*! \brief populate upcoming_intersection_ids_ from local traffic lanelet ids
+  @param current_lanelet vehicle location
+   */
+  void updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_lanelet);
+
   visualization_msgs::MarkerArray tcm_marker_array_;
   cav_msgs::TrafficControlRequestPolygon tcr_polygon_;
   std_msgs::Int32MultiArray upcoming_intersection_ids_;

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2107,7 +2107,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds()
   }
   else{
      ROS_DEBUG_STREAM("NO matching Traffic lights along the route");
-  }
+  }//END Traffic signals
 
   auto intersections = route_lanelet.regulatoryElementsAs<lanelet::SignalizedIntersection>();
   if (intersections.empty())
@@ -2129,12 +2129,14 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds()
         }
       }
     }
+  } //END intersections
 
-    ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
+  ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
+  if(map_msg_intersection_id != 0 && cur_signal_group_id != 0)
+  {    
     upcoming_intersection_ids_.data.push_back(static_cast<int>(map_msg_intersection_id));
     upcoming_intersection_ids_.data.push_back(static_cast<int>(cur_signal_group_id));
-
-  } //END intersections
+  }
 }
 
 const uint8_t WorkZoneSection::OPEN = 0;

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2084,13 +2084,15 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
   uint16_t cur_signal_group_id = 0;
   for(auto itr = sim_.signal_group_to_entry_lanelet_ids_.begin(); itr != sim_.signal_group_to_entry_lanelet_ids_.end(); itr++)
   {
-    if(itr->second == cur_lanelet.id())
+    if(itr->second.find(cur_lanelet.id()) != itr->second.end())
     {
       cur_signal_group_id = itr->first;
     }
   }
-
-  lanelet::Ids lanelet_ids = current_route.route_path_lanelet_ids();
+  lanelet::Lanelets entry_lls;
+  entry_lls.push_back(cur_lanelet);
+  lanelet::Lanelets exit_lls;
+  lanelet::Ids lanelet_ids = current_route.route_path_lanelet_ids;
   lanelet::Id intersection_id = lanelet::InvalId ;
   for(auto itr = lanelet_ids.begin() ; itr != lanelet_ids.end() ; itr++)
   {
@@ -2098,7 +2100,8 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
     {
       continue;
     }
-    intersection_id = sim_.matchSignalizedIntersection(cur_lanelet, current_map_->laneletLayer.get(*itr), current_map_);
+    exit_lls.push_back(current_map_->laneletLayer.get(*itr));
+    intersection_id = sim_.matchSignalizedIntersection(entry_lls, exit_lls, current_map_);
   }
 
   if(intersection_id != lanelet::InvalId)

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2133,7 +2133,8 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds()
 
   ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
   if(map_msg_intersection_id != 0 && cur_signal_group_id != 0)
-  {    
+  { 
+    upcoming_intersection_ids_.data.clear();
     upcoming_intersection_ids_.data.push_back(static_cast<int>(map_msg_intersection_id));
     upcoming_intersection_ids_.data.push_back(static_cast<int>(cur_signal_group_id));
   }

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2111,6 +2111,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       }
     }
   }
+  ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
   upcoming_intersection_ids_.data.push_back(static_cast<int>(map_msg_intersection_id));
   upcoming_intersection_ids_.data.push_back(static_cast<int>(cur_signal_group_id));
 }

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2089,6 +2089,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       cur_signal_group_id = itr->first;
     }
   }
+
   lanelet::Lanelets entry_lls;
   entry_lls.push_back(cur_lanelet);
   lanelet::Lanelets exit_lls;
@@ -2102,6 +2103,11 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
     }
     exit_lls.push_back(current_map_->laneletLayer.get(*itr));
     intersection_id = sim_.matchSignalizedIntersection(entry_lls, exit_lls, current_map_);
+    
+    if(intersection_id != lanelet::InvalId)
+    {
+      break;
+    }
   }
 
   if(intersection_id != lanelet::InvalId)
@@ -2114,6 +2120,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       }
     }
   }
+  
   ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
   upcoming_intersection_ids_.data.push_back(static_cast<int>(map_msg_intersection_id));
   upcoming_intersection_ids_.data.push_back(static_cast<int>(cur_signal_group_id));

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2102,13 +2102,9 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       continue;
     }
     exit_lls.push_back(current_map_->laneletLayer.get(*itr));
-    intersection_id = sim_.matchSignalizedIntersection(entry_lls, exit_lls, current_map_);
-    
-    if(intersection_id != lanelet::InvalId)
-    {
-      break;
-    }
   }
+
+  intersection_id = sim_.matchSignalizedIntersection(entry_lls, exit_lls, current_map_);
 
   if(intersection_id != lanelet::InvalId)
   {
@@ -2120,7 +2116,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       }
     }
   }
-  
+
   ROS_DEBUG_STREAM("MAP msg: Intersection ID = " <<  map_msg_intersection_id << ", Signal Group ID =" << cur_signal_group_id );
   upcoming_intersection_ids_.data.push_back(static_cast<int>(map_msg_intersection_id));
   upcoming_intersection_ids_.data.push_back(static_cast<int>(cur_signal_group_id));

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -2108,7 +2108,7 @@ void WMBroadcaster::updateUpcomingSGIntersectionIds(const lanelet::Lanelet cur_l
       
       for(auto inner_itr = exit_lls.begin(); inner_itr != exit_lls.end(); inner_itr++)
       {
-        if(std::find(cur_route_lanelet_ids.begin(), cur_route_lanelet_ids.end() , *inner_itr) != cur_route_lanelet_ids.end())
+        if(std::find(cur_route_lanelet_ids.begin(), cur_route_lanelet_ids.end() , inner_itr->id() ) != cur_route_lanelet_ids.end())
         {
           intersection_id = itr->get()->id();
         }

--- a/carma_wm_ctrl/src/WMBroadcasterNode.cpp
+++ b/carma_wm_ctrl/src/WMBroadcasterNode.cpp
@@ -99,7 +99,7 @@ int WMBroadcasterNode::run()
       tcr_visualizer_pub_.publish(wmb_.tcr_polygon_);
       wmb_.publishLightId();
       //updating upcoming traffic signal group id and intersection id
-      updateUpcomingSGIntersectionIds();
+      wmb_.updateUpcomingSGIntersectionIds();
       if (wmb_.upcoming_intersection_ids_.data.size() > 0)
         upcoming_intersection_ids_pub_.publish(wmb_.upcoming_intersection_ids_);
       if(wmb_.getRoute().route_path_lanelet_ids.size() > 0)

--- a/carma_wm_ctrl/src/WMBroadcasterNode.cpp
+++ b/carma_wm_ctrl/src/WMBroadcasterNode.cpp
@@ -98,6 +98,8 @@ int WMBroadcasterNode::run()
       tcm_visualizer_pub_.publish(wmb_.tcm_marker_array_);
       tcr_visualizer_pub_.publish(wmb_.tcr_polygon_);
       wmb_.publishLightId();
+      //updating upcoming traffic signal group id and intersection id
+      updateUpcomingSGIntersectionIds();
       if (wmb_.upcoming_intersection_ids_.data.size() > 0)
         upcoming_intersection_ids_pub_.publish(wmb_.upcoming_intersection_ids_);
       if(wmb_.getRoute().route_path_lanelet_ids.size() > 0)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
The UI should be subscribing to a topic that provides the SPAT messages in order to showcase the phase and timing of the traffic signals at TFHRC.
## Description
CARMA Web UI - Traffic signal phase and timing display not working
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
