### PR TITLE
Fix argument ordering restrictions for --ros1 and --ros2

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -23,43 +23,64 @@ echo ""
 echo "##### $IMAGE Docker Image Build Script #####"
 echo ""
 
+ROS1_PACKAGES=""
+ROS2_PACKAGES=""
+ROS1_PACKAGES_COLLECT=false
+ROS2_PACKAGES_COLLECT=false
+
 while [[ $# -gt 0 ]]; do
     arg="$1"
     case $arg in
         -v|--version)
+            ROS1_PACKAGES_COLLECT=false
+            ROS2_PACKAGES_COLLECT=false
+
             COMPONENT_VERSION_STRING="$2"
             shift
             shift
             ;;
         --system-release)
+            ROS1_PACKAGES_COLLECT=false
+            ROS2_PACKAGES_COLLECT=false
+
             SYSTEM_RELEASE=true
             shift
             ;;
         -p|--push)
+            ROS1_PACKAGES_COLLECT=false
+            ROS2_PACKAGES_COLLECT=false
+
             PUSH=true
             shift
             ;;
         -d|--develop)
+            ROS1_PACKAGES_COLLECT=false
+            ROS2_PACKAGES_COLLECT=false
+
             USERNAME=usdotfhwastoldev
             COMPONENT_VERSION_STRING=develop
             shift
             ;;
         --ros-1-packages|--ros1)
-            ROS1_PACKAGES=""
+            ROS1_PACKAGES_COLLECT=true
+            ROS2_PACKAGES_COLLECT=false
+
             shift
             ;;
         --ros-2-packages|--ros2)
-            ROS2_PACKAGES=""
+            ROS1_PACKAGES_COLLECT=false
+            ROS2_PACKAGES_COLLECT=true
+
             shift
             ;;
         *)
             # Var test based on Stack Overflow question: https://stackoverflow.com/questions/5406858/difference-between-unset-and-empty-variables-in-bash
             # Asker: green69
             # Answerer: geekosaur
-            if [ "${ROS2_PACKAGES+set}" = "set" ]; then
-                ROS2_PACKAGES="$ROS2_PACKAGES $arg"
-            elif [ "${ROS1_PACKAGES+set}" = "set" ]; then
+            if $ROS1_PACKAGES_COLLECT; then
                 ROS1_PACKAGES="$ROS1_PACKAGES $arg"
+            elif $ROS2_PACKAGES_COLLECT; then
+                ROS2_PACKAGES="$ROS2_PACKAGES $arg"
             else
                 echo "Unknown argument $arg..."
                 exit -1
@@ -70,7 +91,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ! -z "$ROS1_PACKAGES$ROS2_PACKAGES" ]]; then
-    echo "Performing incremental build of image to rebuild packages: $ROS1_PACKAGES $ROS2_PACKAGES..."
+    echo "Performing incremental build of image to rebuild packages: ROS1>> $ROS1_PACKAGES ROS2>> $ROS2_PACKAGES..."
 
     echo "Updating Dockerfile references to use most recent image as base image"
     # Trim of docker image LS command sourced from 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -14,11 +14,10 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
+set -ex
 
 # Build the software and its dependencies
 
-set -ex
- 
 ###
 # ROS1 installation
 ###


### PR DESCRIPTION
# PR Details
## Description

<!--- Describe your changes in detail -->
The incremental build flags --ros1 and --ros2 are now able to be supplied in any order and multiple times
 build-image.sh --ros2 ... --ros1, build-image.sh --ros1 ... --ros2, and build-image.sh --ros1 ... --ros1
are all now supported and should result in the specified packages being built correctly.

Once this change is approved, I will need to mirror this change on all other repos for consistency.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This PR addresses part of the issue #1960 , specifically the issue pertaining to the order in which build arguments are supplied. The other reported part of the issue has not yet been reproduced and is not addressed here. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixes an unecessary restriction on the order in which build arguments could be passed to the incremental build process, which would cause a build failure without warning if applied incorrectly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the build system locally by building various combinations of argument orders:

`build-image.sh --ros1 yield_plugin --ros2 arbitrator`
`build-image.sh --ros2 arbitrator --ros1 yield_plugin`

Note: The -d flag has no effect here, but was tested to match the reported issue to ensure non-breakage.
`build-image.sh -d --ros1 yield_plugin --ros2 arbitrator` 
`build-image.sh -d --ros2 arbitrator --ros1 yield_plugin`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
