### PR TITLE
Add logic to platooning_control for outputting acceleration commands

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -47,7 +47,7 @@ if [[ "$BRANCH" = "develop" ]]; then
 else
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch carma-system-3.11.0
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch carma-system-3.11.0
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch test/voices_master
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-messenger.git --branch carma-system-3.11.0
 fi
 
 # add astuff messages

--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -53,7 +53,7 @@ namespace platoon_control
 			geometry_msgs::TwistStamped composeTwistCmd(double linear_vel, double angular_vel);
 
 			// Compose control message by calculating speed and steering commands.
-			autoware_msgs::ControlCommandStamped composeCtrlCmd(double linear_vel, double steering_angle);
+			autoware_msgs::ControlCommandStamped composeCtrlCmd(double linear_vel, double steering_angle, double linear_accel);
 
 			// find the point correspoding to the lookahead distance
 			cav_msgs::TrajectoryPlanPoint getLookaheadTrajectoryPoint(cav_msgs::TrajectoryPlan trajectory_plan);

--- a/platooning_control/include/platoon_control.h
+++ b/platooning_control/include/platoon_control.h
@@ -63,6 +63,10 @@ namespace platoon_control
 
 			// current speed (in m/s)
 			double current_speed_ = 0.0;
+
+			// Timestamp associated with the latest speed received and stored in current_speed_
+			ros::Time current_speed_timestamp_;
+
 			double trajectory_speed_ = 0.0;
 
         

--- a/platooning_control/include/platoon_control_worker.h
+++ b/platooning_control/include/platoon_control_worker.h
@@ -93,7 +93,7 @@ namespace platoon_control
         * \brief Generates acceleration command based on the second trajectory point. Should be
         *        called after generateSpeed() so that the latest commanded speed can be used.
         */
-        void generateAccel(const double& current_vehicle_speed);
+        void generateAccel(const double& current_speed, const ros::Time& current_speed_timestamp, const ros::Time& current_time);
 
         /**
         * \brief set platoon leader

--- a/platooning_control/include/platoon_control_worker.h
+++ b/platooning_control/include/platoon_control_worker.h
@@ -93,7 +93,7 @@ namespace platoon_control
         * \brief Generates acceleration command based on the second trajectory point. Should be
         *        called after generateSpeed() so that the latest commanded speed can be used.
         */
-        void generateAccel(const cav_msgs::TrajectoryPlanPoint& next_trajectory_point);
+        void generateAccel(const double& current_vehicle_speed);
 
         /**
         * \brief set platoon leader

--- a/platooning_control/include/platoon_control_worker.h
+++ b/platooning_control/include/platoon_control_worker.h
@@ -90,6 +90,12 @@ namespace platoon_control
         void generateSteer(const cav_msgs::TrajectoryPlanPoint& point);
 
         /**
+        * \brief Generates acceleration command based on the second trajectory point. Should be
+        *        called after generateSpeed() so that the latest commanded speed can be used.
+        */
+        void generateAccel(const cav_msgs::TrajectoryPlanPoint& next_trajectory_point);
+
+        /**
         * \brief set platoon leader
         */
         void setLeader(const PlatoonLeaderInfo& leader);
@@ -106,6 +112,7 @@ namespace platoon_control
         double speedCmd_ = 0;
         double steerCmd_ = 0;
         double angVelCmd_ = 0;
+        double accelCmd_ = 0;
         double desired_gap_ = ctrl_config_.standStillHeadway;
         double actual_gap_ = 0.0;
         bool last_cmd_set_ = false;

--- a/platooning_control/src/platoon_control.cpp
+++ b/platooning_control/src/platoon_control.cpp
@@ -221,7 +221,7 @@ namespace platoon_control
         pcw_.setLeader(platoon_leader_);
     	pcw_.generateSpeed(first_trajectory_point);
     	pcw_.generateSteer(lookahead_point);
-        pcw_.generateAccel(first_trajectory_point); // Should be called after pcw_.generateSpeed so that generateAccel() can use the latest commanded speed in calculation
+        pcw_.generateAccel(current_speed_); // Should be called after pcw_.generateSpeed so that generateAccel() can use the latest commanded speed in calculation
 
         geometry_msgs::TwistStamped twist_msg = composeTwistCmd(pcw_.speedCmd_, pcw_.angVelCmd_);
         twist_pub_.publish(twist_msg);

