### PR TITLE
create carma cloud client

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -75,7 +75,8 @@ sonar.modules= bsm_generator, \
   points_map_filter, \
   light_controlled_intersection_tactical_plugin, \
   platoon_control_ihp, \
-  carma_guidance_plugins
+  carma_guidance_plugins, \
+  carma_cloud_client
 
 guidance.sonar.projectBaseDir                  = /opt/carma/src/CARMAPlatform/guidance
 bsm_generator.sonar.projectBaseDir             = /opt/carma/src/CARMAPlatform/bsm_generator
@@ -121,6 +122,7 @@ light_controlled_intersection_tactical_plugin.sonar.projectBaseDir = /opt/carma/
 platoon_control_ihp.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/platooning_control_ihp
 lci_strategic_plugin.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/lci_strategic_plugin
 carma_guidance_plugins.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/carma_guidance_plugins
+carma_cloud_client.sonar.projectBaseDir = /opt/carma/src/CARMAPlatform/carma_cloud_client
 
 # C++ Package differences
 # Sources
@@ -212,6 +214,8 @@ lci_strategic_plugin.sonar.sources = src
 lci_strategic_plugin.sonar.exclusions  =test/**
 carma_guidance_plugins.sonar.sources = src
 carma_guidance_plugins.sonar.exclusions  =test/**
+carma_cloud_client.sonar.sources = src
+carma_cloud_client.sonar.exclusions  =test/**
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
@@ -260,3 +264,4 @@ platoon_control_ihp_plugin.sonar.tests = test
 lci_strategic_plugin.sonar.sources = src
 lci_strategic_plugin.sonar.sources = test
 carma_guidance_plugins.sonar.sources = test
+carma_cloud_client.sonar.sources = test

--- a/carma_cloud_client/CMakeLists.txt
+++ b/carma_cloud_client/CMakeLists.txt
@@ -1,0 +1,79 @@
+
+# Copyright (C) 2022 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+cmake_minimum_required(VERSION 3.5)
+project(carma_cloud_client)
+
+# Declare carma package and check ROS version
+find_package(carma_cmake_common REQUIRED)
+carma_check_ros_version(2)
+carma_package()
+
+## Find dependencies using ament auto
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+find_package(CURL REQUIRED)
+
+# Name build targets
+set(node_exec carma_cloud_client_node_exec)
+set(node_lib carma_cloud_client_node)
+
+# Includes
+include_directories(
+  include
+  ${CURL_INCLUDE_DIR}
+)
+
+# Build
+ament_auto_add_library(${node_lib} SHARED
+        src/carma_cloud_client_node.cpp
+)
+
+ament_auto_add_executable(${node_exec} 
+        src/main.cpp 
+)
+
+# Register component
+rclcpp_components_register_nodes(${node_lib} "carma_cloud_client::CarmaCloudClient")
+target_link_libraries(${node_lib}
+        ${CURL_LIBRARIES}
+)
+
+# All locally created targets will need to be manually linked
+# ament auto will handle linking of external dependencies
+target_link_libraries(${node_exec}
+        ${node_lib}
+        ${CURL_LIBRARIES}
+)
+
+# Testing
+if(BUILD_TESTING)  
+
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies() # This populates the ${${PROJECT_NAME}_FOUND_TEST_DEPENDS} variable
+
+  ament_add_gtest(test_carma_cloud_client test/node_test.cpp)
+
+  ament_target_dependencies(test_carma_cloud_client ${${PROJECT_NAME}_FOUND_TEST_DEPENDS})
+
+  target_link_libraries(test_carma_cloud_client ${node_lib} ${CURL_LIBRARIES} curl)
+
+endif()
+
+# Install
+ament_auto_package(
+        INSTALL_TO_SHARE config launch
+)

--- a/carma_cloud_client/README.md
+++ b/carma_cloud_client/README.md
@@ -1,3 +1,4 @@
 # carma_cloud_client
+CARMA Cloud Client is a ROS2 node in CARMA platform which is responsible for cellular communication with CARMA Cloud.
 
-TODO for USER: Add description of package and link to confluence documentation.
+https://usdot-carma.atlassian.net/wiki/spaces/CRMPLT/pages/2365030405/CARMA+Cloud+Client

--- a/carma_cloud_client/README.md
+++ b/carma_cloud_client/README.md
@@ -1,0 +1,3 @@
+# carma_cloud_client
+
+TODO for USER: Add description of package and link to confluence documentation.

--- a/carma_cloud_client/config/parameters.yaml
+++ b/carma_cloud_client/config/parameters.yaml
@@ -1,0 +1,7 @@
+url : "http://127.0.0.1:33333" # 33333 is the port that will send from v2xhub to carma cloud ## initally was 23665
+base_hb : "/carmacloud/v2xhub"
+base_req : "/carmacloud/tcmreq"
+base_ack : "/carmacloud/tcmack"
+port : "33333"
+list : "force"
+fetchtime : 15

--- a/carma_cloud_client/config/parameters.yaml
+++ b/carma_cloud_client/config/parameters.yaml
@@ -1,7 +1,7 @@
-url : "http://127.0.0.1:33333" # 33333 is the port that will send from v2xhub to carma cloud ## initally was 23665
-base_hb : "/carmacloud/v2xhub"
-base_req : "/carmacloud/tcmreq"
-base_ack : "/carmacloud/tcmack"
-port : "33333"
-list : "force"
-fetchtime : 15
+url : "http://127.0.0.1:"  #host machine IP
+port : "33333"; #the port that will send from v2xhub to carma cloud ## initally was 23665
+base_req : "/carmacloud/tcmreq" #URL for traffic control request
+base_ack : "/carmacloud/tcmack"  #URL for traffic control acknowlegement.
+list : "true" #list determines how the TCMs will be sent in response. "true" means a list of TCMs are sent. "false" means one at a time
+fetchtime : 15  # number of days back when a geofence is valid
+method : "POST"

--- a/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
+++ b/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
@@ -27,16 +27,19 @@ namespace carma_cloud_client
    */
   struct Config
   {
-    
+    //host machine IP
     std::string url ="http://127.0.0.1:"; 
     std::string base_hb = "/carmacloud/v2xhub";
+    //URL for traffic control request
     std::string base_req = "/carmacloud/tcmreq";
+    //URL for traffic control acknowlegement.
     std::string base_ack = "/carmacloud/tcmack";
+    std::string method = "POST";
     // 33333 is the port that will send from v2xhub to carma cloud ## initally was 23665
     std::string port = "33333";
     // list determines how the TCMs will be sent in response. "true" means a list of TCMs are sent. "false" means one at a time
     std::string list = "true";
-    std::string method = "POST";
+    // number of days back when a geofence is valid
     int fetchtime = 15;
 
     // Stream operator for this config

--- a/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
+++ b/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <iostream>
+#include <vector>
+
+namespace carma_cloud_client
+{
+
+  /**
+   * \brief Stuct containing the algorithm configuration values for carma_cloud_client
+   */
+  struct Config
+  {
+    
+    std::string url ="http://127.0.0.1:"; 
+    std::string base_hb = "/carmacloud/v2xhub";
+    std::string base_req = "/carmacloud/tcmreq";
+    std::string base_ack = "/carmacloud/tcmack";
+    // 33333 is the port that will send from v2xhub to carma cloud ## initally was 23665
+    std::string port = "33333";
+    // list determines how the TCMs will be sent in response. "true" means a list of TCMs are sent. "false" means one at a time
+    std::string list = "true";
+    std::string method = "POST";
+    int fetchtime = 15;
+
+    // Stream operator for this config
+    friend std::ostream &operator<<(std::ostream &output, const Config &c)
+    {
+      output << "carma_cloud_client::Config { " << std::endl
+           << "url: " << c.url << std::endl
+           << "base_hb: " << c.base_hb << std::endl
+           << "base_req: " << c.base_req << std::endl
+           << "base_ack: " << c.base_ack << std::endl
+           << "port: " << c.port << std::endl
+           << "list: " << c.list << std::endl
+           << "fetchtime: " << c.fetchtime << std::endl
+           << "method: " << c.method << std::endl
+           << "}" << std::endl;
+      return output;
+    }
+  };
+
+} // carma_cloud_client

--- a/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_node.hpp
+++ b/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_node.hpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#pragma once
+
+#define CURL_STATICLIB 
+
+#include <rclcpp/rclcpp.hpp>
+#include <functional>
+#include <std_msgs/msg/string.hpp>
+#include <std_srvs/srv/empty.hpp>
+#include <curl/curl.h>
+#include <curl/easy.h>
+#include <j2735_convertor/control_request_convertor.hpp>
+#include <stdio.h>
+#include <cstdio>
+#include <iostream>
+
+
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
+#include "carma_cloud_client/carma_cloud_client_config.hpp"
+#include <j2735_v2x_msgs/msg/traffic_control_request.hpp>
+#include <carma_v2x_msgs/msg/traffic_control_request.hpp>
+
+
+namespace carma_cloud_client
+{
+
+  /**
+   * \brief TODO for USER: Add class description
+   * 
+   */
+  class CarmaCloudClient : public carma_ros2_utils::CarmaLifecycleNode
+  {
+
+  private:
+    // TCR Subscriber
+    carma_ros2_utils::SubPtr<carma_v2x_msgs::msg::TrafficControlRequest> tcr_sub_;
+
+    // Node configuration
+    Config config_;
+
+  public:
+    /**
+     * \brief Node constructor 
+     */
+    explicit CarmaCloudClient(const rclcpp::NodeOptions &);
+
+    /**
+     * \brief callback for dynamic parameter updates
+     * \param parameters list of parameters
+     */
+    rcl_interfaces::msg::SetParametersResult 
+    parameter_update_callback(const std::vector<rclcpp::Parameter> &parameters);
+
+
+    /**
+     * \brief TCR subscription callback
+     * \param msg Traffic Control Request pointer
+     */
+    void tcr_callback(carma_v2x_msgs::msg::TrafficControlRequest::UniquePtr msg);
+
+    /**
+     * \brief Funtion to Convert the TCR into XML format
+     * \param xml_str array of characters for xml format
+     * \param request_msg input TCR msg
+     */
+    void XMLconversion(char* xml_str, carma_v2x_msgs::msg::TrafficControlRequest request_msg);
+
+    /**
+     * \brief Send http request to carma cloud
+     * \param local_msg msg to be sent to cloud
+     * \param local_url url to cloud
+     * \param local_base base to be added to url
+     * \param local_method method
+     */
+    int CloudSend(const std::string &local_msg, const std::string& local_url, const std::string& local_base, const std::string& local_method);
+
+    /**
+     * \brief Send async http request to carma cloud
+     * \param local_msg msg to be sent to cloud
+     * \param local_url url to cloud
+     * \param local_base base to be added to url
+     * \param local_method method
+     */
+    void CloudSendAsync(const std::string& local_msg,const std::string& local_url, const std::string& local_base, const std::string& local_method);
+  
+
+    ////
+    // Overrides
+    ////
+    carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &prev_state);
+
+  };
+
+} // carma_cloud_client

