### PR TITLE
Update IHP platoon gap calculation with multiple vehciles in between

### DIFF
--- a/platooning_strategic_IHP/config/parameters.yaml
+++ b/platooning_strategic_IHP/config/parameters.yaml
@@ -27,3 +27,5 @@ test_front_join: false
 slowDownAdjuster: 0.75
 createGapAdjuster: 0.3
 minPlatooningSpeed: 2.0
+allowCutinJoin: true
+significantDTDchange: 0.2

--- a/platooning_strategic_IHP/include/platoon_config_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_config_ihp.h
@@ -80,6 +80,8 @@ struct PlatoonPluginConfig
                                 // Flag can be set to true, to test front join functionality with two vehicles
                                 // But in normal operating conditions it should be set to false
   //------------------------------------------------------------------------------------------------
+  bool allowCutinJoin = true;    //Flag to enable/disable cut-in joins
+  double significantDTDchange = 0.2;   // Ratio of dtd that is considered a significant change and triggers a new sort of platoon vector
 
 
   friend std::ostream& operator<<(std::ostream& output, const PlatoonPluginConfig& c)
@@ -106,6 +108,8 @@ struct PlatoonPluginConfig
           << "maxCrosstrackError: " << c.maxCrosstrackError << std::endl
           << "vehicleID: " << c.vehicleID << std::endl
           << "minPlatooningSpeed: " << c.minPlatooningSpeed << std::endl
+          << "allowCutinJoin: " << c.allowCutinJoin << std::endl
+          << "significantDTDchange: " << c.significantDTDchange << std::endl
           << "}" << std::endl;
     return output;
   }

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -340,7 +340,7 @@ namespace platoon_strategic_ihp
         // UCLA: add indicator of lane change 
         bool safeToLaneChange = false;
 
-        int dynamic_leader_index_ = 0;
+        size_t dynamic_leader_index_ = 0;
         
     private:
 

--- a/platooning_strategic_IHP/include/platoon_manager_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_manager_ihp.h
@@ -339,6 +339,8 @@ namespace platoon_strategic_ihp
         bool isCreateGap = false;
         // UCLA: add indicator of lane change 
         bool safeToLaneChange = false;
+
+        int dynamic_leader_index_ = 0;
         
     private:
 

--- a/platooning_strategic_IHP/include/platoon_strategic_plugin_node_ihp.h
+++ b/platooning_strategic_IHP/include/platoon_strategic_plugin_node_ihp.h
@@ -86,6 +86,8 @@ public:
     pnh.param<double>("maxCrosstrackError", config.maxCrosstrackError, config.maxCrosstrackError);
     pnh.param<bool>("test_front_join", config.test_front_join, config.test_front_join);
     pnh.param<double>("minPlatooningSpeed", config.minPlatooningSpeed, config.minPlatooningSpeed);
+    pnh.param<bool>("allowCutinJoin", config.allowCutinJoin, config.allowCutinJoin);
+    pnh.param<double>("significantDTDchange", config.significantDTDchange, config.significantDTDchange);
     pnh.getParam("/vehicle_length", config.vehicleLength);
     pnh.getParam("/vehicle_id", config.vehicleID);
     

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -192,8 +192,9 @@ namespace platoon_strategic_ihp
             for (size_t i = 0;  i < platoon.size();  ++i)
             {
                 std::string hostFlag = " ";
-                if (i == hostPosInPlatoon_)
+                if (platoon[i].staticId == getHostStaticID)
                 {
+                    hostPosInPlatoon_ = i;
                     hostFlag = "Host";
                 }
                 ROS_DEBUG_STREAM("    " << platoon[i].staticId << " " << hostFlag);

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -198,7 +198,7 @@ namespace platoon_strategic_ihp
                     hostPosInPlatoon_ = i;
                     hostFlag = "Host";
                 }
-                ROS_DEBUG_STREAM("    " << platoon[i].staticId << " " << hostFlag);
+                ROS_DEBUG_STREAM("    " << platoon[i].staticId << "its DTD: " << platoon[i].vehiclePosition << " " << hostFlag);
             }
         }
 
@@ -221,7 +221,7 @@ namespace platoon_strategic_ihp
                     hostPosInPlatoon_ = i;
                     hostFlag = "Host";
                 }
