### PR TITLE
Update system_controller to publish alert for ROS1 nodes

### DIFF
--- a/system_controller/include/system_controller/system_controller_node.hpp
+++ b/system_controller/include/system_controller/system_controller_node.hpp
@@ -73,11 +73,21 @@ namespace system_controller
      */ 
     void on_error(const std::exception &e);
 
+    /**
+     * \brief Publishes a SystemAlert message to the rest of the carma-platform system.
+     *        NOTE: This callback will automatically populate the msg.source_node field based on this node name.
+     * \param msg The message to publish
+     */
+    void publish_system_alert(carma_msgs::msg::SystemAlert msg);
+
     //! The default topic name for the system alert topic
     const std::string system_alert_topic_{"/system_alert"};
 
     //! The subscriber for the system alert topic
     rclcpp::Subscription<carma_msgs::msg::SystemAlert>::SharedPtr system_alert_sub_;
+
+    //! System alert publisher
+    std::shared_ptr<rclcpp::Publisher<carma_msgs::msg::SystemAlert>> system_alert_pub_;
 
     //! Lifecycle Manager which will track the managed nodes and call their lifecycle services on request
     ros2_lifecycle_manager::Ros2LifecycleManager lifecycle_mgr_;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the system_controller to publish a SHUTDOWN system alert on subsystem failure such that the ROS1 nodes will shutdown if the ros2 system shutsdown. 
<!--- Describe your changes in detail -->

## Related Issue
Supports resolution of https://github.com/usdot-fhwa-stol/carma-platform/issues/1702
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reliable shutdown behavior
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on silver lexus with lidar to gps failover
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