--- a/carma_cloud_client/launch/carma_cloud_client_launch.py
+++ b/carma_cloud_client/launch/carma_cloud_client_launch.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2022 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from ament_index_python import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from carma_ros2_utils.launch.get_current_namespace import GetCurrentNamespace
+
+import os
+
+
+'''
+This file is can be used to launch the CARMA carma_cloud_client_node.
+  Though in carma-platform it may be launched directly from the base launch file.
+'''
+
+def generate_launch_description():
+
+    # Declare the log_level launch argument
+    log_level = LaunchConfiguration('log_level')
+    declare_log_level_arg = DeclareLaunchArgument(
+        name ='log_level', default_value='WARN')
+    
+    # Get parameter file path
+    param_file_path = os.path.join(
+        get_package_share_directory('carma_cloud_client'), 'config/parameters.yaml')
+
+        
+    # Launch node(s) in a carma container to allow logging to be configured
+    container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_cloud_client_container',
+        namespace=GetCurrentNamespace(),
+        executable='carma_component_container_mt',
+        composable_node_descriptions=[
+            
+            # Launch the core node(s)
+            ComposableNode(
+                    package='carma_cloud_client',
+                    plugin='carma_cloud_client::CarmaCloudClient',
+                    name='carma_cloud_client',
+                    extra_arguments=[
+                        {'use_intra_process_comms': True},
+                        {'--log-level' : log_level }
+                    ],
+                    parameters=[ param_file_path ]
+            ),
+        ]
+    )
+
+    return LaunchDescription([
+        declare_log_level_arg,
+        container
+    ])