--- a/platooning_control/src/platoon_control.cpp
+++ b/platooning_control/src/platoon_control.cpp
@@ -186,6 +186,7 @@ namespace platoon_control
 
     void PlatoonControlPlugin::currentTwist_cb(const geometry_msgs::TwistStamped::ConstPtr& twist){
         current_speed_ = twist->twist.linear.x;
+        current_speed_timestamp_ = twist->header.stamp;
     }
 
 
@@ -221,7 +222,7 @@ namespace platoon_control
         pcw_.setLeader(platoon_leader_);
     	pcw_.generateSpeed(first_trajectory_point);
     	pcw_.generateSteer(lookahead_point);
-        pcw_.generateAccel(current_speed_); // Should be called after pcw_.generateSpeed so that generateAccel() can use the latest commanded speed in calculation
+        pcw_.generateAccel(current_speed_, current_speed_timestamp_, ros::Time::now()); // Should be called after pcw_.generateSpeed so that generateAccel() can use the latest commanded speed in calculation
 
         geometry_msgs::TwistStamped twist_msg = composeTwistCmd(pcw_.speedCmd_, pcw_.angVelCmd_);
         twist_pub_.publish(twist_msg);

--- a/platooning_control/src/platoon_control_worker.cpp
+++ b/platooning_control/src/platoon_control_worker.cpp
@@ -133,7 +133,7 @@ namespace platoon_control
                     speed_cmd = min;
                 }
                 lastCmdSpeed = speed_cmd;
-                ROS_WARN_STREAM("The speed command after max accel cap is: " << speed_cmd << " m/s");
+                ROS_DEBUG_STREAM("The speed command after max accel cap is: " << speed_cmd << " m/s");
         }
 
         speedCmd_ = speed_cmd;

--- a/platooning_control/src/platoon_control_worker.cpp
+++ b/platooning_control/src/platoon_control_worker.cpp
@@ -153,12 +153,23 @@ namespace platoon_control
     }
 
     void PlatoonControlWorker::generateAccel(const double& current_speed, const ros::Time& current_speed_timestamp, const ros::Time& current_time)
-    {
+    {   
+        // NOTE: This approach for calculating commanded acceleration assumes that the current_speed and current_speed_timestamp values are from recent data
+        //       readings, and can be used to calculate a valid acceleration.
+
         const double v_i = current_speed; 
         const double v_f = speedCmd_; 
         const double delta_time = (current_time - current_speed_timestamp).toSec();
         ROS_DEBUG_STREAM("V_i: " << v_i << ", V_f: " << v_f << ", delta_time: " << delta_time << "sec"); 
-        accelCmd_ = (v_f - v_i) / delta_time;
+
+        if (delta_time == 0.0) {
+            ROS_WARN_STREAM("delta_time is 0, commanded accel will be set to 0 m/s^2");
+            accelCmd_ = 0.0;
+            return;
+        }
+        else {
+            accelCmd_ = (v_f - v_i) / delta_time;
+        }
 
         ROS_DEBUG_STREAM("Commanded accel before applying limits: " << accelCmd_ << " m/s^2");
 

--- a/platooning_control/src/platoon_control_worker.cpp
+++ b/platooning_control/src/platoon_control_worker.cpp
@@ -133,7 +133,7 @@ namespace platoon_control
                     speed_cmd = min;
                 }
                 lastCmdSpeed = speed_cmd;
-                ROS_DEBUG_STREAM("The speed command after max accel cap is: " << speed_cmd << " m/s");
+                ROS_WARN_STREAM("The speed command after max accel cap is: " << speed_cmd << " m/s");
         }
 
         speedCmd_ = speed_cmd;
@@ -150,6 +150,15 @@ namespace platoon_control
         pp_.calculateSteer(point);
     	steerCmd_ = pp_.getSteeringAngle(); 
         angVelCmd_ = pp_.getAngularVelocity();
