### PR TITLE
Add intersection data broadcasted by carma-platform

### DIFF
--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.h
@@ -719,6 +719,7 @@ private:
   ////////// VARIABLES ///////////
   
   std::string previous_strategy_params_ = "";  
+  std::string upcoming_id_ = "";
 
   double max_comfort_accel_ = 2.0;  // acceleration rates after applying miltiplier
   double max_comfort_decel_ = -2.0; 

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -985,6 +985,7 @@ cav_msgs::MobilityOperation LCIStrategicPlugin::generateMobilityOperation()
     cav_msgs::MobilityOperation mo_;
     mo_.m_header.timestamp = ros::Time::now().toNSec()/1000000;
     mo_.m_header.sender_id = config_.vehicle_id;
+    mo_.m_header.recipient_id = upcoming_id_;
     mo_.m_header.sender_bsm_id = bsm_id_;
     mo_.strategy = light_controlled_intersection_strategy_;
 
@@ -1085,6 +1086,9 @@ bool LCIStrategicPlugin::planManeuverCb(cav_srvs::PlanManeuversRequest& req, cav
   }
   // Get current traffic light information
   ROS_DEBUG("\n\nFinding traffic_light information");
+
+  auto inter_list = wm_->getSignalizedIntersectionsAlongRoute({ req.veh_x, req.veh_y });
+  auto upcoming_id_= inter_list.front()->id();
 
   auto traffic_list = wm_->getSignalsAlongRoute({ req.veh_x, req.veh_y });
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
It was requested to add which intersection the status and intent messages are being broadcasted for from carma-platform during UC3.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1962
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