--- a/carma_cloud_client/package.xml
+++ b/carma_cloud_client/package.xml
@@ -16,7 +16,8 @@
 <package format="3">
   <name>carma_cloud_client</name>
   <version>1.0.0</version>
-  <description>The carma_cloud_client package</description>
+  <description>The carma_cloud_client package communicates with carma cloud by forwarding the TCR 
+                and receives TCM to/from cloud through http</description>
 
   <maintainer email="carma@dot.gov">carma</maintainer>
 
@@ -30,7 +31,6 @@
   <depend>rclcpp</depend>
   <depend>carma_ros2_utils</depend>
   <depend>rclcpp_components</depend>
-  <depend>std_srvs</depend>
   <depend>j2735_v2x_msgs</depend>
   <depend>carma_v2x_msgs</depend>
   <depend>j2735_convertor</depend>

--- a/carma_cloud_client/package.xml
+++ b/carma_cloud_client/package.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+<!--  
+ Copyright (C) 2022 LEIDOS.
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+-->
+
+<package format="3">
+  <name>carma_cloud_client</name>
+  <version>1.0.0</version>
+  <description>The carma_cloud_client package</description>
+
+  <maintainer email="carma@dot.gov">carma</maintainer>
+
+  <license>Apache 2.0</license>
+  
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>carma_cmake_common</build_depend>
+  <build_depend>ament_auto_cmake</build_depend>
+  <build_depend>curl</build_depend>
+
+  <depend>rclcpp</depend>
+  <depend>carma_ros2_utils</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
+  <depend>j2735_v2x_msgs</depend>
+  <depend>carma_v2x_msgs</depend>
+  <depend>j2735_convertor</depend>
+  
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/carma_cloud_client/src/carma_cloud_client_node.cpp
+++ b/carma_cloud_client/src/carma_cloud_client_node.cpp
@@ -26,14 +26,19 @@ namespace carma_cloud_client
     config_ = Config();
 
     // Declare parameters
