### PR TITLE
Configure the acknowledgement of geofence updates for CMV's

### DIFF
--- a/carma_wm_ctrl/CMakeLists.txt
+++ b/carma_wm_ctrl/CMakeLists.txt
@@ -113,7 +113,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Install Other Resources
-install(DIRECTORY launch
+install(DIRECTORY launch config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/carma_wm_ctrl/config/parameters.yaml
+++ b/carma_wm_ctrl/config/parameters.yaml
@@ -1,0 +1,4 @@
+#Integer; The number of times it publishes Geofence Acknowledgement.
+ack_pub_times: 1 
+#Double; Max lane width in meters within which geofence points are associated to a lanelet as those points are guaranteed to apply to a single lane
+max_lane_width: 4.0

--- a/carma_wm_ctrl/launch/carma_wm_broadcaster.launch
+++ b/carma_wm_ctrl/launch/carma_wm_broadcaster.launch
@@ -12,14 +12,12 @@
 -->
 
 <launch>
-  <arg name = "max_lane_width"  default = "4" doc= "Max lane width in meters within which geofence points are associated to a lanelet as those points are guaranteed to apply to a single lane"/>
-  <arg name = "ack_pub_times"  default = "1" doc= "The number of times it publishes Geofence Acknowledgement "/>
   <node name="carma_wm_broadcaster" pkg="carma_wm_ctrl" type="carma_wm_ctrl_node">
     <remap from="georeference" to="$(optenv CARMA_LOCZ_NS)/map_param_loader/georeference"/>
     <remap from="$(optenv CARMA_ENV_NS)/geofence" to="$(optenv CARMA_MSG_NS)/incoming_geofence_control"/>
     <remap from="$(optenv CARMA_ENV_NS)/incoming_map" to="$(optenv CARMA_MSG_NS)/incoming_map"/>
     <remap from="current_pose" to="$(optenv CARMA_LOCZ_NS)/current_pose"/>
-    <param name="max_lane_width" value = "$(arg max_lane_width)" />
-    <param name="ack_pub_times" value = "$(arg ack_pub_times)" />
+    <remap from="$(optenv CARMA_ENV_NS)/outgoing_geofence_ack" to="$(optenv CARMA_MSG_NS)/outgoing_mobility_operation"/>
+    <rosparam command="load" file="$(find carma_wm_ctrl)/config/parameters.yaml"/>
   </node>
 </launch>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Add configuration parameters.yaml file.
Update the current configuration params to get the values from the parameters.yaml file
remap topic outgoing_geofence_ack to outgoing_mobility_operation message
## Description

<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Freight testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
