### PR TITLE
Added a few cleanups where logic needs to abort.

### DIFF
--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -184,6 +184,15 @@ namespace platoon_strategic_ihp
         void resetPlatoon();
 
         /**
+         * \brief Removes a single member from the internal record of platoon members
+         * 
+         * \param mem index of the member to be removed (zero-based)
+         * 
+         * \return true if removal was successful, false otherwise
+         */
+        bool removeMember(const size_t mem);
+        
+        /**
         * \brief Returns dynamic leader of the host vehicle.
         * 
         * \return The current dynamic leader as a vehcile object. 

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -232,6 +232,24 @@ namespace platoon_strategic_ihp
         // Clean up other variables
         currentPlatoonID = dummyID;
         platoonLeaderID = dummyID;
+        hostPosInPlatoon_ = 0;
+    }
+
+    bool PlatoonManager::removeMember(const size_t mem)
+    {
+        // Don't remove ourselves!
+        if (hostPosInPlatoon_ == mem)
+        {
+            return false;
+        }
+
+        // Don't remove a member that isn't there
+        else if (platoon.size() <= 1  ||  mem >= platoon.size())
+        {
+            return false;
+        }
+
+        platoon.erase(platoon.begin() + mem, platoon.begin() + mem + 1);
     }
         
     // Find the downtrack distance of the last vehicle of the platoon, in m.    

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -249,6 +249,10 @@ namespace platoon_strategic_ihp
             return false;
         }
 
+        if (mem < hostPosInPlatoon_)
+        {
+            --hostPosInPlatoon_;
+        }
         platoon.erase(platoon.begin() + mem, platoon.begin() + mem + 1);
     }
         

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -254,6 +254,7 @@ namespace platoon_strategic_ihp
             --hostPosInPlatoon_;
         }
         platoon.erase(platoon.begin() + mem, platoon.begin() + mem + 1);
+        return true;
     }
         
     // Find the downtrack distance of the last vehicle of the platoon, in m.    


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fleshed out logic where aborts are needed to better clean up the records of platooning info (e.g. the roster of members).

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Aborted platoon attempts leave the records in an untidy state and make it unclear what is happening.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local build of package.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