-    // config_.example_param = declare_parameter<std::string>("example_param", config_.example_param);
+    config_.url = declare_parameter<std::string>("url", config_.url);
+    config_.base_req = declare_parameter<std::string>("base_req", config_.base_req);
+    config_.base_ack = declare_parameter<std::string>("base_ack", config_.base_ack);
+    config_.port = declare_parameter<std::string>("port", config_.port);
+    config_.list = declare_parameter<std::string>("list", config_.list);
+    config_.method = declare_parameter<std::string>("method", config_.method);
+    config_.fetchtime = declare_parameter<int>("fetchtime", config_.fetchtime);
   }
 
   rcl_interfaces::msg::SetParametersResult CarmaCloudClient::parameter_update_callback(const std::vector<rclcpp::Parameter> &parameters)
   {
     
     auto error = update_params<std::string>({{"url", config_.url}, 
-                                             {"base_hb", config_.base_hb},
                                              {"base_req", config_.base_req},
                                              {"base_ack", config_.base_ack},
                                              {"port", config_.port},
@@ -49,13 +54,12 @@ namespace carma_cloud_client
 
   carma_ros2_utils::CallbackReturn CarmaCloudClient::handle_on_configure(const rclcpp_lifecycle::State &)
   {
-    RCLCPP_INFO_STREAM(this->get_logger(), "CarmaCloudClient trying to configure");
+    RCLCPP_DEBUG_STREAM(this->get_logger(), "CarmaCloudClient trying to configure");
     // Reset config
     config_ = Config();
 
     // Load parameters
     get_parameter<std::string>("url", config_.url);
-    get_parameter<std::string>("base_hb", config_.base_hb);
     get_parameter<std::string>("base_req", config_.base_req);
     get_parameter<std::string>("base_ack", config_.base_ack);
     get_parameter<std::string>("port", config_.port);
@@ -85,7 +89,7 @@ namespace carma_cloud_client
 
     CloudSend(xml_str, config_.url, config_.base_req, config_.method);
     
-    RCLCPP_INFO_STREAM(  get_logger(), "tcr_sub_ callback called ");
+    RCLCPP_DEBUG_STREAM(  get_logger(), "tcr_sub_ callback called ");
   }
 
   void CarmaCloudClient::XMLconversion(char* xml_str, carma_v2x_msgs::msg::TrafficControlRequest request_msg)
@@ -94,7 +98,7 @@ namespace carma_cloud_client
 
     j2735_convertor::geofence_request::convert(request_msg, j2735_tcr);
 
-    RCLCPP_INFO_STREAM(  get_logger(), "converted: "); 
+    RCLCPP_DEBUG_STREAM(  get_logger(), "converted: "); 
 
     size_t hexlen = 2; //size of each hex representation with a leading 0
     char reqid[j2735_tcr.tcr_v01.reqid.id.size() * hexlen + 1];
@@ -103,13 +107,13 @@ namespace carma_cloud_client
       sprintf(reqid+(i*hexlen), "%.2X", j2735_tcr.tcr_v01.reqid.id[i]);
     }
 
-	  RCLCPP_INFO_STREAM(  get_logger(), "reqid: " << reqid);
+	  RCLCPP_DEBUG_STREAM(  get_logger(), "reqid: " << reqid);
   
     long int reqseq = j2735_tcr.tcr_v01.reqseq;
-    RCLCPP_INFO_STREAM(  get_logger(), "reqseq: " << reqseq);
+    RCLCPP_DEBUG_STREAM(  get_logger(), "reqseq: " << reqseq);
 
 	  long int scale = j2735_tcr.tcr_v01.scale;
-    RCLCPP_INFO_STREAM(  get_logger(), "scale: " << scale);
+    RCLCPP_DEBUG_STREAM(  get_logger(), "scale: " << scale);
 
     int totBounds =  j2735_tcr.tcr_v01.bounds.size();
     int cnt=0;
@@ -151,7 +155,7 @@ namespace carma_cloud_client
     // with port and list
     sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=\"%s\" list=\"%s\"><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",port, list, reqid, reqseq,scale,bounds_str);
 
-    RCLCPP_INFO_STREAM(  get_logger(), "xml_str: " << xml_str);
+    RCLCPP_DEBUG_STREAM(  get_logger(), "xml_str: " << xml_str);
 
   }
 