+    }
+
+    void PlatoonControlWorker::generateAccel(const cav_msgs::TrajectoryPlanPoint& next_trajectory_point)
+    {
+        const double delta_distance =
+            std::hypot(next_trajectory_point.x - current_pose_.position.x, next_trajectory_point.y - current_pose_.position.y);
+        const double v_i = currentSpeed;
+        const double v_f = speedCmd_; 
+        accelCmd_ = (v_f * v_f - v_i * v_i) / (2 * delta_distance);
     }
 
     // TODO get the actual leader from strategic plugin

--- a/platooning_control/src/platoon_control_worker.cpp
+++ b/platooning_control/src/platoon_control_worker.cpp
@@ -152,13 +152,15 @@ namespace platoon_control
         angVelCmd_ = pp_.getAngularVelocity();
     }
 
-    void PlatoonControlWorker::generateAccel(const double& current_vehicle_speed)
+    void PlatoonControlWorker::generateAccel(const double& current_speed, const ros::Time& current_speed_timestamp, const ros::Time& current_time)
     {
-        const double v_i = current_vehicle_speed; 
+        const double v_i = current_speed; 
         const double v_f = speedCmd_; 
-        const double delta_time = ctrl_config_.cmdTmestamp / 1000.0;
+        const double delta_time = (current_time - current_speed_timestamp).toSec();
         ROS_DEBUG_STREAM("V_i: " << v_i << ", V_f: " << v_f << ", delta_time: " << delta_time << "sec"); 
         accelCmd_ = (v_f - v_i) / delta_time;
+
+        ROS_DEBUG_STREAM("Commanded accel before applying limits: " << accelCmd_ << " m/s^2");
 
         if(enableMaxAccelFilter) {
             if (accelCmd_ > ctrl_config_.maxAccel) {
@@ -169,7 +171,7 @@ namespace platoon_control
             }
         }
 
-        ROS_DEBUG_STREAM("Commanded accel (raw): " << accelCmd_ << " m/s^2");
+        ROS_DEBUG_STREAM("Commanded accel after applying limits: " << accelCmd_ << " m/s^2");
     }
 
     // TODO get the actual leader from strategic plugin

--- a/platooning_control/test/test_worker.cpp
+++ b/platooning_control/test/test_worker.cpp
@@ -130,3 +130,24 @@ TEST(PlatoonControlWorkerTest, test_steer)
     pcw.generateSteer(point);
     EXPECT_NEAR(0, pcw.steerCmd_, 0.1);
 }
+
+TEST(PlatoonControlWorkerTest, test_accel)
+{
+
+    platoon_control::PlatoonControlWorker pcw;
+    pcw.currentSpeed = 5.0;
+    pcw.speedCmd_ = 6.0;
+    
+    geometry_msgs::PoseStamped current_pose;
+    current_pose.pose.position.x = 0.0;
+    current_pose.pose.position.y = 0.0;
+
+    pcw.setCurrentPose(current_pose);
+
+    cav_msgs::TrajectoryPlanPoint next_trajectory_point;
+    next_trajectory_point.x = 0.0;
+    next_trajectory_point.y = 10.0;
+
+    pcw.generateAccel(next_trajectory_point);
+    EXPECT_NEAR(0.55, pcw.accelCmd_, 0.1);
+}

--- a/platooning_control/test/test_worker.cpp
+++ b/platooning_control/test/test_worker.cpp
@@ -144,10 +144,8 @@ TEST(PlatoonControlWorkerTest, test_accel)
 
     pcw.setCurrentPose(current_pose);
 
-    cav_msgs::TrajectoryPlanPoint next_trajectory_point;
-    next_trajectory_point.x = 0.0;
-    next_trajectory_point.y = 10.0;
+    double current_speed = 5.0;
 
-    pcw.generateAccel(next_trajectory_point);
+    pcw.generateAccel(current_speed);
     EXPECT_NEAR(0.55, pcw.accelCmd_, 0.1);
 }

