### PR TITLE
return remaining points

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -877,7 +877,23 @@ namespace basic_autonomy
             ROS_DEBUG_STREAM("Ending state's index before applying buffer (buffer_pt_index): " << buffer_pt_index);
             ROS_DEBUG_STREAM("Corresponding to point: x: " << all_sampling_points[buffer_pt_index].x() << ", y:" << all_sampling_points[buffer_pt_index].y());
 
-            if(nearest_pt_index + 1 >= buffer_pt_index){
+            if(nearest_pt_index + 1 = buffer_pt_index){
+                ROS_WARN_STREAM("Returning the two remaining points in the maneuver");
+
+                std::vector<lanelet::BasicPoint2d> remaining_traj_points = {all_sampling_points[nearest_pt_index], all_sampling_points[nearest_pt_index + 1]};
+
+                std::vector<double> downtracks = carma_wm::geometry::compute_arc_lengths(remaining_traj_points);
+                std::vector<double> speeds = {state.longitudinal_vel, state.longitudinal_vel};//Keep current speed
+                std::vector<double> times;
+                trajectory_utils::conversions::speed_to_time(downtracks, speeds, &times);
+                std::vector<double> yaw = {state.orientation, state.orientation}; //Keep current orientation
+                
+                std::vector<cav_msgs::TrajectoryPlanPoint> traj_points =
+                trajectory_from_points_times_orientations(remaining_traj_points, times, yaw, state_time);
+
+                return traj_points;
+            }
+            else if(nearest_pt_index + 1 > buffer_pt_index){
                 ROS_WARN_STREAM("Current state is at or past the planned end distance. Couldn't generate trajectory");
                 return {};
             }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR aims to resolve an issue where planning for lane follow maneuver starts close enough to the end of the maneuver such that there are only 1 one remaining point to be added in path.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
