### PR TITLE
Fix/eq

### DIFF
--- a/lci_strategic_plugin/config/parameters.yaml
+++ b/lci_strategic_plugin/config/parameters.yaml
@@ -11,7 +11,7 @@ min_approach_distance : 30.0
 trajectory_smoothing_activation_distance: 140.0
 
 # Double: A buffer infront of the stopping location which will still be considered a valid stop. Units in meters
-stopping_location_buffer : 16.0
+stopping_location_buffer : 8.0
 
 # Double: A buffer in seconds around the green phase which will reduce the phase length such that vehicle still considers it non-green
 green_light_time_buffer : 2.0

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
@@ -232,11 +232,14 @@ private:
    * \brief Return true if the car can arrive at given arrival time within green light time buffer
    * \param light_arrival_time_by_algo ROS time at green where vehicle arrives
    * \param traffic_light Traffic signal to check time against
-   * \return true (bool optional) if can make it at both bounds of error time. 
+   * \param check_late check late arrival, default true
+   * \param check_early check early arrival, default true
+   * \return true (bool optional) if can make it at both bounds of error time.
+   *  
    * NOTE: internally uses config_.green_light_time_buffer
    * NOTE: boost::none optional if any of the light state was invalid
    */
-  boost::optional<bool> canArriveAtGreenWithCertainty(const ros::Time& light_arrival_time_by_algo, const lanelet::CarmaTrafficSignalPtr& traffic_light) const;
+  boost::optional<bool> canArriveAtGreenWithCertainty(const ros::Time& light_arrival_time_by_algo, const lanelet::CarmaTrafficSignalPtr& traffic_light, bool check_late, bool check_early) const;
 
   /**
    * \brief Compose a trajectory smoothing maneuver msg (sent as transit maneuver message)

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
@@ -37,6 +37,8 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <std_msgs/Int8.h>
 #include <std_msgs/Float64.h>
+#include <math.h>
+#include <algorithm>
 
 namespace lci_strategic_plugin
 {

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -758,7 +758,7 @@ void LCIStrategicPlugin::planWhenWAITING(const cav_srvs::PlanManeuversRequest& r
   if (!bool_optional_late_certainty)
   {
     ROS_ERROR_STREAM("Unable to resolve green light...");
-    return ;
+    return;
   }
 
   if (current_light_state_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED &&

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -198,7 +198,7 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const ro
       can_make_late_arrival = (late_arrival_state_by_algo_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED);
 
     // We will cross the light on the green phase even if we arrive early or late
-    if (check_early && check_late)  // Green light
+    if (can_make_early_arrival && can_make_late_arrival)  // Green light
       return true;
     else
       return false;

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -746,9 +746,7 @@ void LCIStrategicPlugin::planWhenWAITING(const cav_srvs::PlanManeuversRequest& r
 
   ROS_DEBUG("traffic_light_down_track %f", traffic_light_down_track);
   
-  auto current_light_state_optional = traffic_light->predictState(lanelet::time::timeFromSec(current_state.stamp.toSec()));
-  
-  auto bool_optional_late_certainty = canArriveAtGreenWithCertainty(current_state.stamp.toSec(), traffic_light, true, false);
+  auto bool_optional_late_certainty = canArriveAtGreenWithCertainty(current_state.stamp, traffic_light, true, false);
   
   if (!bool_optional_late_certainty)
   {

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -746,6 +746,13 @@ void LCIStrategicPlugin::planWhenWAITING(const cav_srvs::PlanManeuversRequest& r
 
   ROS_DEBUG("traffic_light_down_track %f", traffic_light_down_track);
   
+  auto current_light_state_optional = traffic_light->predictState(lanelet::time::timeFromSec(current_state.stamp.toSec()));
+  ROS_DEBUG_STREAM("WAITING STATE: requested time to check: " << std::to_string(req.header.stamp.toSec()));
+  ROS_DEBUG_STREAM("WAITING STATE: requested time to CURRENT STATE check: " << std::to_string(current_state.stamp.toSec()));
+  
+  if (!validLightState(current_light_state_optional, current_state.stamp))
+    return;
+
   auto bool_optional_late_certainty = canArriveAtGreenWithCertainty(current_state.stamp, traffic_light, true, false);
   
   if (!bool_optional_late_certainty)
@@ -753,13 +760,6 @@ void LCIStrategicPlugin::planWhenWAITING(const cav_srvs::PlanManeuversRequest& r
     ROS_ERROR_STREAM("Unable to resolve green light...");
     return ;
   }
-
-  auto current_light_state_optional = traffic_light->predictState(lanelet::time::timeFromSec(current_state.stamp.toSec()));
-  ROS_DEBUG_STREAM("WAITING STATE: requested time to check: " << std::to_string(req.header.stamp.toSec()));
-  ROS_DEBUG_STREAM("WAITING STATE: requested time to CURRENT STATE check: " << std::to_string(current_state.stamp.toSec()));
-  
-  if (!validLightState(current_light_state_optional, current_state.stamp))
-    return;
 
   if (current_light_state_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED &&
         bool_optional_late_certainty.get()) // if can make with certainty

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -596,13 +596,9 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
                                                   current_state_speed, intersection_speed_.get(), max_comfort_accel_, max_comfort_decel_);
 
   ROS_DEBUG_STREAM("earliest_entry_time: " << std::to_string(earliest_entry_time.toSec()) << ", with : " << earliest_entry_time - current_state.stamp  << " left at: " << std::to_string(current_state.stamp.toSec()));
-  ROS_ERROR_STREAM("earliest_entry_time: " << std::to_string(earliest_entry_time.toSec()) << ", with : " << earliest_entry_time - current_state.stamp  << " left at: " << std::to_string(current_state.stamp.toSec()));
 
   ros::Time nearest_green_entry_time = get_nearest_green_entry_time(current_state.stamp, earliest_entry_time, traffic_light) 
                                           + ros::Duration(0.01); //0.01sec more buffer since green_light algorithm's timestamp picks the previous signal
-
-  ROS_ERROR_STREAM("123");
-  ROS_DEBUG_STREAM("123");
 
   if (!nearest_green_entry_time_cached_) 
   {
@@ -632,8 +628,6 @@ void LCIStrategicPlugin::planWhenAPPROACHING(const cav_srvs::PlanManeuversReques
   print_boundary_distances(boundary_distances); //debug
 
   auto boundary_traj_params = get_boundary_traj_params(req.header.stamp.toSec(), current_state_speed, intersection_speed_.get(), speed_limit, config_.algo_minimum_speed, max_comfort_accel_, max_comfort_decel_, current_state.downtrack, traffic_light_down_track, distance_remaining_to_traffic_light, boundary_distances);
-  ROS_ERROR_STREAM("1212");
-  ROS_DEBUG_STREAM("1212");
 
   TrajectoryParams ts_params = get_ts_case(req.header.stamp.toSec(), nearest_green_entry_time.toSec(), current_state_speed, intersection_speed_.get(), speed_limit, config_.algo_minimum_speed, max_comfort_accel_, max_comfort_decel_, current_state.downtrack, traffic_light_down_track, distance_remaining_to_traffic_light, boundary_distances, boundary_traj_params);
   print_params(ts_params);

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -750,7 +750,8 @@ void LCIStrategicPlugin::planWhenWAITING(const cav_srvs::PlanManeuversRequest& r
   
   if (!bool_optional_late_certainty)
   {
-    throw std::invalid_argument("Unable to resolve the green signal...");
+    ROS_ERROR_STREAM("Unable to resolve green light...");
+    return ;
   }
 
   auto current_light_state_optional = traffic_light->predictState(lanelet::time::timeFromSec(current_state.stamp.toSec()));

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -157,7 +157,7 @@ ros::Duration LCIStrategicPlugin::get_earliest_entry_time(double remaining_dista
   
   ROS_DEBUG_STREAM("x: " << x << ", x2: " << x2 << ", x1: " << x1 << ", v_hat: " << v_hat);
 
-  if (v_hat <= config_.algo_minimum_speed - epsilon_ || is_nan(v_hat))
+  if (v_hat <= config_.algo_minimum_speed - epsilon_ || isnan(v_hat))
   {
     ROS_DEBUG_STREAM("Detected that v_hat is smaller than allowed!!!: " << v_hat);
     v_hat = config_.algo_minimum_speed;

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -254,19 +254,29 @@ double LCIStrategicPlugin::get_inflection_speed_value(double x, double x1, doubl
   }
   else if (x1 > x && x >= x2)
   {
+    ROS_ERROR_STREAM("got here 1: "<< std::sqrt((2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2)))/(max_decel - max_accel)));
+    ROS_DEBUG_STREAM("got here 1: " << std::sqrt((2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2)))/(max_decel - max_accel)));
+
     return std::sqrt((2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2)))/(max_decel - max_accel));
   }
   else if (x2 > x)
   {
     if (current_speed <= departure_speed)
     {
+      ROS_ERROR_STREAM("Got here 2: " << std::sqrt(2 * x * max_accel + std::pow(current_speed, 2)));
+      ROS_DEBUG_STREAM("Got here 2: " << std::sqrt(2 * x * max_accel + std::pow(current_speed, 2)));
+
       return std::sqrt(2 * x * max_accel + std::pow(current_speed, 2));
     }
     else
     {
+      ROS_ERROR_STREAM("Got here 3: " << std::sqrt(2 * x * max_decel + std::pow(current_speed, 2)));
+      ROS_DEBUG_STREAM("Got here 3: " << std::sqrt(2 * x * max_decel + std::pow(current_speed, 2)));
+
       return std::sqrt(2 * x * max_decel + std::pow(current_speed, 2));
     }
   }
+  
 }
 
 double LCIStrategicPlugin::calc_estimated_entry_time_left(double entry_dist, double current_speed, double departure_speed) const

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -254,7 +254,7 @@ double LCIStrategicPlugin::get_inflection_speed_value(double x, double x1, doubl
   }
   else if (x1 > x && x >= x2)
   {
-    return std::sqrt(2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2))/(max_decel - max_accel));
+    return std::sqrt((2 * x * max_accel * max_decel + max_decel * std::pow(current_speed, 2) - max_accel * (std::pow(departure_speed, 2)))/(max_decel - max_accel));
   }
   else if (x2 > x)
   {

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -188,8 +188,16 @@ ros::Duration LCIStrategicPlugin::get_earliest_entry_time(double remaining_dista
   }
   else
   {
-    t_decel = ros::Duration((departure_speed - v_hat) / max_decel);
+    if (x < x2)
+    {
+      t_decel = ros::Duration((v_hat - current_speed) / max_decel);
+    }
+    else
+    {
+      t_decel = ros::Duration((departure_speed - v_hat) / max_decel);
+    }
   }
+
   ros::Duration t_cruise;
   if (x1 <= x)
   {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added ability to choose early or late arrival for case when the car starts from WAITING state. Then it should only go if late arrival in green is certain.
Trying to fix negative duration error by adding max(x,0) guard.
And also found the actual reason why there is negative duration which is the v_hat was nan due to wrong equation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on Blue Lexus with R30 left of the signal from EL1

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