@@ -160,7 +164,7 @@ namespace carma_cloud_client
     CURL *req;
     CURLcode res;
     std::string urlfull = local_url + config_.port + local_base;	
-    RCLCPP_INFO_STREAM(  get_logger(), "full url: " << urlfull);
+    RCLCPP_DEBUG_STREAM(  get_logger(), "full url: " << urlfull);
     req = curl_easy_init();
     if(req) {
       curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());

--- a/carma_cloud_client/src/carma_cloud_client_node.cpp
+++ b/carma_cloud_client/src/carma_cloud_client_node.cpp
@@ -149,11 +149,8 @@ namespace carma_cloud_client
     strcpy(list, config_.list.c_str());
  
     // with port and list
-    sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=%s list=%s><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",port, list, reqid, reqseq,scale,bounds_str);
-    
-    // without port and list
-    // sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>", reqid, reqseq,scale,bounds_str);
-        
+    sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=\"%s\" list=\"%s\"><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",port, list, reqid, reqseq,scale,bounds_str);
+
     RCLCPP_INFO_STREAM(  get_logger(), "xml_str: " << xml_str);
 
   }

--- a/carma_cloud_client/src/carma_cloud_client_node.cpp
+++ b/carma_cloud_client/src/carma_cloud_client_node.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include "carma_cloud_client/carma_cloud_client_node.hpp"
+
+namespace carma_cloud_client
+{
+  namespace std_ph = std::placeholders;
+
+  CarmaCloudClient::CarmaCloudClient(const rclcpp::NodeOptions &options)
+      : carma_ros2_utils::CarmaLifecycleNode(options)
+  {
+    // Create initial config
+    config_ = Config();
+
+    // Declare parameters
+    // config_.example_param = declare_parameter<std::string>("example_param", config_.example_param);
+  }
+
+  rcl_interfaces::msg::SetParametersResult CarmaCloudClient::parameter_update_callback(const std::vector<rclcpp::Parameter> &parameters)
+  {
+    
+    auto error = update_params<std::string>({{"url", config_.url}, 
+                                             {"base_hb", config_.base_hb},
+                                             {"base_req", config_.base_req},
+                                             {"base_ack", config_.base_ack},
+                                             {"port", config_.port},
+                                             {"list", config_.list},
+                                             {"method", config_.method}} , parameters);
+
+    rcl_interfaces::msg::SetParametersResult result;
+
+    result.successful = !error;
+
+    return result;
+  }
+
+  carma_ros2_utils::CallbackReturn CarmaCloudClient::handle_on_configure(const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO_STREAM(this->get_logger(), "CarmaCloudClient trying to configure");
+    // Reset config
+    config_ = Config();
+
+    // Load parameters
+    get_parameter<std::string>("url", config_.url);
+    get_parameter<std::string>("base_hb", config_.base_hb);
+    get_parameter<std::string>("base_req", config_.base_req);
+    get_parameter<std::string>("base_ack", config_.base_ack);
+    get_parameter<std::string>("port", config_.port);
+    get_parameter<std::string>("list", config_.list);
+    get_parameter<std::string>("method", config_.method);
+    get_parameter<int>("fetchtime", config_.fetchtime);
+
+    // Register runtime parameter update callback
+    add_on_set_parameters_callback(std::bind(&CarmaCloudClient::parameter_update_callback, this, std_ph::_1));
+
+    // Setup subscribers
+    tcr_sub_ = create_subscription<carma_v2x_msgs::msg::TrafficControlRequest>("outgoing_geofence_request", 10,
+                                                              std::bind(&CarmaCloudClient::tcr_callback, this, std_ph::_1));                                                     
+
+
+    // Return success if everything initialized successfully
+    return CallbackReturn::SUCCESS;
+  }
+
+  void CarmaCloudClient::tcr_callback(carma_v2x_msgs::msg::TrafficControlRequest::UniquePtr msg)
+  {
+    carma_v2x_msgs::msg::TrafficControlRequest request_msg(*msg.get());
+
+    char xml_str[10000]; 
+
+    XMLconversion(xml_str, request_msg);
+
+    CloudSend(xml_str, config_.url, config_.base_req, config_.method);
+    
+    RCLCPP_INFO_STREAM(  get_logger(), "tcr_sub_ callback called ");
+  }
+
+  void CarmaCloudClient::XMLconversion(char* xml_str, carma_v2x_msgs::msg::TrafficControlRequest request_msg)
+  {
+    j2735_v2x_msgs::msg::TrafficControlRequest j2735_tcr;
+
+    j2735_convertor::geofence_request::convert(request_msg, j2735_tcr);
+
+    RCLCPP_INFO_STREAM(  get_logger(), "converted: "); 
+
+    size_t hexlen = 2; //size of each hex representation with a leading 0
+    char reqid[j2735_tcr.tcr_v01.reqid.id.size() * hexlen + 1];
+    for (int i = 0; i < j2735_tcr.tcr_v01.reqid.id.size(); i++)
+    {
+      sprintf(reqid+(i*hexlen), "%.2X", j2735_tcr.tcr_v01.reqid.id[i]);
+    }
+
+	  RCLCPP_INFO_STREAM(  get_logger(), "reqid: " << reqid);
+  
+    long int reqseq = j2735_tcr.tcr_v01.reqseq;
+    RCLCPP_INFO_STREAM(  get_logger(), "reqseq: " << reqseq);
+
+	  long int scale = j2735_tcr.tcr_v01.scale;
+    RCLCPP_INFO_STREAM(  get_logger(), "scale: " << scale);
+
+    int totBounds =  j2735_tcr.tcr_v01.bounds.size();
+    int cnt=0;
+    char bounds_str[5000];
+		strcpy(bounds_str,"");
+
+    //  get current time 
+    std::time_t tm = this->now().seconds()/60 - config_.fetchtime*24*60; //  T minus fetchtime*24 hours in  min  
+
+    while(cnt<totBounds)
+    {
+
+      uint32_t oldest = tm;
+      long lat = j2735_tcr.tcr_v01.bounds[cnt].reflat; 
+      long longg = j2735_tcr.tcr_v01.bounds[cnt].reflon;
+
+    
+      long dtx0 = j2735_tcr.tcr_v01.bounds[cnt].offsets[0].deltax;
+      long dty0 = j2735_tcr.tcr_v01.bounds[cnt].offsets[0].deltay;
+      long dtx1 = j2735_tcr.tcr_v01.bounds[cnt].offsets[1].deltax;
+      long dty1 = j2735_tcr.tcr_v01.bounds[cnt].offsets[1].deltay;
+      long dtx2 = j2735_tcr.tcr_v01.bounds[cnt].offsets[2].deltax;
+      long dty2 = j2735_tcr.tcr_v01.bounds[cnt].offsets[2].deltay;
+
+      int x = std::sprintf(bounds_str+strlen(bounds_str),"<bounds><TrafficControlBounds><oldest>%ld</oldest><reflon>%ld</reflon><reflat>%ld</reflat><offsets><OffsetPoint><deltax>%ld</deltax><deltay>%ld</deltay></OffsetPoint><OffsetPoint><deltax>%ld</deltax><deltay>%ld</deltay></OffsetPoint><OffsetPoint><deltax>%ld</deltax><deltay>%ld</deltay></OffsetPoint></offsets></TrafficControlBounds></bounds>",oldest,longg,lat,dtx0,dty0,dtx1,dty1,dtx2,dty2);
+
+      cnt++;
+
+    }	
+
+    
+
+    char port[config_.port.size() + 1];
+    strcpy(port, config_.port.c_str());
+
+    char list[config_.list.size() + 1];
+    strcpy(list, config_.list.c_str());
+ 
+    // with port and list
+    sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=%s list=%s><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",port, list, reqid, reqseq,scale,bounds_str);
+    
+    // without port and list
+    // sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>", reqid, reqseq,scale,bounds_str);
+        
+    RCLCPP_INFO_STREAM(  get_logger(), "xml_str: " << xml_str);
+
+  }
+
+  int CarmaCloudClient::CloudSend(const std::string &local_msg, const std::string& local_url, const std::string& local_base, const std::string& local_method)
+  { 	
+    CURL *req;
+    CURLcode res;
+    std::string urlfull = local_url + config_.port + local_base;	
+    RCLCPP_INFO_STREAM(  get_logger(), "full url: " << urlfull);
+    req = curl_easy_init();
+    if(req) {
+      curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
+
+      if(strcmp(local_method.c_str(),"POST")==0)
+      {
+        curl_easy_setopt(req, CURLOPT_POSTFIELDS, local_msg.c_str());
+        curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
+        res = curl_easy_perform(req);
+        if(res != CURLE_OK)
+        {
+          RCLCPP_ERROR_STREAM(  get_logger(), "curl send failed: " << curl_easy_strerror(res));
+          return 1;
+        }	  
+      }
+      curl_easy_cleanup(req);
+    }	
+      
+    return 0;
+  }
+
+  void CarmaCloudClient::CloudSendAsync(const std::string& local_msg,const std::string& local_url, const std::string& local_base, const std::string& local_method)
+  {
+    std::thread t([this, &local_msg, &local_url, &local_base, &local_method](){	
+      CloudSend(local_msg, local_url, local_base, local_method);	
+    });
+    t.detach();
+  }
+
+
+} // carma_cloud_client
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader
+RCLCPP_COMPONENTS_REGISTER_NODE(carma_cloud_client::CarmaCloudClient)

