### PR TITLE
Feature/ihp identities

### DIFF
--- a/platooning_strategic_IHP/config/parameters.yaml
+++ b/platooning_strategic_IHP/config/parameters.yaml
@@ -7,6 +7,7 @@ maxAllowedJoinTimeGap: 15.0
 maxAllowedJoinGap: 90.0
 desiredJoinTimeGap: 4.0
 desiredJoinGap: 30.0
+maxLeaderAbortingCalls: 4
 waitingStateTimeout: 25.0
 cmdSpeedMaxAdjustment: 10.0
 minAllowableHeadaway: 1.6

--- a/platooning_strategic_IHP/include/platoon_config_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_config_ihp.h
@@ -42,6 +42,7 @@ struct PlatoonPluginConfig
   double longitudinalCheckThresold      = 85.0;    // m
   double desiredJoinTimeGap             = 4.0;     // s
   double desiredJoinGap                 = 30.0;    // m
+  int    maxLeaderAbortingCalls         = 4;       // counter
   double waitingStateTimeout            = 25.0;    // s
   double cmdSpeedMaxAdjustment          = 10.0;    // m/s
     
@@ -86,6 +87,7 @@ struct PlatoonPluginConfig
           << "maxAllowedJoinTimeGap: " << c.maxAllowedJoinTimeGap << std::endl
           << "desiredJoinTimeGap: " << c.desiredJoinTimeGap << std::endl
           << "desiredJoinGap: " << c.desiredJoinGap << std::endl
+          << "maxLeaderAbortingCalls: " << c.maxLeaderAbortingCalls << std::endl
           << "waitingStateTimeout: " << c.waitingStateTimeout << std::endl
           << "cmdSpeedMaxAdjustment: " << c.cmdSpeedMaxAdjustment << std::endl
           << "minAllowableHeadaway: " << c.minAllowableHeadaway << std::endl

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -44,11 +44,13 @@ namespace platoon_strategic_ihp
     */ 
     struct PlatoonPlan 
     {
-        bool valid;
-        unsigned long planStartTime;
-        std::string planId;
-        std::string peerId;
-        PlatoonPlan():valid(false), planStartTime(0), planId(""), peerId("") {} ;
+        bool            valid;          //is this plan currently in use?
+        unsigned long   planStartTime;  //time that plan was initiated
+        std::string     planId;         //ID of this platoon
+        std::string     peerId;         //vehicle ID of a candidtate joining vehicle
+
+        PlatoonPlan() : valid(false), planStartTime(0), planId(""), peerId("") {}
+
         PlatoonPlan(bool valid, unsigned long planStartTime, std::string planId, std::string peerId): 
             valid(valid), planStartTime(planStartTime), planId(planId), peerId(peerId) {}  
     };
@@ -286,11 +288,9 @@ namespace platoon_strategic_ihp
         double getCutInGap(const int gap_leading_index, const double joinerDtD);
 
         // Member variables
-        std::string currentPlatoonID = "default_test_id";
         bool isFollower = false;
         PlatoonState current_platoon_state = PlatoonState::STANDBY;
         PlatoonPlan current_plan;
-        std::string targetLeaderId = "default_target_leader_id";
 
         // host vehicle's static ID 
         std::string HostMobilityId = "default_host_id";
@@ -305,7 +305,6 @@ namespace platoon_strategic_ihp
         // local copy of configuration file
         PlatoonPluginConfig config_;
 
-        std::string targetPlatoonId;
         std::string OPERATION_INFO_TYPE = "INFO";
         std::string OPERATION_STATUS_TYPE = "STATUS";
         std::string JOIN_AT_REAR_PARAMS = "SIZE:%1%,SPEED:%2%,DTD:%3%";

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -40,18 +40,18 @@
 namespace platoon_strategic_ihp
 {
     /**
-    * \brief Struct for a platoon plan
+    * \brief Struct for an action plan, which describes a transient joining activity
     */ 
-    struct PlatoonPlan 
+    struct ActionPlan 
     {
-        bool            valid;          //is host currently in or joining a platoon?
+        bool            valid;          //is host currently negotiating/executing a join action?
         unsigned long   planStartTime;  //time that plan was initiated
-        std::string     planId;         //ID of this platoon
-        std::string     peerId;         //vehicle ID of a candidtate joining vehicle or leader of platoon we are joining
+        std::string     planId;         //ID of this action
+        std::string     peerId;         //vehicle ID of the candidtate joining vehicle or leader of platoon we are joining
 
-        PlatoonPlan() : valid(false), planStartTime(0), planId(""), peerId("") {}
+        ActionPlan() : valid(false), planStartTime(0), planId(""), peerId("") {}
 
-        PlatoonPlan(bool valid, unsigned long planStartTime, std::string planId, std::string peerId): 
+        ActionPlan(bool valid, unsigned long planStartTime, std::string planId, std::string peerId): 
             valid(valid), planStartTime(planStartTime), planId(planId), peerId(peerId) {}  
     };
 
@@ -107,7 +107,9 @@ namespace platoon_strategic_ihp
         double vehicleCrossTrack;
         // The local time stamp when the host vehicle update any informations of this member.
         long   timestamp;
+
         PlatoonMember(): staticId(""), commandSpeed(0.0), vehicleSpeed(0.0), vehiclePosition(0.0), vehicleCrossTrack(0.0), timestamp(0) {} 
+
         PlatoonMember(std::string staticId, double commandSpeed, double vehicleSpeed, double vehiclePosition, double vehicleCrossTrack, long timestamp): staticId(staticId),
             commandSpeed(commandSpeed), vehicleSpeed(vehicleSpeed), vehiclePosition(vehiclePosition), vehicleCrossTrack(vehicleCrossTrack), timestamp(timestamp) {}
     };
