### PR TITLE
fix

### DIFF
--- a/lci_strategic_plugin/config/parameters.yaml
+++ b/lci_strategic_plugin/config/parameters.yaml
@@ -11,7 +11,7 @@ min_approach_distance : 30.0
 trajectory_smoothing_activation_distance: 140.0
 
 # Double: A buffer infront of the stopping location which will still be considered a valid stop. Units in meters
-stopping_location_buffer : 16.0
+stopping_location_buffer : 8.0
 
 # Double: A buffer in seconds around the green phase which will reduce the phase length such that vehicle still considers it non-green
 green_light_time_buffer : 2.0

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
@@ -37,6 +37,8 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <std_msgs/Int8.h>
 #include <std_msgs/Float64.h>
+#include <math.h>
+#include <algorithm>
 
 namespace lci_strategic_plugin
 {
@@ -232,11 +234,14 @@ private:
    * \brief Return true if the car can arrive at given arrival time within green light time buffer
    * \param light_arrival_time_by_algo ROS time at green where vehicle arrives
    * \param traffic_light Traffic signal to check time against
-   * \return true (bool optional) if can make it at both bounds of error time. 
+   * \param check_late check late arrival, default true
+   * \param check_early check early arrival, default true
+   * \return true (bool optional) if can make it at both bounds of error time.
+   *  
    * NOTE: internally uses config_.green_light_time_buffer
    * NOTE: boost::none optional if any of the light state was invalid
    */
-  boost::optional<bool> canArriveAtGreenWithCertainty(const ros::Time& light_arrival_time_by_algo, const lanelet::CarmaTrafficSignalPtr& traffic_light) const;
+  boost::optional<bool> canArriveAtGreenWithCertainty(const ros::Time& light_arrival_time_by_algo, const lanelet::CarmaTrafficSignalPtr& traffic_light, bool check_late, bool check_early) const;
 
   /**
    * \brief Compose a trajectory smoothing maneuver msg (sent as transit maneuver message)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added ability to choose early or late arrival for case when the car starts from WAITING state. Then it should only go if late arrival in green is certain.
Trying to fix negative duration error by adding max(x,0) guard.
And also found the actual reason why there is negative duration which is the v_hat was nan due to wrong equation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on Blue Lexus with R30 left of the signal from EL1

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
