### PR TITLE
optimize tactical plugin trajectory generation

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -817,7 +817,7 @@ namespace basic_autonomy
                 
                 ROS_DEBUG_STREAM( "Number of left out basic_points size: " << left_points_size);
 
-                double percent_points_lost = 100 * left_points_size/basic_points.size();
+                float percent_points_lost = 100.0 * (float)left_points_size/basic_points.size();
 
                 if (percent_points_lost > 50.0)
                 {

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -801,6 +801,9 @@ namespace basic_autonomy
                 ROS_WARN_STREAM("Insufficient Spline Points");
                 return nullptr;
             }
+            ROS_DEBUG_STREAM("Original basic_points size: " << basic_points.size());
+
+
             std::vector<lanelet::BasicPoint2d> resized_basic_points = basic_points;
             
             // The large the number of points, longer it takes to calculate a spline fit
@@ -808,7 +811,21 @@ namespace basic_autonomy
             if (resized_basic_points.size() > 400)
             {
                 resized_basic_points.resize(400);
+                ROS_DEBUG_STREAM("Resized basic_points size: " << resized_basic_points.size());
+
+                size_t left_points_size = basic_points.size() - resized_basic_points.size();
+                
+                ROS_DEBUG_STREAM( "Number of left out basic_points size: " << left_points_size);
+
+                int percent_points_lost = 100 * left_points_size/basic_points.size();
+
+                if (percent_points_lost > 50)
+                {
+                    ROS_WARN_STREAM("More than half of basic points are ignored for spline fitting");
+                }
             }
+            
+
 
             std::unique_ptr<basic_autonomy::smoothing::SplineI> spl = std::make_unique<basic_autonomy::smoothing::BSpline>();
 

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -817,9 +817,9 @@ namespace basic_autonomy
                 
                 ROS_DEBUG_STREAM( "Number of left out basic_points size: " << left_points_size);
 
-                int percent_points_lost = 100 * left_points_size/basic_points.size();
+                double percent_points_lost = 100 * left_points_size/basic_points.size();
 
-                if (percent_points_lost > 50)
+                if (percent_points_lost > 50.0)
                 {
                     ROS_WARN_STREAM("More than half of basic points are ignored for spline fitting");
                 }

--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -801,10 +801,18 @@ namespace basic_autonomy
                 ROS_WARN_STREAM("Insufficient Spline Points");
                 return nullptr;
             }
+            std::vector<lanelet::BasicPoint2d> resized_basic_points = basic_points;
+            
+            // The large the number of points, longer it takes to calculate a spline fit
+            // So if the basic_points vector size is large, only the first 400 points are used to compute a spline fit. 
+            if (resized_basic_points.size() > 400)
+            {
+                resized_basic_points.resize(400);
+            }
 
             std::unique_ptr<basic_autonomy::smoothing::SplineI> spl = std::make_unique<basic_autonomy::smoothing::BSpline>();
 
-            spl->setPoints(basic_points);
+            spl->setPoints(resized_basic_points);
 
             return spl;
         }

--- a/basic_autonomy_ros2/src/basic_autonomy.cpp
+++ b/basic_autonomy_ros2/src/basic_autonomy.cpp
@@ -817,7 +817,7 @@ namespace basic_autonomy
                 size_t left_points_size = basic_points.size() - resized_basic_points.size();
                 RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Number of left out basic_points size: " << left_points_size);
 
-                double percent_points_lost = 100 * left_points_size/basic_points.size();
+                float percent_points_lost = 1100.0 * (float)left_points_size/basic_points.size();
 
                 if (percent_points_lost > 50.0)
                 {

--- a/basic_autonomy_ros2/src/basic_autonomy.cpp
+++ b/basic_autonomy_ros2/src/basic_autonomy.cpp
@@ -817,9 +817,9 @@ namespace basic_autonomy
                 size_t left_points_size = basic_points.size() - resized_basic_points.size();
                 RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Number of left out basic_points size: " << left_points_size);
 
-                int percent_points_lost = 100 * left_points_size/basic_points.size();
+                double percent_points_lost = 100 * left_points_size/basic_points.size();
 
-                if (percent_points_lost > 50)
+                if (percent_points_lost > 50.0)
                 {
                     RCLCPP_WARN_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "More than half of basic points are ignored for spline fitting");
                 }

--- a/basic_autonomy_ros2/src/basic_autonomy.cpp
+++ b/basic_autonomy_ros2/src/basic_autonomy.cpp
@@ -817,7 +817,7 @@ namespace basic_autonomy
                 size_t left_points_size = basic_points.size() - resized_basic_points.size();
                 RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Number of left out basic_points size: " << left_points_size);
 
-                float percent_points_lost = 1100.0 * (float)left_points_size/basic_points.size();
+                float percent_points_lost = 100.0 * (float)left_points_size/basic_points.size();
 
                 if (percent_points_lost > 50.0)
                 {

--- a/basic_autonomy_ros2/src/basic_autonomy.cpp
+++ b/basic_autonomy_ros2/src/basic_autonomy.cpp
@@ -803,9 +803,18 @@ namespace basic_autonomy
                 return nullptr;
             }
 
+            std::vector<lanelet::BasicPoint2d> resized_basic_points = basic_points;
+            
+            // The large the number of points, longer it takes to calculate a spline fit
+            // So if the basic_points vector size is large, only the first 400 points are used to compute a spline fit. 
+            if (resized_basic_points.size() > 400)
+            {
+                resized_basic_points.resize(400);
+            }
+
             std::unique_ptr<basic_autonomy::smoothing::SplineI> spl = std::make_unique<basic_autonomy::smoothing::BSpline>();
 
-            spl->setPoints(basic_points);
+            spl->setPoints(resized_basic_points);
 
             return spl;
         }

--- a/basic_autonomy_ros2/src/basic_autonomy.cpp
+++ b/basic_autonomy_ros2/src/basic_autonomy.cpp
@@ -802,16 +802,29 @@ namespace basic_autonomy
                 RCLCPP_WARN_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Insufficient Spline Points");
                 return nullptr;
             }
+            
+            RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Original basic_points size: " << basic_points.size());
 
             std::vector<lanelet::BasicPoint2d> resized_basic_points = basic_points;
-            
+
             // The large the number of points, longer it takes to calculate a spline fit
             // So if the basic_points vector size is large, only the first 400 points are used to compute a spline fit. 
             if (resized_basic_points.size() > 400)
             {
                 resized_basic_points.resize(400);
-            }
+                RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Resized basic_points size: " << resized_basic_points.size());
 
+                size_t left_points_size = basic_points.size() - resized_basic_points.size();
+                RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "Number of left out basic_points size: " << left_points_size);
+
+                int percent_points_lost = 100 * left_points_size/basic_points.size();
+
+                if (percent_points_lost > 50)
+                {
+                    RCLCPP_WARN_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "More than half of basic points are ignored for spline fitting");
+                }
+            }
+            
             std::unique_ptr<basic_autonomy::smoothing::SplineI> spl = std::make_unique<basic_autonomy::smoothing::BSpline>();
 
             spl->setPoints(resized_basic_points);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR is a fix for issue #1908 where some tactical plugins take longer to generate a trajectory, causing the service request from plan_delegator to time out without any response.
This was caused because sometimes the number of points used to calculate a spline fit is large, which contributes to the delay. Therefore, the number of points used to calculate the spline is limited to a reasonable value that is large enough to include most of the points, but small enough that the spline calculations are done in time. 

## Related Issue
#1908 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
