### PR TITLE
clear markers before publishing new ones

### DIFF
--- a/object_visualizer/src/object_visualizer_node.cpp
+++ b/object_visualizer/src/object_visualizer_node.cpp
@@ -93,6 +93,15 @@ namespace object_visualizer
     }
 
     visualization_msgs::msg::MarkerArray viz_msg;
+    //Send delete all markers before adding new ones
+    visualization_msgs::msg::Marker marker;
+    marker.id = 0;
+    marker.action = visualization_msgs::msg::Marker::DELETEALL;
+    viz_msg.markers.push_back(marker);
+    external_objects_viz_pub_->publish(viz_msg);
+
+    viz_msg.markers.clear();
+    
     viz_msg.markers.reserve(msg->objects.size());
 
     

--- a/object_visualizer/src/object_visualizer_node.cpp
+++ b/object_visualizer/src/object_visualizer_node.cpp
@@ -93,16 +93,12 @@ namespace object_visualizer
     }
 
     visualization_msgs::msg::MarkerArray viz_msg;
-    //Send delete all markers before adding new ones
+    //delete all markers before adding new ones
     visualization_msgs::msg::Marker marker;
+    viz_msg.markers.reserve(msg->objects.size() + 1); //+1 to account for delete all marker
     marker.id = 0;
     marker.action = visualization_msgs::msg::Marker::DELETEALL;
     viz_msg.markers.push_back(marker);
-    external_objects_viz_pub_->publish(viz_msg);
-
-    viz_msg.markers.clear();
-    
-    viz_msg.markers.reserve(msg->objects.size());
 
     
     size_t id = 0; // We always count the id from zero so we can delete markers later in a consistent manner
@@ -179,8 +175,12 @@ namespace object_visualizer
     }
 
     visualization_msgs::msg::MarkerArray viz_msg;
-
-    viz_msg.markers.reserve(msg->roadway_obstacles.size());
+    //delete all markers before adding new ones
+    visualization_msgs::msg::Marker marker;
+    viz_msg.markers.reserve(msg->roadway_obstacles.size() + 1); //+1 to account for delete all marker
+    marker.id = 0;
+    marker.action = visualization_msgs::msg::Marker::DELETEALL;
+    viz_msg.markers.push_back(marker);
 
     size_t id = 0; // We always count the id from zero so we can delete markers later in a consistent manner
     for (auto obj : msg->roadway_obstacles) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR fixes issue #1765 
## Description
The fix here is to delete all external object markers before publishing a new list of external objects to rviz.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
