### PR TITLE
fix nan in lci_tactical_plugin and lci_strat edge case

### DIFF
--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -348,8 +348,6 @@ void LCIStrategicPlugin::handleGreenSignalScenario(const cav_srvs::PlanManeuvers
     resp.new_plan.maneuvers.push_back(composeIntersectionTransitMessage(
         traffic_light_down_track, intersection_end_downtrack_.get(), intersection_speed_.get(),
         intersection_speed_.get(), light_arrival_time_by_algo, intersection_exit_time, entry_lanelet.id(), exit_lanelet.id()));
-    
-    case_num_ = ts_params.case_num; //to print for debugging
   }
 }
 
@@ -640,6 +638,7 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
     if (!resp.new_plan.maneuvers.empty()) // able to pass at green
     {
       last_case_num_ = ts_params.case_num;
+      case_num_ = ts_params.case_num; //to print for debugging
       return;
     }
     

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -642,11 +642,15 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
       last_case_num_ = ts_params.case_num;
       return;
     }
-     
+    
+    ROS_DEBUG_STREAM("Not able to make it with certainty: TSCase: " << ts_params.case_num << ", changing it to 8");
+    ts_params = boundary_traj_params[7];
+    ts_params.is_algorithm_successful = false;
+    ts_params.case_num = CASE_8;
+    print_params(ts_params);
   }
   
-  ROS_DEBUG_STREAM("Not able to make it with certainty: TSCase: " << ts_params.case_num);
-
+  ROS_DEBUG_STREAM("Not able to make it with certainty: NEW TSCase: " << ts_params.case_num);
   // if algorithm is NOT successful or if the vehicle cannot make the green light with certainty
 
   double safe_distance_to_stop = pow(current_state.speed, 2)/(2 * max_comfort_decel_norm_);

--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -407,6 +407,13 @@ void LightControlledIntersectionTacticalPlugin::apply_trajectory_smoothing_algor
       //buffer points that will be cut
       speed_i = prev_speed;
     }
+
+    if (isnan(speed_i))
+    {
+      speed_i = std::max(config_.minimum_speed, algo_min_speed);
+      ROS_DEBUG_STREAM("Detected nan number from equations. Set to " << speed_i);
+    }
+
     p.speed = std::max({speed_i, config_.minimum_speed, algo_min_speed});
     p.speed = std::min({p.speed, speed_limit_, algo_max_speed}); 
     ROS_DEBUG_STREAM("Applied speed: " << p.speed << ", at dist: " << total_dist_planned);

--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -407,10 +407,8 @@ void LightControlledIntersectionTacticalPlugin::apply_trajectory_smoothing_algor
       //buffer points that will be cut
       speed_i = prev_speed;
     }
-    double speed_limit = p.speed; //p.speed originally is speed_limit
-
     p.speed = std::max({speed_i, config_.minimum_speed, algo_min_speed});
-    p.speed = std::min({p.speed, speed_limit, algo_max_speed}); 
+    p.speed = std::min({p.speed, speed_limit_, algo_max_speed}); 
     ROS_DEBUG_STREAM("Applied speed: " << p.speed << ", at dist: " << total_dist_planned);
 
     prev_point = p;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -47,9 +47,8 @@ void PurePursuitWrapper::trajectoryPlanHandler(const cav_msgs::TrajectoryPlan::C
   std::vector<double> times;
   std::vector<double> downtracks;
 
-  //Remove trajectory points with duplicated timestamps
-  std::vector<cav_msgs::TrajectoryPlanPoint> trajectory_points = remove_repeated_timestamps(tp->trajectory_points);
-  ROS_DEBUG_STREAM("Original Trajectory size:"<<tp->trajectory_points.size() <<" Size after removing duplicate timestamps:"<<trajectory_points.size());
+  std::vector<cav_msgs::TrajectoryPlanPoint> trajectory_points = tp->trajectory_points;
+  ROS_DEBUG_STREAM("Original Trajectory size:"<<trajectory_points.size());
 
   trajectory_utils::conversions::trajectory_to_downtrack_time(trajectory_points, &downtracks, &times);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
1)
Whenever we are checking limits of the resulting applied speeds in each points, it checks min or max of algo_min and algo_max or speed_limits in general.

When providing the speed_limit, current code has artifact from previous version where it uses wrong speed_limit. 
speed_limit is extracted from lanelet and saves as an internal variable.

Bug seen was in LCI_Tactical, there was line "applied speed: -nan", which can only say that if p.speed was -nan from the logs as algo_min and algo_max were valid numbers. 

2)

When the vehicle is able to calculate 1-7 case, but not able to make it due to green buffer, vehicle should be defaulting to case8 (currently in our test cases) but when it is doing that, it is using previous 1-7 case params when executing that scenario. This is fixed now by forcing ts_params to case 8 when required.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
TSMO UC2
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
not yet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