-                ROS_DEBUG_STREAM("    " << platoon[i].staticId << " " << hostFlag);
+                ROS_DEBUG_STREAM("    " << platoon[i].staticId << "its DTD: " << platoon[i].vehiclePosition << " " << hostFlag);
             }
         }
     }

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -345,7 +345,7 @@ namespace platoon_strategic_ihp
         // If the distance headway between the subject vehicle and its predecessor is an issue
         // according to the "min_gap" and "max_gap" thresholds, then it should follow its predecessor
         // The following line will not throw exception because the length of downtrack array is larger than two in this case
-        double distHeadwayWithPredecessor = downtrackDistance[hostPosInPlatoon_ - 2] - downtrackDistance[hostPosInPlatoon_ - 1];
+        double distHeadwayWithPredecessor = downtrackDistance[hostPosInPlatoon_ - 1] - downtrackDistance[hostPosInPlatoon_];
         gapWithPred_ = distHeadwayWithPredecessor;
         if(insufficientGapWithPredecessor(distHeadwayWithPredecessor)) {
             ROS_DEBUG_STREAM("APF algorithm decides there is an issue with the gap with preceding vehicle: " << distHeadwayWithPredecessor << " m. Case Two");

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -158,7 +158,7 @@ namespace platoon_strategic_ihp
         // update/add this info into the list
         for (size_t i = 0;  i < platoon.size();  ++i){
             if(platoon[i].staticId == senderId) {
-                if ((dtDistance - platoon[i].vehiclePosition)/platoon[i].vehiclePosition > config_.significantDTDchange)
+                if (abs(dtDistance - platoon[i].vehiclePosition)/(platoon[i].vehiclePosition + 0.01) > config_.significantDTDchange)
                 {
                     ROS_DEBUG_STREAM( "DTD of member " << platoon[i].staticId << " is changed significantly, so a new sort is needed");
 

--- a/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_manager_ihp.cpp
@@ -282,6 +282,7 @@ namespace platoon_strategic_ihp
             dynamicLeader = platoon[0];
             if (algorithmType_ == "APF_ALGORITHM"){
                 size_t newLeaderIndex = allPredecessorFollowing();
+                dynamic_leader_index_ = (int)newLeaderIndex;
                 if(newLeaderIndex < platoon.size() && newLeaderIndex >= 0) { //this must always be true!
                     dynamicLeader = platoon[newLeaderIndex];
                     ROS_DEBUG_STREAM("APF output: " << dynamicLeader.staticId);

--- a/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
+++ b/platooning_strategic_IHP/src/platoon_strategic_ihp.cpp
@@ -494,6 +494,14 @@ namespace platoon_strategic_ihp
                 status_msg.host_platoon_position = pm_.getNumberOfVehicleInFront();
                 ROS_DEBUG_STREAM("pm platoonsize: " << pm_.getTotalPlatooningSize() << ", platoon_leader " << platoon_leader.staticId);
 
+                int numOfVehiclesGaps = pm_.getNumberOfVehicleInFront() - pm_.dynamic_leader_index_;
+                ROS_DEBUG_STREAM("The host vehicle have " << numOfVehiclesGaps << " vehicles between itself and its leader (includes the leader)");
+
+                // TODO: currently the average length of the vehicle is obtained from a config parameter. In future, plugin needs to be updated to receive each vehicle's actual length through status or BSM messages for more accuracy.
+                status_msg.desired_gap = std::max(config_.standStillHeadway * numOfVehiclesGaps, config_.timeHeadway * current_speed_* numOfVehiclesGaps) + (numOfVehiclesGaps - 1) * 5.0;//config_.averageVehicleLength;
+                ROS_DEBUG_STREAM("The desired gap with the leader is " << status_msg.desired_gap);
+
+
                 // TODO: To uncomment the following lines, platooninfo msg must be updated
                 // UCLA: Add the value of the summation of "veh_len/veh_speed" for all predecessors
                 // status_msg.current_predecessor_time_headway_sum = pm_.getPredecessorTimeHeadwaySum();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
IHP strategic plugin is updated to calculate the gap with dynamic leader, in case there are multiple vehcles are in between.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
