### PR TITLE
Fix/mobility viz

### DIFF
--- a/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
+++ b/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
@@ -216,6 +216,8 @@ namespace mobilitypath_visualizer {
 
             if (i >= msg.trajectory.offsets.size()) { // If we need to delete previous points
                 marker.action = visualization_msgs::msg::Marker::DELETE;
+                output.markers.push_back(marker);
+                continue;
             }
 
             marker.points = {};

--- a/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
+++ b/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
@@ -166,6 +166,12 @@ namespace mobilitypath_visualizer {
     {
         visualization_msgs::msg::MarkerArray output;
         
+        if (msg.trajectory.offsets.empty())
+        {
+            RCLCPP_WARN_STREAM(get_logger(), "Received empty mobility path to visualize! Returning...");
+            return output;
+        }
+
         visualization_msgs::msg::Marker marker;
         marker.header.frame_id = "map";
 

--- a/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
+++ b/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
@@ -190,6 +190,8 @@ namespace mobilitypath_visualizer {
         auto curr_location_msg = msg; //variable to update on each iteration as offsets are measured since last traj point
         
         marker.id = 0;
+        geometry_msgs::msg::Point arrow_start;
+        geometry_msgs::msg::Point arrow_end;
 
         if (msg.trajectory.offsets.empty())
         {
@@ -197,12 +199,10 @@ namespace mobilitypath_visualizer {
         }
         else
         {
-            geometry_msgs::msg::Point arrow_start;
             RCLCPP_DEBUG_STREAM(get_logger(), "ECEF point x: " << curr_location_msg.trajectory.location.ecef_x << ", y:" << curr_location_msg.trajectory.location.ecef_y);
             arrow_start = ECEFToMapPoint(curr_location_msg.trajectory.location); //also convert from cm to m
             RCLCPP_DEBUG_STREAM(get_logger(), "Map point x: " << arrow_start.x << ", y:" << arrow_start.y);
-
-            geometry_msgs::msg::Point arrow_end;
+            
             curr_location_msg.trajectory.location.ecef_x += + msg.trajectory.offsets[0].offset_x;
             curr_location_msg.trajectory.location.ecef_y += + msg.trajectory.offsets[0].offset_y;
             curr_location_msg.trajectory.location.ecef_z += + msg.trajectory.offsets[0].offset_z;

--- a/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
+++ b/mobilitypath_visualizer/src/mobilitypath_visualizer.cpp
@@ -165,12 +165,6 @@ namespace mobilitypath_visualizer {
     visualization_msgs::msg::MarkerArray MobilityPathVisualizer::composeVisualizationMarker(const carma_v2x_msgs::msg::MobilityPath& msg, const MarkerColor& color)
     {
         visualization_msgs::msg::MarkerArray output;
-        
-        if (msg.trajectory.offsets.empty())
-        {
-            RCLCPP_WARN_STREAM(get_logger(), "Received empty mobility path to visualize! Returning...");
-            return output;
-        }
 
         visualization_msgs::msg::Marker marker;
         marker.header.frame_id = "map";
@@ -196,19 +190,27 @@ namespace mobilitypath_visualizer {
         auto curr_location_msg = msg; //variable to update on each iteration as offsets are measured since last traj point
         
         marker.id = 0;
-        geometry_msgs::msg::Point arrow_start;
-        RCLCPP_DEBUG_STREAM(get_logger(), "ECEF point x: " << curr_location_msg.trajectory.location.ecef_x << ", y:" << curr_location_msg.trajectory.location.ecef_y);
-        arrow_start = ECEFToMapPoint(curr_location_msg.trajectory.location); //also convert from cm to m
-        RCLCPP_DEBUG_STREAM(get_logger(), "Map point x: " << arrow_start.x << ", y:" << arrow_start.y);
 
-        geometry_msgs::msg::Point arrow_end;
-        curr_location_msg.trajectory.location.ecef_x += + msg.trajectory.offsets[0].offset_x;
-        curr_location_msg.trajectory.location.ecef_y += + msg.trajectory.offsets[0].offset_y;
-        curr_location_msg.trajectory.location.ecef_z += + msg.trajectory.offsets[0].offset_z;
-        arrow_end = ECEFToMapPoint(curr_location_msg.trajectory.location); //also convert from cm to m
+        if (msg.trajectory.offsets.empty())
+        {
+            marker.action = visualization_msgs::msg::Marker::DELETE;
+        }
+        else
+        {
+            geometry_msgs::msg::Point arrow_start;
+            RCLCPP_DEBUG_STREAM(get_logger(), "ECEF point x: " << curr_location_msg.trajectory.location.ecef_x << ", y:" << curr_location_msg.trajectory.location.ecef_y);
+            arrow_start = ECEFToMapPoint(curr_location_msg.trajectory.location); //also convert from cm to m
+            RCLCPP_DEBUG_STREAM(get_logger(), "Map point x: " << arrow_start.x << ", y:" << arrow_start.y);
 
-        marker.points.push_back(arrow_start);
-        marker.points.push_back(arrow_end);
+            geometry_msgs::msg::Point arrow_end;
+            curr_location_msg.trajectory.location.ecef_x += + msg.trajectory.offsets[0].offset_x;
+            curr_location_msg.trajectory.location.ecef_y += + msg.trajectory.offsets[0].offset_y;
+            curr_location_msg.trajectory.location.ecef_z += + msg.trajectory.offsets[0].offset_z;
+            arrow_end = ECEFToMapPoint(curr_location_msg.trajectory.location); //also convert from cm to m
+
+            marker.points.push_back(arrow_start);
+            marker.points.push_back(arrow_end);
+        }
 
         output.markers.push_back(marker);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

During UC1 regression testing, it was found that when carma-platform publishes empty mobility_path with up-to-date timestamp (not 0, but empty offset points), other vehicle's mobility_path visualizer crashes. This is because the visualizer had a guard for 0 timestamp before, but due to requirement of UC1, mobility_path always has up-to-date timestamp now, which crashed the vehicles then. Since then, platform is updated to not publish empty mobility_path either, but still the guard should be added so that the node doesn't segfault.


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1939
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
