### PR TITLE
Fix carma package build error

### DIFF
--- a/carma/CMakeLists.txt
+++ b/carma/CMakeLists.txt
@@ -49,9 +49,6 @@ if(${ROS_VERSION} EQUAL 1) # ROS 1
                 scripts
                 rviz
                 DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-        install(DIRECTORY
-                ui/config
-                DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/ui)
 
 else() # ROS2
 
@@ -60,7 +57,7 @@ else() # ROS2
 
         
         ament_auto_package(
-                INSTALL_TO_SHARE config launch routes scripts rviz ui
+                INSTALL_TO_SHARE config launch routes scripts rviz
         )
 endif()
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes an error within the carma package, which causes a build failure. The 'ui' directory within carma was recently removed, but it is still referenced in the package's CMakeLists. This PR removes those references.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #1900 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
carma package was successfully built locally with these updates

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
