### PR TITLE
Lane change trajectory fixes

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -1029,6 +1029,12 @@ namespace basic_autonomy
             std::vector<lanelet::BasicPoint2d> all_sampling_points;
             all_sampling_points.reserve(1 + future_geom_points.size() * 2);
 
+            lanelet::BasicPoint2d current_vehicle_point(state.x_pos_global, state.y_pos_global);
+
+            future_geom_points.insert(future_geom_points.begin(),
+                                       current_vehicle_point); // Add current vehicle position to front of future geometry points
+
+            final_actual_speeds.insert(final_actual_speeds.begin(), state.longitudinal_vel);
         
             //Compute points to local downtracks
             std::vector<double> downtracks = carma_wm::geometry::compute_arc_lengths(future_geom_points);
@@ -1048,6 +1054,10 @@ namespace basic_autonomy
             ROS_DEBUG_STREAM("Got sampled points with size:" << all_sampling_points.size());
 
             std::vector<double> final_yaw_values = carma_wm::geometry::compute_tangent_orientations(future_geom_points);
+            if(final_yaw_values.size() > 0) {
+                final_yaw_values[0] = state.orientation; // Set the initial yaw value based on the initial state
+            }
+
             final_actual_speeds = smoothing::moving_average_filter(final_actual_speeds, detailed_config.speed_moving_average_window_size);
 
             //Convert speeds to time

--- a/cooperative_lanechange/include/cooperative_lanechange.h
+++ b/cooperative_lanechange/include/cooperative_lanechange.h
@@ -45,7 +45,18 @@ namespace cooperative_lanechange
 {
   // Helpful using declarations
   using PointSpeedPair = basic_autonomy::waypoint_generation::PointSpeedPair;
-  
+
+    /**
+     * \brief Convenience struct for storing the original start_dist and starting_lane_id associated 
+     * with a received lane change maneuver.
+     */
+    struct LaneChangeManeuverOriginalValues
+    {
+        std::string maneuver_id;
+        std::string original_starting_lane_id; // original starting_lane_id associated with lane change maneuver
+        double original_start_dist; // original start_dist associated with lane change maneuver
+    };
+
     class CooperativeLaneChangePlugin
     {
         public:
@@ -189,8 +200,8 @@ namespace cooperative_lanechange
             std::string sender_id_ = DEFAULT_STRING_;
             cav_msgs::BSMCoreData bsm_core_;
 
-            // Maps maneuver IDs to their original start_dist value
-            std::unordered_map<std::string, double> original_maneuver_start_dists_;
+            // Maps maneuver IDs to their corresponding LaneChangeManeuverOriginalValues object
+            std::unordered_map<std::string, LaneChangeManeuverOriginalValues> original_lc_maneuver_values_;
 
             //Plugin specific params
             double desired_time_gap_ = 3.0;

--- a/cooperative_lanechange/include/cooperative_lanechange.h
+++ b/cooperative_lanechange/include/cooperative_lanechange.h
@@ -182,15 +182,15 @@ namespace cooperative_lanechange
             double maneuver_fraction_completed_ = 0;
             // flag to check if CLC plugin is called
             bool clc_called_ = false;
-            //flag to check if lane change is in progress
-            bool is_lanechange_in_progress_ = false;
-            double lc_starting_downtrack_ = 0.0;
             // Mobility request id
             std::string clc_request_id_ = "default_request_id";
             // ROS params
             //Vehicle params
             std::string sender_id_ = DEFAULT_STRING_;
             cav_msgs::BSMCoreData bsm_core_;
+
+            // Maps maneuver IDs to their original start_dist value
+            std::unordered_map<std::string, double> original_maneuver_start_dists_;
 
             //Plugin specific params
             double desired_time_gap_ = 3.0;

--- a/cooperative_lanechange/src/cooperative_lanechange.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange.cpp
@@ -306,6 +306,7 @@ namespace cooperative_lanechange
         // Set starting downtrack for lane change maneuver, which will remain constant constant
         std::string maneuver_id = maneuver_plan[0].lane_change_maneuver.parameters.maneuver_id;
         if (original_maneuver_start_dists_.find(maneuver_id) == original_maneuver_start_dists_.end()) {
+            ROS_DEBUG_STREAM("Received maneuver id " << maneuver_id << " for the first time. Original start dist is " << maneuver_plan[0].lane_change_maneuver.start_dist);
             original_maneuver_start_dists_[maneuver_id] = maneuver_plan[0].lane_change_maneuver.start_dist;
         }
 
@@ -525,6 +526,7 @@ namespace cooperative_lanechange
         
         if (original_maneuver_start_dists_.find(maneuver_id) != original_maneuver_start_dists_.end()) {
             original_start_dist = original_maneuver_start_dists_[maneuver_id];
+            ROS_DEBUG_STREAM("Maneuver id " << maneuver_id << " original start dist is " << original_start_dist);
         }
         else {
             ROS_WARN_STREAM("No original start_dist for lane change maneuver was found!");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes two fixes in cooperative_lanechange and basic_autonomy to address issues with lane change trajectories:
- Fixes in basic_autonomy constrain the first trajectory plan point to use the received vehicle state (position, longitudinal speed, and orientation). This ensures that a proper target_time is assigned to the first lane change trajectory plan point in order to match the intended vehicle speed.
- Fixes in cooperative_lanechange enable CooperativeLaneChangePlugin to store the original start_dist and starting_lane_id of each received lane change maneuver. Each time a trajectory is planned for a lane change maneuver, it's original start_dist and starting_lane_id is now used. Prior to this fix, the start_dist and the starting_lane_id could change mid-lanechange for lane changes that spanned multiple lanelets longitudinally, which led to steering jerk during the lane change. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- Issue #1683 
- Issue #1340 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Silver Truck at Suntrax as part of Freight Workzone testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