--- a/platooning_control/test/test_worker.cpp
+++ b/platooning_control/test/test_worker.cpp
@@ -135,17 +135,12 @@ TEST(PlatoonControlWorkerTest, test_accel)
 {
 
     platoon_control::PlatoonControlWorker pcw;
-    pcw.currentSpeed = 5.0;
-    pcw.speedCmd_ = 6.0;
-    
-    geometry_msgs::PoseStamped current_pose;
-    current_pose.pose.position.x = 0.0;
-    current_pose.pose.position.y = 0.0;
-
-    pcw.setCurrentPose(current_pose);
-
     double current_speed = 5.0;
+    pcw.speedCmd_ = 6.0;
 
-    pcw.generateAccel(current_speed);
-    EXPECT_NEAR(0.55, pcw.accelCmd_, 0.1);
+    ros::Time current_speed_timestamp = ros::Time(1,0);
+    ros::Time current_time = ros::Time(3,0);
+
+    pcw.generateAccel(current_speed, current_speed_timestamp, current_time);
+    EXPECT_NEAR(0.5, pcw.accelCmd_, 0.1);
 }

--- a/platooning_strategic/include/platoon_strategic.h
+++ b/platooning_strategic/include/platoon_strategic.h
@@ -492,7 +492,7 @@ namespace platoon_strategic
             int statusMessageInterval_ = 100; //ms
             int NEGOTIATION_TIMEOUT = 5000;  // ms
             int noLeaderUpdatesCounter = 0;
-            int LEADER_TIMEOUT_COUNTER_LIMIT = 5;
+            int LEADER_TIMEOUT_COUNTER_LIMIT = 25;
             double waitingStateTimeout = 25.0; // s
             double desiredJoinGap = 30.0; // m
             double desiredJoinTimeGap = 4.0; // s

--- a/platooning_strategic/include/platoon_strategic.h
+++ b/platooning_strategic/include/platoon_strategic.h
@@ -492,7 +492,7 @@ namespace platoon_strategic
             int statusMessageInterval_ = 100; //ms
             int NEGOTIATION_TIMEOUT = 5000;  // ms
             int noLeaderUpdatesCounter = 0;
-            int LEADER_TIMEOUT_COUNTER_LIMIT = 25;
+            int LEADER_TIMEOUT_COUNTER_LIMIT = 5;
             double waitingStateTimeout = 25.0; // s
             double desiredJoinGap = 30.0; // m
             double desiredJoinTimeGap = 4.0; // s

--- a/platooning_strategic/src/platoon_strategic.cpp
+++ b/platooning_strategic/src/platoon_strategic.cpp
@@ -110,6 +110,7 @@ namespace platoon_strategic
             lanelet::BasicPoint2d current_loc(pose_msg_.pose.position.x, pose_msg_.pose.position.y);
             carma_wm::TrackPos tc = wm_->routeTrackPos(current_loc);
             current_downtrack_ = tc.downtrack;
+            pm_.current_downtrack_distance_ = current_downtrack_;
             ROS_DEBUG_STREAM("current_downtrack_ = " << current_downtrack_);
             current_crosstrack_ = tc.crosstrack;
             ROS_DEBUG_STREAM("current_crosstrack_ = " << current_crosstrack_);
@@ -263,11 +264,7 @@ namespace platoon_strategic
             ROS_DEBUG_STREAM("change the state from standby to leader at start-up");
         }
 
-        
-        pm_.current_downtrack_distance_ = current_downtrack_;
-        pm_.HostMobilityId = config_.vehicleID;
-        ROS_DEBUG_STREAM("current_downtrack: " << current_downtrack_);
-        
+        pm_.HostMobilityId = config_.vehicleID;        
         return true;
     }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
**NOTE**: This is a PR for the test/master_voices carma-platform branch, which is branched off of CARMA System 3.11.0

For a CARMA Platform vehicle to perform properly in a CARLA Simulation, the control commands published to /guidance/ctrl_raw must include an acceleration command (in addition to a speed and a steering command). Prior to this PR, the platooning_control guidance plugin only outputted speed and steering commands to this topic.

In addition to this, a small bug fix was applied to platoon_strategic.cpp in order to correctly set the host vehicle's current downtrack distance in the class' platoon_manager object. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All new and existing unit tests pass; carma-platform image integration tested successfully with full run-through of three-vehicle platoon as part of VOICES test with constructed (simulated) vehicles.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
