### PR TITLE
fix basic_autonomy function call

### DIFF
--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -224,26 +224,26 @@ std::vector<PointSpeedPair> LightControlledIntersectionTacticalPlugin::create_ge
   ROS_DEBUG_STREAM("VehDowntrack:"<<max_starting_downtrack);
   for(const auto &maneuver : maneuvers)
   {
-      double starting_downtrack = GET_MANEUVER_PROPERTY(maneuver, start_dist);
-      
-      starting_downtrack = std::min(starting_downtrack, max_starting_downtrack);
+    double starting_downtrack = GET_MANEUVER_PROPERTY(maneuver, start_dist);
+    
+    starting_downtrack = std::min(starting_downtrack, max_starting_downtrack);
 
-      ROS_DEBUG_STREAM("Used downtrack: " << starting_downtrack);
+    ROS_DEBUG_STREAM("Used downtrack: " << starting_downtrack);
 
-      // check if required parameter from strategic planner is present
-      if(GET_MANEUVER_PROPERTY(maneuver, parameters.float_valued_meta_data).empty())
-      {
-        throw std::invalid_argument("No time_to_schedule_entry is provided in float_valued_meta_data");
-      }
+    // check if required parameter from strategic planner is present
+    if(GET_MANEUVER_PROPERTY(maneuver, parameters.float_valued_meta_data).empty())
+    {
+      throw std::invalid_argument("No time_to_schedule_entry is provided in float_valued_meta_data");
+    }
 
-      //overwrite maneuver type to use lane follow library function
-      cav_msgs::Maneuver temp_maneuver = maneuver;
-      temp_maneuver.type =cav_msgs::Maneuver::LANE_FOLLOWING;
-      ROS_DEBUG_STREAM("Creating Lane Follow Geometry");
-      std::vector<PointSpeedPair> lane_follow_points = basic_autonomy::waypoint_generation::create_lanefollow_geometry(maneuver, starting_downtrack, wm, ending_state_before_buffer, general_config, detailed_config, visited_lanelets);
-      points_and_target_speeds.insert(points_and_target_speeds.end(), lane_follow_points.begin(), lane_follow_points.end());
-      
-      break; // expected to receive only one maneuver to plan
+    //overwrite maneuver type to use lane follow library function
+    cav_msgs::Maneuver temp_maneuver = maneuver;
+    temp_maneuver.type =cav_msgs::Maneuver::LANE_FOLLOWING;
+    ROS_DEBUG_STREAM("Creating Lane Follow Geometry");
+    std::vector<PointSpeedPair> lane_follow_points = basic_autonomy::waypoint_generation::create_lanefollow_geometry(maneuver, starting_downtrack, wm, general_config, detailed_config, visited_lanelets);
+    points_and_target_speeds.insert(points_and_target_speeds.end(), lane_follow_points.begin(), lane_follow_points.end());
+    
+    break; // expected to receive only one maneuver to plan
   }
 
   return points_and_target_speeds;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This pr updates a call to the basic_autonomy library for creating a lanefollow trajectory. The function in basic_autonomy was updated to not require the ending_state_before_buffer, because it was never being used in the function.
So this update shouldn't change the logic here either.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests still pass
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
