### PR TITLE
fix py eq and inters var

### DIFF
--- a/lci_strategic_plugin/config/parameters.yaml
+++ b/lci_strategic_plugin/config/parameters.yaml
@@ -2,7 +2,7 @@
 vehicle_decel_limit_multiplier : 1.0
 
 # Double: multiplier to apply to the maximum allowable vehicle acceleration limit so we plan under our capabilities
-vehicle_accel_limit_multiplier : 01.0
+vehicle_accel_limit_multiplier : 1.0
 
 # Double: The minimum distance in meters that the vehicle can be at before requiring a transition to the APPROACH state
 min_approach_distance : 30.0
@@ -11,7 +11,7 @@ min_approach_distance : 30.0
 trajectory_smoothing_activation_distance: 140.0
 
 # Double: A buffer infront of the stopping location which will still be considered a valid stop. Units in meters
-stopping_location_buffer : 12.0
+stopping_location_buffer : 16.0
 
 # Double: A buffer in seconds around the green phase which will reduce the phase length such that vehicle still considers it non-green
 green_light_time_buffer : 2.0

--- a/lci_strategic_plugin/config/parameters.yaml
+++ b/lci_strategic_plugin/config/parameters.yaml
@@ -30,7 +30,7 @@ absolute_minimum_speed : 4.4704
 deceleration_fraction : 0.8
 
 # Double: Desired distance to stop buffer in meters
-desired_distance_to_stop_buffer : 10.0
+desired_distance_to_stop_buffer : 15.0
 
 # Double: The minimum period in seconds which a maneuver plan must cover if the plugin wishes to control the whole plan
 min_maneuver_planning_period : 15.1

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -540,18 +540,6 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
     return;
   }
 
-   // At this point we know the vehicle is within the activation distance and we know the current and next light phases
-  // If the vehicle is at a stop trigger the stopped state
-  constexpr double HALF_MPH_IN_MPS = 0.22352;
-  if (current_state.speed < HALF_MPH_IN_MPS &&
-      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer)
-  {
-    transition_table_.signal(TransitEvent::STOPPED);  // The vehicle has come to a stop at the light
-    ROS_DEBUG_STREAM("CARMA has detected that the vehicle stopped at the stop bar. Transitioning to WAITING STATE");
-
-    return;
-  }
-
   // At this point we know the vehicle is within the activation distance and we know the current and next light phases
   // All we need to now determine is if we should stop or if we should continue
   lanelet::ConstLanelet intersection_lanelet;
@@ -589,7 +577,7 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
   // If the vehicle is at a stop trigger the stopped state
   constexpr double HALF_MPH_IN_MPS = 0.22352;
   if (current_state.speed < HALF_MPH_IN_MPS &&
-      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer + length_to_front_bumper_)
+      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer)
   {
     transition_table_.signal(TransitEvent::STOPPED);  // The vehicle has come to a stop at the light
     ROS_DEBUG_STREAM("CARMA has detected that the vehicle stopped at the stop bar. Transitioning to WAITING STATE");

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -541,6 +541,18 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
   }
 
    // At this point we know the vehicle is within the activation distance and we know the current and next light phases
+  // If the vehicle is at a stop trigger the stopped state
+  constexpr double HALF_MPH_IN_MPS = 0.22352;
+  if (current_state.speed < HALF_MPH_IN_MPS &&
+      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer)
+  {
+    transition_table_.signal(TransitEvent::STOPPED);  // The vehicle has come to a stop at the light
+    ROS_DEBUG_STREAM("CARMA has detected that the vehicle stopped at the stop bar. Transitioning to WAITING STATE");
+
+    return;
+  }
+
+  // At this point we know the vehicle is within the activation distance and we know the current and next light phases
   // All we need to now determine is if we should stop or if we should continue
   lanelet::ConstLanelet intersection_lanelet;
 

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -540,18 +540,7 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
     return;
   }
 
-  // If the vehicle is at a stop trigger the stopped state
-  constexpr double HALF_MPH_IN_MPS = 0.22352;
-  if (current_state.speed < HALF_MPH_IN_MPS &&
-      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer + length_to_front_bumper_)
-  {
-    transition_table_.signal(TransitEvent::STOPPED);  // The vehicle has come to a stop at the light
-    ROS_DEBUG_STREAM("CARMA has detected that the vehicle stopped at the stop bar. Transitioning to WAITING STATE");
-
-    return;
-  }
-
-  // At this point we know the vehicle is within the activation distance and we know the current and next light phases
+   // At this point we know the vehicle is within the activation distance and we know the current and next light phases
   // All we need to now determine is if we should stop or if we should continue
   lanelet::ConstLanelet intersection_lanelet;
 
@@ -584,6 +573,17 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
       wm_->routeTrackPos(exit_lanelet.centerline2d().front().basicPoint2d()).downtrack;
 
   ROS_DEBUG_STREAM("intersection_end_downtrack_: " << intersection_end_downtrack_.get());
+
+  // If the vehicle is at a stop trigger the stopped state
+  constexpr double HALF_MPH_IN_MPS = 0.22352;
+  if (current_state.speed < HALF_MPH_IN_MPS &&
+      fabs(distance_remaining_to_traffic_light) < config_.stopping_location_buffer + length_to_front_bumper_)
+  {
+    transition_table_.signal(TransitEvent::STOPPED);  // The vehicle has come to a stop at the light
+    ROS_DEBUG_STREAM("CARMA has detected that the vehicle stopped at the stop bar. Transitioning to WAITING STATE");
+
+    return;
+  }
 
   // Start of TSMO UC2 Algorithm
 

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -210,7 +210,7 @@ double LCIStrategicPlugin::get_inflection_speed_value(double x, double x1, doubl
   {
     return free_flow_speed;
   }
-  else if (x1 > x >= x2)
+  else if (x1 > x && x >= x2)
   {
     return std::sqrt(2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2))/(max_decel - max_accel));
   }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
When vehicle starts from STOPPING range, it hasn't saved the intersection variables so it throws exception. 
Also if condition still had python syntax which gives wrong results


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
TSMO UC2 testing
## How Has This Been Tested?
not yet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
