### PR TITLE
Fix/rfp shortest path fix

### DIFF
--- a/route_following_plugin/include/route_following_plugin.h
+++ b/route_following_plugin/include/route_following_plugin.h
@@ -241,6 +241,7 @@ namespace route_following_plugin
         ros::Publisher plugin_discovery_pub_;
         ros::Publisher upcoming_lane_change_status_pub_;
         ros::Subscriber twist_sub_;
+        ros::Subscriber current_maneuver_plan_sub_;
         ros::Timer discovery_pub_timer_;
 
         // ROS service servers
@@ -279,6 +280,9 @@ namespace route_following_plugin
         // Current vehicle pose in map
         geometry_msgs::PoseStamped pose_msg_;
         lanelet::BasicPoint2d current_loc_;
+        
+        // Currently executing maneuver plan from Arbitrator
+        cav_msgs::ManeuverPlanConstPtr current_maneuver_plan_;
 
         //Queue of maneuver plans
         std::vector<cav_msgs::Maneuver> latest_maneuver_plan_;
@@ -300,6 +304,14 @@ namespace route_following_plugin
          * \param msg Latest twist message
          */
         void twist_cb(const geometry_msgs::TwistStampedConstPtr& msg);
+
+        /**
+         * \brief Callback for the ManeuverPlan subscriber, will store the current maneuver plan received locally.
+         * Used as part of the detection system for differentiating leaving the shortest path via another plugin
+         * vs. control drift taking the vehicle's reference point outside of the intended lane.
+         * \param msg Latest ManeuverPlan message
+         */
+        void current_maneuver_plan_cb(const cav_msgs::ManeuverPlanConstPtr& msg);
 
         /**
          * \brief returns duration as ros::Duration required to complete maneuver given its start dist, end dist, start speed and end speed

--- a/route_following_plugin/src/route_following_plugin.cpp
+++ b/route_following_plugin/src/route_following_plugin.cpp
@@ -100,6 +100,7 @@ void setManeuverLaneletIds(cav_msgs::Maneuver& mvr, lanelet::Id start_id, lanele
 
         // pose_sub_ = nh_->subscribe("current_pose", 1, &RouteFollowingPlugin::pose_cb, this);
         twist_sub_ = nh_->subscribe("current_velocity", 1, &RouteFollowingPlugin::twist_cb, this);
+        twist_sub_ = nh_->subscribe("final_maneuver_plan", 1, &RouteFollowingPlugin::latest_maneuver_plan_cb, this);
 
         // read ros parameters
         pnh_->param<double>("minimal_plan_duration", min_plan_duration_, 16.0);
@@ -150,6 +151,10 @@ void setManeuverLaneletIds(cav_msgs::Maneuver& mvr, lanelet::Id start_id, lanele
     void RouteFollowingPlugin::twist_cb(const geometry_msgs::TwistStampedConstPtr &msg)
     {
         current_speed_ = msg->twist.linear.x;
+    }
+    
+    void current_maneuver_plan_cb(const cav_msgs::ManeuverPlanConstPtr& msg) {
+        current_maneuver_plan_ = msg;
     }
 
     std::vector<cav_msgs::Maneuver> RouteFollowingPlugin::routeCb(const lanelet::routing::LaneletPath &route_shortest_path)
@@ -528,7 +533,6 @@ void setManeuverLaneletIds(cav_msgs::Maneuver& mvr, lanelet::Id start_id, lanele
 
         ROS_DEBUG_STREAM("Looking up front bumper pose...");
         
-        
         try
         {
             tf_ = tf2_buffer_.lookupTransform("map", "vehicle_front", ros::Time(0), ros::Duration(1.0)); //save to local copy of transform 1 sec timeout
@@ -550,10 +554,7 @@ void setManeuverLaneletIds(cav_msgs::Maneuver& mvr, lanelet::Id start_id, lanele
         current_loc_ = current_loc;
         double current_progress = wm_->routeTrackPos(current_loc).downtrack;
         
-        auto llts = wm_->getLaneletsFromPoint(current_loc, 10);                                          
-
         ROS_DEBUG_STREAM("pose_cb : current_progress" << current_progress << ", and upcoming_lane_change_status_msg_map_.size(): " << upcoming_lane_change_status_msg_map_.size());
-
         while (!upcoming_lane_change_status_msg_map_.empty() && current_progress > upcoming_lane_change_status_msg_map_.front().first)
         {
             ROS_DEBUG_STREAM("pose_cb : the vehicle has passed the lanechange point at downtrack" << upcoming_lane_change_status_msg_map_.front().first);
@@ -568,15 +569,33 @@ void setManeuverLaneletIds(cav_msgs::Maneuver& mvr, lanelet::Id start_id, lanele
             ROS_DEBUG_STREAM("upcoming_lane_change_status_msg_map_.front().second.downtrack_until_lanechange: " <<static_cast<double>(upcoming_lane_change_status_msg_map_.front().second.downtrack_until_lanechange));
             upcoming_lane_change_status_pub_.publish(upcoming_lane_change_status_msg_map_.front().second); 
         }
+        
+        // Check if we need to return to route shortest path.
+        // Step 1. Check if another plugin aside from RFP has been in control
+        if (current_maneuver_plan_  != nullptr &&
+            GET_MANEUVER_PROPERTY(current_maneuver_plan_->maneuvers[0], parameters.planning_strategic_plugin) \
+            != planning_strategic_plugin_) {
+            // If another plugin may have brought us off shortest path, check our current lanelet
+            auto llts = wm_->getLaneletsFromPoint(current_loc, 10);                                          
+            // Remove any candidate lanelets not on the route
+            llts.erase(std::remove_if(llts.begin(), llts.end(),
+                [&](auto lanelet) -> {
+                    return !wm_.getRoute().contains(lanelet);
+                }, 
+                llts.end()));
 
-        auto current_lanelet = llts[0];
-        // if the current lanelet is not on the shortest path
-        if (shortest_path_set_.find(current_lanelet.id()) == shortest_path_set_.end())
-        {
-            returnToShortestPath(current_lanelet);
-   
+            // !!! ASSUMPTION !!!:
+            // Once non-route lanelets have been removed, it is assumed that our actual current lanelet is the only one that can remain.
+            // TODO: Verify that this assumption is true in all cases OR implement more robust logic to track current lanelet when there are overlaps
+            auto current_lanelet = llts[0];
+
+            // if the current lanelet is not on the shortest path
+            if (shortest_path_set_.find(current_lanelet.id()) == shortest_path_set_.end())
+            {
+                returnToShortestPath(current_lanelet);
+    
+            }
         }
-      
     }
 
     ros::Duration RouteFollowingPlugin::getManeuverDuration(cav_msgs::Maneuver &maneuver, double epsilon) const


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
To address the anomaly described in #1813 , a check has been implemented to limit the times at which RFP will evaluate the need to return to shortest path. Now it should only trigger if a plugin other than RFP was in control at the time, meaning that control drift during regular RFP operation will not be considered as leaving the shortest path. In addition, a filter has been implemented such that when evaluating the vehicle's current lanelet, only lanelets on the route are considered as possible candidates.

## Related Issue
Resolves #1813 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is to support IHP2 testing as resolution of a blocking issue discovered during testing.

## How Has This Been Tested?

This has not yet been tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