@@ -170,6 +172,11 @@ namespace platoon_strategic_ihp
         * \brief Returns total size of the platoon , in number of vehicles.
         */
         int getTotalPlatooningSize();
+
+        /**
+         * \brief Resets necessary variables to indicate that the current ActionPlan is dead.
+         */
+        void clearActionPlan();
 
         /**
         * \brief Returns dynamic leader of the host vehicle.
@@ -288,9 +295,11 @@ namespace platoon_strategic_ihp
         double getCutInGap(const int gap_leading_index, const double joinerDtD);
 
         // Member variables
+        std::string currentPlatoonID = ""; //empty string indicates not part of a platoon
+        std::string platoonLeaderID = "";  //empty string indicates not part of a platoon
         bool isFollower = false;
         PlatoonState current_platoon_state = PlatoonState::STANDBY;
-        PlatoonPlan current_plan;
+        ActionPlan current_plan = ActionPlan(); //this plan represents a joining activity only, not the platoon itself
 
         // host vehicle's static ID 
         std::string HostMobilityId = "default_host_id";

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -297,7 +297,7 @@ namespace platoon_strategic_ihp
         // Member variables
         std::string currentPlatoonID = ""; //empty string indicates not part of a platoon
         std::string platoonLeaderID = "";  //empty string indicates not part of a platoon
-        bool isFollower = false;
+        std::string targetPlatoonID = "";  //ID of a real platoon that we may be attempting to join (empty if neighbor is a solo vehicle)
         PlatoonState current_platoon_state = PlatoonState::STANDBY;
         ActionPlan current_plan = ActionPlan(); //this plan represents a joining activity only, not the platoon itself
 

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -44,10 +44,10 @@ namespace platoon_strategic_ihp
     */ 
     struct PlatoonPlan 
     {
-        bool            valid;          //is this plan currently in use?
+        bool            valid;          //is host currently in or joining a platoon?
         unsigned long   planStartTime;  //time that plan was initiated
         std::string     planId;         //ID of this platoon
-        std::string     peerId;         //vehicle ID of a candidtate joining vehicle
+        std::string     peerId;         //vehicle ID of a candidtate joining vehicle or leader of platoon we are joining
 
         PlatoonPlan() : valid(false), planStartTime(0), planId(""), peerId("") {}
 

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -300,6 +300,7 @@ namespace platoon_strategic_ihp
         std::string targetPlatoonID = "";  //ID of a real platoon that we may be attempting to join (empty if neighbor is a solo vehicle)
         PlatoonState current_platoon_state = PlatoonState::STANDBY;
         ActionPlan current_plan = ActionPlan(); //this plan represents a joining activity only, not the platoon itself
+        bool isFollower = false;
 
         // host vehicle's static ID 
         std::string HostMobilityId = "default_host_id";

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -344,21 +344,9 @@ namespace platoon_strategic_ihp
             long waitingStartTime = 0;
             // start time of candidate follower state, s
             long candidatestateStartTime = 0;
-            // potential new platood id 
-            std::string potentialNewPlatoonId = "";
-
-            // UCLA: potential new platoon id for front join
-            std::string potentialNewPlatoonId_front_  = "";
 
             // Host Mobility ID
             std::string HostMobilityId = "hostid";
-
-            // UCLA: leader_waiting applicant id
-            std::string lw_applicantId_ = "";
-            // UCLA: add new joiner ID front for frontal join
-            std::string fj_new_joiner_Id_ = "";
-            // The current joining vehicle's static ID. (This value will be reset once the leader exit lead_with_operation state)
-            std::string joiningID_ = "";
 
             // ROS Publishers
             ros::Publisher platoon_strategic_ihp_plugin_discovery_pub_;

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -299,11 +299,6 @@ namespace platoon_strategic_ihp
             void setPMState(PlatoonState desiredState);
 
             /**
-             * \brief UCLA Setter: function to set pm_.current_plan.valid. (This is only used for UniteTst).
-             */
-            void setPMValid(bool isPlanValid);
-
-            /**
              * \brief UCLA Setter: Update platoon list (Unit Test).
              */
             void updatePlatoonList(std::vector<PlatoonMember> platoon_list);
@@ -355,8 +350,6 @@ namespace platoon_strategic_ihp
             // UCLA: potential new platoon id for front join
             std::string potentialNewPlatoonId_front_  = "";
 
-            // target platood id 
-            std::string targetPlatoonId = "";
             // Host Mobility ID
             std::string HostMobilityId = "hostid";
 
@@ -811,6 +804,7 @@ namespace platoon_strategic_ihp
             // Plugin discovery message
             cav_msgs::Plugin plugin_discovery_msg_;
 
+            // Latch to allow only one request from aborting leader to a front joiner
             bool isFirstLeaderAbortRequest_ = true;
 
             double maxAllowedJoinTimeGap_ = 15.0;

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -526,16 +526,6 @@ namespace platoon_strategic_ihp
             cav_msgs::MobilityOperation composeMobilityOperationCandidateFollower();
             
             /**
-             * \brief Helper to store info on new action plan and platoon updates
-             * 
-             * \param msg the incoming mobility operation message with leader & platoon info
-             * \param request a structure holding mobility request header info to the platoon leader
-             * \param targetPlatoonSize num vehicles in the platoon described by msg
-             */
-            void create_join_action_plan(const cav_msgs::MobilityOperation& msg, const cav_msgs::MobilityRequest& request, 
-                                         const int targetPlatoonSize);
-
-            /**
             * \brief Function to convert pose from map frame to ecef location
             *
             * \param pose_msg pose message
@@ -804,6 +794,9 @@ namespace platoon_strategic_ihp
 
             // Latch to allow only one request from aborting leader to a front joiner
             bool isFirstLeaderAbortRequest_ = true;
+
+            // Number of calls to the run_leader_aborting() method
+            int numLeaderAbortingCalls_ = 0;
 
             double maxAllowedJoinTimeGap_ = 15.0;
             double maxAllowedJoinGap_ = 90;

--- a/platooning_strategic_IHP/include/platoon_strategic_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_ihp.h
@@ -526,6 +526,16 @@ namespace platoon_strategic_ihp
             cav_msgs::MobilityOperation composeMobilityOperationCandidateFollower();
             
             /**
+             * \brief Helper to store info on new action plan and platoon updates
+             * 
+             * \param msg the incoming mobility operation message with leader & platoon info
+             * \param request a structure holding mobility request header info to the platoon leader
+             * \param targetPlatoonSize num vehicles in the platoon described by msg
+             */
+            void create_join_action_plan(const cav_msgs::MobilityOperation& msg, const cav_msgs::MobilityRequest& request, 
+                                         const int targetPlatoonSize);
+
+            /**
             * \brief Function to convert pose from map frame to ecef location
             *
             * \param pose_msg pose message

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -536,7 +536,7 @@ namespace platoon_strategic_ihp
  
         hostPosInPlatoon_ = 1;
         isFollower = true;
-        currentPlatoonID = newPlatoonId;
+        current_plan.planId = newPlatoonId;
         ROS_DEBUG_STREAM("The platoon manager is changed from leader state to follower state. Platoon vector re-initialized. Plan ID = " << newPlatoonId);
     }
 

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -206,6 +206,14 @@ namespace platoon_strategic_ihp
         ROS_DEBUG_STREAM("platoonSize: " << platoon.size());
         return platoon.size();
     }
+
+    // Reset variables to indicate there is no current action in work
+    void PlatoonManager::clearActionPlan()
+    {
+        current_plan.valid = false;
+        current_plan.planId = "";
+        current_plan.peerId = "";
+    }
         
     // Find the downtrack distance of the last vehicle of the platoon, in m.    
     double PlatoonManager::getPlatoonRearDowntrackDistance(){
@@ -534,9 +542,9 @@ namespace platoon_strategic_ihp
         platoon.push_back(newLeader); //can get location info updated later with a STATUS or INFO message
         platoon.push_back(hostInfo);
  
-        hostPosInPlatoon_ = 1;
+        hostPosInPlatoon_ = 1; //since host was previously leader it is now guaranteed to be 2nd in the line (index 1)
         isFollower = true;
-        current_plan.planId = newPlatoonId;
+        currentPlatoonID = newPlatoonId;
         ROS_DEBUG_STREAM("The platoon manager is changed from leader state to follower state. Platoon vector re-initialized. Plan ID = " << newPlatoonId);
     }
 

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -213,6 +213,7 @@ namespace platoon_strategic_ihp
         current_plan.valid = false;
         current_plan.planId = "";
         current_plan.peerId = "";
+        // Leave the platoon & leader IDs alone since we might continue to be in one
     }
         
     // Find the downtrack distance of the last vehicle of the platoon, in m.    

--- a/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
@@ -989,6 +989,8 @@ namespace platoon_strategic_ihp
             request.location = pose_to_ecef(pose_msg_);
             request.strategy = PLATOONING_STRATEGY;
             request.urgency = 50;
+
+            int platoon_size = pm_.getTotalPlatooningSize();
             
             // step 3. Request Rear Join 
             if(isVehicleRightInFront(rearVehicleDtd, rearVehicleCtd)  &&  !config_.test_front_join)
@@ -1794,7 +1796,6 @@ namespace platoon_strategic_ihp
             ROS_DEBUG_STREAM("CUT-IN join maneuver is already in operation, NACK incoming join requests from other candidates.");
             return MobilityRequestResponse::NACK;
         }
-
     }
 
     // UCLA: add request call-back function for prepare to join (for cut-in join)
@@ -2673,7 +2674,7 @@ namespace platoon_strategic_ihp
             infoOperation = composeMobilityOperationLeadWithOperation(OPERATION_INFO_TYPE);
             mobility_operation_publisher_(infoOperation);
             prevHeartBeatTime_ = ros::Time::now().toNSec() / 1000000;
-            ROS_DEBUG_STREAM("Published heart beat platoon INFO mobility operatrion message");
+            ROS_DEBUG_STREAM("Published heart beat platoon INFO mobility operation message");
         }
         // Task 2
         // if (isTimeForHeartBeat) 
@@ -2836,6 +2837,7 @@ namespace platoon_strategic_ihp
         else if (pm_.current_platoon_state == PlatoonState::PREPARETOJOIN)
         {
             run_prepare_to_join();
+        }
         // coding oversight
         else
         {

--- a/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
@@ -1070,7 +1070,7 @@ namespace platoon_strategic_ihp
                     pm_.targetPlatoonID = platoonId;
                     ROS_DEBUG_STREAM("Storing real neighbor platoon's ID as target: " << pm_.targetPlatoonID);
                 }
-           }
+            }
 
             // step 5. Request cut-in join (front, middle or rear, from adjacent lane)
             else if (isVehicleNearTargetPlatoon(rearVehicleDtd, frontVehicleDtd, frontVehicleCtd) && !config_.test_front_join)
@@ -1393,7 +1393,6 @@ namespace platoon_strategic_ihp
             {
                 pm_.currentPlatoonID = msg.header.plan_id;
             }
-            pm_.current_plan = ActionPlan(true, 0, msg.header.plan_id, msg.header.sender_id);
 
             // Add the joiner to our platoon record
             PlatoonMember newMember = PlatoonMember();
@@ -1412,8 +1411,7 @@ namespace platoon_strategic_ihp
         }
 
         // Indicate the current join activity is complete
-        pm_.current_plan.planId = "";
-        pm_.current_plan.valid = false;
+        pm_.clearActionPlan();
         return response;
     }
     
@@ -1910,12 +1908,12 @@ namespace platoon_strategic_ihp
                     {
                         pm_.currentPlatoonID = "";
                         pm_.platoonLeaderID = "";
-                        pm_.targetPlatoonID = "";
                     }
                 }
 
                 // Clear our current join plan either way
                 pm_.clearActionPlan();
+                pm_.targetPlatoonID = "";
             }
             else
             {
@@ -2501,7 +2499,7 @@ namespace platoon_strategic_ihp
         }
 
         //Task 4: publish platoon status message (as single joiner)
-        if (pm_.current_plan.valid) //don't want to do this until iterations after MobReq message is delivered above
+        if (pm_.current_plan.valid) //don't want to do this until iterations after MobReq message is delivered above so recipient will understand it
         {
             cav_msgs::MobilityOperation status;
             status = composeMobilityOperationCandidateFollower();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Logic fixes for rear & front join to consistently use identifiers for the various vehicles involved, platoon IDs and joining plan information for each interaction.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
PR #1647

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Problems completing a front join during testing on 3/24/22.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code successfully built.  This is a branch off of an integration branch, so will be testing in vehicles later.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