--- a/carma_cloud_client/src/main.cpp
+++ b/carma_cloud_client/src/main.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <rclcpp/rclcpp.hpp>
+#include "carma_cloud_client/carma_cloud_client_node.hpp"
+
+int main(int argc, char **argv) 
+{
+  std::cerr<<"0"<<std::endl;
+  rclcpp::init(argc, argv);
+  std::cerr<<"1"<<std::endl;
+  auto node = std::make_shared<carma_cloud_client::CarmaCloudClient>(rclcpp::NodeOptions());
+  std::cerr<<"2"<<std::endl;
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/carma_cloud_client/src/main.cpp
+++ b/carma_cloud_client/src/main.cpp
@@ -19,11 +19,8 @@
 
 int main(int argc, char **argv) 
 {
-  std::cerr<<"0"<<std::endl;
   rclcpp::init(argc, argv);
-  std::cerr<<"1"<<std::endl;
   auto node = std::make_shared<carma_cloud_client::CarmaCloudClient>(rclcpp::NodeOptions());
-  std::cerr<<"2"<<std::endl;
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());
   executor.spin();

--- a/carma_cloud_client/test/node_test.cpp
+++ b/carma_cloud_client/test/node_test.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <chrono>
+#include <thread>
+#include <future>
+
+#include "carma_cloud_client/carma_cloud_client_node.hpp"
+
+
+TEST(Testcarma_cloud_client, test_xml_conversion){
+
+    rclcpp::NodeOptions options;
+    carma_cloud_client::CarmaCloudClient plugin(options);
+
+    carma_v2x_msgs::msg::TrafficControlRequest request_msg;
+    request_msg.choice = carma_v2x_msgs::msg::TrafficControlRequest::TCRV01;
+    request_msg.tcr_v01.reqseq = 123;
+    request_msg.tcr_v01.reqid.id = {0, 1, 2, 3, 4, 5, 6, 7};
+    carma_v2x_msgs::msg::TrafficControlBounds b1;
+    b1.oldest = b1.oldest.set__nanosec(500000000);
+    b1.reflat = 45.0;// 45 deg
+    b1.reflon = 40.0;// 40 deg
+    
+    for(int i = 0; i < 3; i++)
+    {
+        b1.offsets[i].deltax = 1000;
+        b1.offsets[i].deltay = 100;
+    }
+
+    request_msg.tcr_v01.bounds.push_back(b1);
+    char xml_str[10000]; 
+    plugin.XMLconversion(xml_str, request_msg);
+    // The resulting xml is printed.
+}
+
+int main(int argc, char ** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    //Initialize ROS
+    rclcpp::init(argc, argv);
+
+    bool success = RUN_ALL_TESTS();
+
+    //shutdown ROS
+    rclcpp::shutdown();
+
+    return success;
+} 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Create a carma_cloud_client ROS2 node in carma-platform. The functionalities for the carma_cloud_client ROS node below:
- Subscribe to carma_wm_ctrl node to get the TCR data. 
- Create a HTTP client and send a TCR post request to carma-cloud. TCR is in XML format. 

## Related Issue
#1965 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested and locally integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
