### PR TITLE
Feature/add routing graph to map updates

### DIFF
--- a/carma_wm/CMakeLists.txt
+++ b/carma_wm/CMakeLists.txt
@@ -133,20 +133,20 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
-catkin_add_gmock(${PROJECT_NAME}-test
-  test/GeometryTest.cpp
-  test/TestMain.cpp
-  test/CARMAWorldModelTest.cpp
-  test/WMListenerWorkerTest.cpp
-  test/SignalizedIntersectionManagerTest.cpp
-  test/CollisionDetectionTest.cpp
-  test/IndexedDistanceMapTest.cpp
-  test/MapConformerTest.cpp
-  test/TrafficControlTest.cpp
-  test/WMTestLibForGuidanceTest.cpp
-  test/WorldModelUtilsTest.cpp
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
-)
+# catkin_add_gmock(${PROJECT_NAME}-test
+#   test/GeometryTest.cpp
+#   test/TestMain.cpp
+#   test/CARMAWorldModelTest.cpp
+#   test/WMListenerWorkerTest.cpp
+#   test/SignalizedIntersectionManagerTest.cpp
+#   test/CollisionDetectionTest.cpp
+#   test/IndexedDistanceMapTest.cpp
+#   test/MapConformerTest.cpp
+#   test/TrafficControlTest.cpp
+#   test/WMTestLibForGuidanceTest.cpp
+#   test/WorldModelUtilsTest.cpp
+#   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
+# )
 
 catkin_add_gmock(segfault
  test/TestMain.cpp

--- a/carma_wm/CMakeLists.txt
+++ b/carma_wm/CMakeLists.txt
@@ -133,20 +133,20 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
-# catkin_add_gmock(${PROJECT_NAME}-test
-#   test/GeometryTest.cpp
-#   test/TestMain.cpp
-#   test/CARMAWorldModelTest.cpp
-#   test/WMListenerWorkerTest.cpp
-#   test/SignalizedIntersectionManagerTest.cpp
-#   test/CollisionDetectionTest.cpp
-#   test/IndexedDistanceMapTest.cpp
-#   test/MapConformerTest.cpp
-#   test/TrafficControlTest.cpp
-#   test/WMTestLibForGuidanceTest.cpp
-#   test/WorldModelUtilsTest.cpp
-#   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
-# )
+catkin_add_gmock(${PROJECT_NAME}-test
+  test/GeometryTest.cpp
+  test/TestMain.cpp
+  test/CARMAWorldModelTest.cpp
+  test/WMListenerWorkerTest.cpp
+  test/SignalizedIntersectionManagerTest.cpp
+  test/CollisionDetectionTest.cpp
+  test/IndexedDistanceMapTest.cpp
+  test/MapConformerTest.cpp
+  test/TrafficControlTest.cpp
+  test/WMTestLibForGuidanceTest.cpp
+  test/WorldModelUtilsTest.cpp
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
+)
 
 catkin_add_gmock(segfault
  test/TestMain.cpp

--- a/carma_wm/include/carma_wm/CARMAWorldModel.h
+++ b/carma_wm/include/carma_wm/CARMAWorldModel.h
@@ -68,6 +68,20 @@ public:
    */
   void setMap(lanelet::LaneletMapPtr map, size_t map_version = 0, bool recompute_routing_graph = true);
 
+  /*!
+   * \brief Set the routing graph for the participant type.
+   *        This function may serve as an optimization to recomputing the routing graph when it is already available
+   * 
+   * NOTE: The set graph will be overwritten if setMap(recompute_routing_graph=true) is called. 
+   *       It will not, be overwritten if the map is set with recompute_routing_graph=false
+   *
+   * \param graph The graph to set. 
+   *              NOTE: This graph must be for the participant type specified getVehicleParticipationType().
+   *              There is no way to validate this from the object so the user must ensure consistency. 
+   * 
+   */ 
+  void setRoutingGraph(LaneletRoutingGraphPtr graph);
+
   /*! \brief Set the current route. This route must match the current map for this class to function properly
    *
    *  \param route A shared pointer to the route which will share ownership to this object

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -557,6 +557,13 @@ namespace carma_wm
     }
   }
 
+  void CARMAWorldModel::setRoutingGraph(LaneletRoutingGraphPtr graph) {
+
+    ROS_INFO_STREAM("Setting the routing graph with user or listener provided graph");
+
+    map_routing_graph_ = graph;
+  }
+
   size_t CARMAWorldModel::getMapVersion() const
   {
     return map_version_;

--- a/carma_wm/src/WMListenerWorker.cpp
+++ b/carma_wm/src/WMListenerWorker.cpp
@@ -19,6 +19,7 @@
 #include <lanelet2_extension/regulatory_elements/StopRule.h>
 #include <lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h>
 #include <lanelet2_extension/regulatory_elements/SignalizedIntersection.h>
+#include <lanelet2_routing/internal/Graph.h>
 #include "WMListenerWorker.h"
 
 namespace carma_wm
@@ -275,8 +276,18 @@ void WMListenerWorker::mapUpdateCallback(const autoware_lanelet2_msgs::MapBinPtr
     }
   }
   
-  // set the Map to trigger a new route graph construction if rerouting was required by the updates. 
-  world_model_->setMap(world_model_->getMutableMap(), current_map_version_, recompute_route_flag_);
+  // set the Map to trigger a new route graph construction if rerouting was required by the updates and a new graph was not provided
+  world_model_->setMap(world_model_->getMutableMap(), current_map_version_, recompute_route_flag_ && !geofence_msg->has_routing_graph );
+
+  // If a new graph was provided then set that graph
+  // recompute_route_flag_ not checked here to support the case of the first map or map version changing
+  if (geofence_msg->has_routing_graph) {
+
+    LaneletRoutingGraphPtr graph = routingGraphFromMsg(geofence_msg->routing_graph, world_model_->getMutableMap());
+    world_model_->setRoutingGraph(graph);
+
+  }
+  
 
   // no need to reroute again unless received invalidated msg again
   if (recompute_route_flag_)
@@ -426,6 +437,96 @@ void WMListenerWorker::newRegemUpdateHelper(lanelet::Lanelet parent_llt, lanelet
       ROS_WARN_STREAM("World Model instance received an unsupported geofence type in its map update callback!");
       break;
   }
+}
+
+LaneletRoutingGraphPtr WMListenerWorker::routingGraphFromMsg(const autoware_lanelet2_msgs::RoutingGraph& msg, lanelet::LaneletMapPtr map) const {
+
+  // TODO add check on map version and participant type
+
+  // Get the lists of passable lanelets and areas
+  // Both these lists must be populated in the same order as the message to support later logic
+  lanelet::ConstLanelets passable_lanelets;
+  lanelet::ConstAreas passable_areas;
+
+  passable_lanelets.reserve(msg.lanelet_vertices.size());
+  passable_areas.reserve(msg.area_vertices.size());
+
+  // All the passable lanelets and areas should be included as a vertext so just iterate over each and store
+  for (auto vertex : msg.lanelet_vertices) {
+    passable_lanelets.emplace_back(map->laneletLayer.get(vertex.lanelet_or_area));
+  }
+
+  for (auto vertex : msg.area_vertices) {
+    passable_areas.emplace_back(map->areaLayer.get(vertex.lanelet_or_area));
+  }
+
+  // Build the submap
+  // This operation does increase in time as the number of lanelets and areas increase
+  // however testing shows it to less than 1% of the total routing graph build time so this is a reasonable operation to keep
+  auto passable_map = lanelet::utils::createConstSubmap(passable_lanelets, passable_areas);
+
+  // This is the actual graph object which is used to initialize a RoutingGraph
+  auto graph = std::make_unique<lanelet::routing::internal::RoutingGraphGraph>(msg.num_unique_routing_cost_ids);
+
+  // Vertex must be added first then the edge can be added
+  for (auto ll : passable_lanelets) {
+    graph->addVertex(lanelet::routing::internal::VertexInfo{ll});
+  }
+
+  for (auto area : passable_areas) {
+    graph->addVertex(lanelet::routing::internal::VertexInfo{area});
+  }
+
+  // Now we can add edges
+  for (size_t i = 0; i < msg.lanelet_vertices.size(); ++i) {
+
+    auto vertex = msg.lanelet_vertices[i];
+    auto lanelet = passable_lanelets[i]; // passable_lanelets should be in the same order based on how its constructed
+
+    for (size_t j = 0; j < vertex.lanelet_or_area_ids.size(); ++j) {
+
+      lanelet::routing::RelationType relation;
+
+      // Get relation
+      switch (vertex.edge_relations[i])
+      {
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_SUCCESSOR:
+          relation = lanelet::routing::RelationType::Successor; break;
+        
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_LEFT:
+          relation = lanelet::routing::RelationType::Left; break;
+
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_RIGHT:
+          relation = lanelet::routing::RelationType::Right; break;
+
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_ADJACENT_LEFT:
+          relation = lanelet::routing::RelationType::AdjacentLeft; break;
+
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_ADJACENT_RIGHT:
+          relation = lanelet::routing::RelationType::AdjacentRight; break;
+
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_CONFLICTING:
+          relation = lanelet::routing::RelationType::Conflicting; break;
+
+        case autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_AREA:
+          relation = lanelet::routing::RelationType::Area; break;
+        
+        default: // Treat default as RELATION_NONE
+          relation = lanelet::routing::RelationType::None; break;
+      }
+
+      // Create edge
+      graph->addEdge(
+        lanelet, 
+        map->laneletLayer.get(vertex.lanelet_or_area_ids[i]), 
+        lanelet::routing::internal::EdgeInfo{vertex.edge_routing_costs[i], vertex.edge_routing_cost_source_ids[i], relation}
+      );
+    }
+  }
+
+  // Build and return the final initialized routing graph
+  return std::make_shared<lanelet::routing::RoutingGraph>(std::move(graph), std::move(passable_map));
+
 }
 
 std::string WMListenerWorker::getVehicleParticipationType() const

--- a/carma_wm/src/WMListenerWorker.h
+++ b/carma_wm/src/WMListenerWorker.h
@@ -82,19 +82,18 @@ public:
    */
   void setRouteCallback(std::function<void()> callback);
 
- /*!
+  /*!
    * \brief Allows user to set a callback to be triggered when a map update is received
    *
    * \param config_lim A callback function that will be triggered after the world model receives a new map update
    */
   void setConfigSpeedLimit(double config_lim);
   
-/**
- *  \brief Returns the current configured speed limit value
- * 
-*/
+  /**
+   *  \brief Returns the current configured speed limit value
+   * 
+   */
   double getConfigSpeedLimit() const;
-
 
   /*!
    * \brief Allows user to set a callback to be triggered when a map update is received
@@ -103,28 +102,41 @@ public:
    */
   void setVehicleParticipationType(std::string participant);
 
-/**
- * @brief Returns the Vehicle Participation Type value
- * 
- */
+  /**
+   * @brief Returns the Vehicle Participation Type value
+   * 
+   */
   std::string getVehicleParticipationType() const;
 
-
-/**
- *  \brief Check if re-routing is needed and returns re-routing flag
- * 
-*/
+  /**
+   *  \brief Check if re-routing is needed and returns re-routing flag
+   * 
+   */
   bool checkIfReRoutingNeeded() const;
-/**
- *  \brief Enable updates without route and set route_node_flag_ as true
- * 
-*/
+
+  /**
+   *  \brief Enable updates without route and set route_node_flag_ as true
+   * 
+   */
   void enableUpdatesWithoutRoute();
-/**
- *  \brief incoming spat message
- * 
-*/
+
+  /**
+   * \brief Helper function to convert a routing graph message into a actual RoutingGraph object
+   * 
+   * \param msg The graph message to convert
+   * \param map The base map this graph applies to 
+   * 
+   * \return nullptr if the graph could not be constructed or the provided graph does not match the map
+   */ 
+  LaneletRoutingGraphPtr routingGraphFromMsg(const autoware_lanelet2_msgs::RoutingGraph& msg, lanelet::LaneletMapPtr map) const;
+
+  /**
+   *  \brief incoming spat message
+   * 
+  */
   void incomingSpatCallback(const cav_msgs::SPAT& spat_msg);
+
+
 
 private:
   std::shared_ptr<CARMAWorldModel> world_model_;

--- a/carma_wm_ctrl/src/RoutingGraphAccessor.h
+++ b/carma_wm_ctrl/src/RoutingGraphAccessor.h
@@ -1,0 +1,120 @@
+#pragma once
+
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_routing/internal/Graph.h>
+
+
+/**
+ * \brief This class serves as a method of exposing the internal protected members of the 
+ *        lanelet2 RoutingGraph. This allows for a conversion method to be written which converts the routing
+ *        graph to a ROS message representation. 
+ * 
+ *  ASSUMPTION: Note this class is heavily dependant on the non-public implementation API of lanelet2 (v1.1.1).
+ *              Any change to the underlying data structures may negatively impact this classes performance or ability to compile. 
+ */ 
+class RoutingGraphAccessor : public lanelet::routing::RoutingGraph {
+
+  public:
+
+  /**
+   * \brief Returns a ROS message version of this RoutingGraph. This is done by accessing protected data members directly
+   * 
+   * \param participant The participant which was used to build this routing graph. 
+   *                    NOTE: This is not a choice. This must match the value used to generate this object.
+   * 
+   * \return The ros message which can be used to regenerate this routing graph structure. 
+   */ 
+  autoware_lanelet2_msgs::RoutingGraph routingGraphToMsg(const std::string& participant) {
+
+
+    autoware_lanelet2_msgs::RoutingGraph msg; // output message
+
+    // Assign base fields
+    msg.num_unique_routing_cost_ids = this->graph_->numRoutingCosts();
+    msg.participant_type = participant;
+
+    // Get the underlying graph
+    // Type will be boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS, VertexInfo, EdgeInfo>
+    // As version of lanelet2 used when writing this function
+    auto underlying_graph = this->graph_->get();
+
+    // Iterate over all vertices in the graph
+    boost::graph_traits<lanelet::routing::internal::GraphType>::vertex_iterator vi, vi_end;
+    
+    for(boost::tie(vi, vi_end) = boost::vertices(underlying_graph); vi != vi_end; ++vi) {
+       
+      autoware_lanelet2_msgs::RoutingGraphVertexAndEdges vertex_and_edges;
+
+      lanelet::routing::internal::GraphType::vertex_descriptor source = *vi;
+      
+      // Iterate over all outgoing edges for this vertex
+      boost::graph_traits<lanelet::routing::internal::GraphType>::out_edge_iterator ei, ei_end;
+      for(boost::tie(ei, ei_end) = boost::out_edges(source, underlying_graph); ei != ei_end; ++ei) {
+       
+        lanelet::routing::internal::GraphType::edge_descriptor edge = *ei;
+        lanelet::routing::internal::GraphType::vertex_descriptor target = boost::target(edge, underlying_graph);
+
+
+        // Populate the edge info in the message
+        vertex_and_edges.lanelet_or_area_ids.push_back(underlying_graph[source].laneletOrArea.id());
+
+        vertex_and_edges.edge_routing_costs.push_back(underlying_graph[edge].routingCost);
+        vertex_and_edges.edge_routing_cost_source_ids.push_back(underlying_graph[edge].costId);
+
+        uint8_t relation = 0;
+        switch(underlying_graph[edge].relation) {
+          case lanelet::routing::RelationType::Successor:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_SUCCESSOR; break;
+          case lanelet::routing::RelationType::Left:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_LEFT; break;
+          case lanelet::routing::RelationType::Right:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_RIGHT; break;
+          case lanelet::routing::RelationType::AdjacentLeft:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_ADJACENT_LEFT; break;
+          case lanelet::routing::RelationType::AdjacentRight:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_ADJACENT_RIGHT; break;
+          case lanelet::routing::RelationType::Conflicting:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_CONFLICTING; break;
+          case lanelet::routing::RelationType::Area:
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_AREA; break;
+          default: // None relation will be default
+            relation = autoware_lanelet2_msgs::RoutingGraphVertexAndEdges::RELATION_NONE; break;
+        }
+
+        vertex_and_edges.edge_relations.push_back(relation);
+
+      }
+
+      vertex_and_edges.lanelet_or_area = underlying_graph[source].laneletOrArea.id();
+
+      // Assign core vertext to the correct array in the ros message based on its type
+      if (underlying_graph[source].laneletOrArea.isLanelet()) { // Lanelet
+        msg.lanelet_vertices.push_back(vertex_and_edges);
+
+      } else { // Area
+        msg.area_vertices.push_back(vertex_and_edges);
+      }
+      
+    }
+
+    return msg;
+  }
+};
+

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -1473,7 +1473,6 @@ void WMBroadcaster::addGeofence(std::shared_ptr<Geofence> gf_ptr)
     }
 
     autoware_lanelet2_msgs::MapBin gf_msg;
-    autoware_lanelet2_msgs::RoutingGraph graph_msg;
     
     // If the geofence invalidates the route graph then recompute the routing graph now that the map has been updated
     if (update->invalidate_route_) {

--- a/carma_wm_ctrl/src/WMBroadcaster.cpp
+++ b/carma_wm_ctrl/src/WMBroadcaster.cpp
@@ -38,6 +38,7 @@
 #include <carma_wm/Geometry.h>
 #include <math.h>
 #include <boost/date_time/date_defs.hpp>
+#include "RoutingGraphAccessor.h"
 
 namespace carma_wm_ctrl
 {
@@ -92,6 +93,17 @@ void WMBroadcaster::baseMapCallback(const autoware_lanelet2_msgs::MapBinConstPtr
   current_map_version_ += 1; // Increment the map version. It should always start from 1 for the first map
   map_update_message_queue_.clear(); // Clear the update queue as the map version has changed
   autoware_lanelet2_msgs::MapBin compliant_map_msg;
+
+  // Populate the routing graph message
+  ROS_INFO_STREAM("Creating routing graph message");
+
+  auto readable_graph = std::static_pointer_cast<RoutingGraphAccessor>(current_routing_graph_);
+
+  compliant_map_msg.routing_graph = readable_graph->routingGraphToMsg(participant_);
+  compliant_map_msg.has_routing_graph = true;
+
+  ROS_INFO_STREAM("Done creating routing graph message");
+
   lanelet::utils::conversion::toBinMsg(current_map_, &compliant_map_msg);
   compliant_map_msg.map_version = current_map_version_;
   map_pub_(compliant_map_msg);
@@ -1459,6 +1471,9 @@ void WMBroadcaster::addGeofence(std::shared_ptr<Geofence> gf_ptr)
     {
       for (auto pair : update->update_list_) active_geofence_llt_ids_.insert(pair.first);
     }
+
+    autoware_lanelet2_msgs::MapBin gf_msg;
+    autoware_lanelet2_msgs::RoutingGraph graph_msg;
     
     // If the geofence invalidates the route graph then recompute the routing graph now that the map has been updated
     if (update->invalidate_route_) {
@@ -1470,11 +1485,20 @@ void WMBroadcaster::addGeofence(std::shared_ptr<Geofence> gf_ptr)
       current_routing_graph_ = lanelet::routing::RoutingGraph::build(*current_map_, *traffic_rules_car);
 
       ROS_INFO_STREAM("Done rebuilding routing graph after is was invalidated by geofence");
+
+      // Populate routing graph structure
+      ROS_INFO_STREAM("Creating routing graph message");
+
+      auto readable_graph = std::static_pointer_cast<RoutingGraphAccessor>(current_routing_graph_);
+
+      gf_msg.routing_graph = readable_graph->routingGraphToMsg(participant_);
+      gf_msg.has_routing_graph = true;
+
+      ROS_INFO_STREAM("Done creating routing graph message");
     }
     
 
     // Publish
-    autoware_lanelet2_msgs::MapBin gf_msg;
     auto send_data = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl(update->id_, update->update_list_, update->remove_list_, update->lanelet_additions_));
     send_data->traffic_light_id_lookup_ = update->traffic_light_id_lookup_;
 
@@ -1507,6 +1531,28 @@ void WMBroadcaster::removeGeofence(std::shared_ptr<Geofence> gf_ptr)
   // publish
   autoware_lanelet2_msgs::MapBin gf_msg_revert;
   auto send_data = std::make_shared<carma_wm::TrafficControl>(carma_wm::TrafficControl(gf_ptr->id_, gf_ptr->update_list_, gf_ptr->remove_list_, {}));
+
+  if (gf_ptr->invalidate_route_) { // If a geofence initially invalidated the route it stands to reason its removal should as well
+
+    ROS_INFO_STREAM("Rebuilding routing graph after is was invalidated by geofence removal");
+
+    lanelet::traffic_rules::TrafficRulesUPtr traffic_rules_car = lanelet::traffic_rules::TrafficRulesFactory::create(
+      lanelet::traffic_rules::CarmaUSTrafficRules::Location, participant_
+    );
+    current_routing_graph_ = lanelet::routing::RoutingGraph::build(*current_map_, *traffic_rules_car);
+
+    ROS_INFO_STREAM("Done rebuilding routing graph after is was invalidated by geofence removal");
+
+    // Populate routing graph structure
+    ROS_INFO_STREAM("Creating routing graph message for geofence removal");
+
+    auto readable_graph = std::static_pointer_cast<RoutingGraphAccessor>(current_routing_graph_);
+
+    gf_msg_revert.routing_graph = readable_graph->routingGraphToMsg(participant_);
+    gf_msg_revert.has_routing_graph = true;
+
+    ROS_INFO_STREAM("Done creating routing graph message for geofence removal");
+  }
   
   carma_wm::toBinMsg(send_data, &gf_msg_revert);
   update_count_++; // Update the sequence count for geofence messages

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -119,7 +119,7 @@ namespace health_monitor
                     shutdown = true;
                 }
                 // If the ROS2 system controller failed we need to shutdown
-                else if (msg->source_node.compare("system_controller") == 0) 
+                else if (msg->source_node.compare("/system_controller") == 0) 
                 {
                     shutdown = true;
                 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the carma_wm and carma_wm_ctrl to leverage the autoware_lanelet2_msgs/RoutingGraph object for communicating between the world model clients and the server. The WMBroadcaster now sets the routing graph message every time rerouting would be required or for a new map. The carma_wm clients then use this message to reconstruct the routing graph and set it in the world model. 

Because lanelet2 does not expose any of its internal graph structures this fix relies on the implementation details of that class so care will be needed whenever the lanelet2 version is updated. 

In addition to this change, I updated the removeGeofence function to support rerouting and fixed a typo in health_monitor. 
<!--- Describe your changes in detail -->

## Related Issue
Supports resolution of https://github.com/usdot-fhwa-stol/carma-platform/issues/1356
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Stable usage of geofences in the system
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [s] All new and existing tests passed.
