### PR TITLE
fix list sync and add remaps motion_computation

### DIFF
--- a/carma/launch/environment.launch.py
+++ b/carma/launch/environment.launch.py
@@ -240,6 +240,8 @@ def generate_launch_description():
                 ],
                 remappings=[
                     ("incoming_mobility_path", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_mobility_path" ] ),
+                    ("incoming_psm", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_psm" ] ),
+                    ("incoming_bsm", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_bsm" ] ),
                     ("georeference", [ EnvironmentVariable('CARMA_LOCZ_NS', default_value=''), "/map_param_loader/georeference" ] )
                 ],
                 parameters=[ 

--- a/motion_computation/config/parameters.yaml
+++ b/motion_computation/config/parameters.yaml
@@ -22,7 +22,7 @@ enable_bsm_processing: false
 
 # Boolean: If true then PSM messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_psm_processing: false
+enable_psm_processing: true
 
 # Boolean: If true then MobilityPath messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)

--- a/motion_computation/config/parameters.yaml
+++ b/motion_computation/config/parameters.yaml
@@ -22,11 +22,11 @@ enable_bsm_processing: false
 
 # Boolean: If true then PSM messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_psm_processing: false
+enable_psm_processing: true
 
 # Boolean: If true then MobilityPath messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_mobility_path_processing: true
+enable_mobility_path_processing: false
 
 # Boolean: If true then ExternalObjects generated from sensor data will be processed.  
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)

--- a/motion_computation/config/parameters.yaml
+++ b/motion_computation/config/parameters.yaml
@@ -22,11 +22,11 @@ enable_bsm_processing: false
 
 # Boolean: If true then PSM messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_psm_processing: true
+enable_psm_processing: false
 
 # Boolean: If true then MobilityPath messages will be converted to ExternalObjects. 
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_mobility_path_processing: false
+enable_mobility_path_processing: true
 
 # Boolean: If true then ExternalObjects generated from sensor data will be processed.  
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)

--- a/motion_computation/src/motion_computation_worker.cpp
+++ b/motion_computation/src/motion_computation_worker.cpp
@@ -86,8 +86,11 @@ void MotionComputationWorker::predictionLogic(carma_perception_msgs::msg::Extern
 
     obj_pub_(synchronization_base_objects);
     bsm_list_.objects.clear();
+    bsm_obj_id_map_.clear();
     psm_list_.objects.clear();
+    psm_obj_id_map_.clear();
     mobility_path_list_.objects.clear();
+    mobility_path_obj_id_map_.clear();
 
     return;
   }
@@ -109,11 +112,13 @@ void MotionComputationWorker::predictionLogic(carma_perception_msgs::msg::Extern
   }
 
   obj_pub_(synchronization_base_objects);
-
-  // Clear mobility msg path queue since it is published
+  // Clear msg queue since it is published
   mobility_path_list_.objects.clear();
+  mobility_path_obj_id_map_.clear();
   bsm_list_.objects.clear();
+  bsm_obj_id_map_.clear();
   psm_list_.objects.clear();
+  psm_obj_id_map_.clear();
 }
 
 void MotionComputationWorker::georeferenceCallback(const std_msgs::msg::String::UniquePtr msg) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fixes an error in motion computation that caused external object lists to reference uninitialized indices. And adds topic remaps for incoming message topics.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
