### PR TITLE
Isolate plugins

### DIFF
--- a/carma/launch/plugins.launch.py
+++ b/carma/launch/plugins.launch.py
@@ -79,9 +79,9 @@ def generate_launch_description():
 
     pure_pursuit_tuning_parameters = [vehicle_calibration_dir, "/pure_pursuit/calibration.yaml"]
 
-    carma_lane_follow_plugins_container = ComposableNodeContainer(
+    carma_inlanecruising_plugin_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='carma_lane_follow_plugins_container',
+        name='carma_lainlanecruising_plugin_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -106,6 +106,16 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+        ]
+    )
+
+    carma_route_following_plugin_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_route_following_plugin_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
+
             ComposableNode(
                 package='route_following_plugin',
                 plugin='route_following_plugin::RouteFollowingPlugin',
@@ -164,9 +174,9 @@ def generate_launch_description():
         ]
     )
 
-    carma_stop_controlled_intersection_plugins_container = ComposableNodeContainer(
+    carma_sci_strategic_plugin_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='carma_stop_controlled_intersection_plugins_container',
+        name='carma_sci_strategic_plugin_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -196,6 +206,15 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+        ]
+    )
+
+    carma_stop_controlled_intersection_tactical_plugin_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_stop_controlled_intersection_tactical_plugin_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                 package='stop_controlled_intersection_tactical_plugin',
                 plugin='stop_controlled_intersection_tactical_plugin::StopControlledIntersectionTacticalPlugin',
@@ -352,9 +371,9 @@ def generate_launch_description():
         ]
     )
     
-    platooning_plugins_container = ComposableNodeContainer(
+    platooning_strategic_plugin_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='platooning_plugins_container',
+        name='platooning_strategic_plugin_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -389,7 +408,16 @@ def generate_launch_description():
                     platoon_strategic_ihp_param_file,
                     vehicle_config_param_file
                 ]
-            ),      
+            ),
+        ]
+    )
+      
+    platooning_tactical_plugin_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='platooning_tactical_plugin_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                 package='platooning_tactical_plugin',
                 plugin='platooning_tactical_plugin::Node',
@@ -413,12 +441,15 @@ def generate_launch_description():
     )
 
     return LaunchDescription([    
-        platooning_plugins_container,
-        carma_lane_follow_plugins_container,
-        carma_stop_and_wait_plugin_container,
-        carma_stop_controlled_intersection_plugins_container,
-        carma_cooperative_lanechange_plugins_container,
-        carma_yield_plugin_container,
-        carma_light_controlled_intersection_plugins_container,
-        carma_pure_pursuit_wrapper_container
+        carma_inlanecruising_plugin_container, 
+        carma_route_following_plugin_container, 
+        carma_stop_and_wait_plugin_container, 
+        carma_sci_strategic_plugin_container, 
+        carma_stop_controlled_intersection_tactical_plugin_container, 
+        carma_cooperative_lanechange_plugins_container, 
+        carma_yield_plugin_container, 
+        carma_light_controlled_intersection_plugins_container, 
+        carma_pure_pursuit_wrapper_container, 
+        platooning_strategic_plugin_container, 
+        platooning_tactical_plugin_container
     ])

--- a/carma/launch/plugins.launch.py
+++ b/carma/launch/plugins.launch.py
@@ -258,9 +258,9 @@ def generate_launch_description():
         ]
     )
 
-    carma_yield_plugin_plugins_container = ComposableNodeContainer(
+    carma_yield_plugin_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='carma_yield_plugin_plugins_container',
+        name='carma_yield_plugin_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -293,9 +293,9 @@ def generate_launch_description():
         ]
     )
 
-    carma_light_controlled_intersection_tactical_plugins_container = ComposableNodeContainer(
+    carma_light_controlled_intersection_plugins_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='carma_light_controlled_intersection_tactical_plugins_container',
+        name='carma_light_controlled_intersection_plugins_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -418,7 +418,7 @@ def generate_launch_description():
         carma_stop_and_wait_plugin_container,
         carma_stop_controlled_intersection_plugins_container,
         carma_cooperative_lanechange_plugins_container,
-        carma_yield_plugin_plugins_container,
-        carma_light_controlled_intersection_tactical_plugins_container,
+        carma_yield_plugin_container,
+        carma_light_controlled_intersection_plugins_container,
         carma_pure_pursuit_wrapper_container
     ])

--- a/carma/launch/plugins.launch.py
+++ b/carma/launch/plugins.launch.py
@@ -79,9 +79,9 @@ def generate_launch_description():
 
     pure_pursuit_tuning_parameters = [vehicle_calibration_dir, "/pure_pursuit/calibration.yaml"]
 
-    carma_plugins_container = ComposableNodeContainer(
+    carma_lane_follow_plugins_container = ComposableNodeContainer(
         package='carma_ros2_utils',
-        name='carma_guidance_core_plugins_container',
+        name='carma_lane_follow_plugins_container',
         executable='carma_component_container_mt',
         namespace=GetCurrentNamespace(),
         composable_node_descriptions=[
@@ -103,27 +103,6 @@ def generate_launch_description():
                 ],
                 parameters=[
                     inlanecruising_plugin_file_path,
-                    vehicle_config_param_file
-                ]
-            ),
-            ComposableNode(
-                package='stop_and_wait_plugin',
-                plugin='stop_and_wait_plugin::StopandWaitNode',
-                name='stop_and_wait_plugin',
-                extra_arguments=[
-                    {'use_intra_process_comms': True}, 
-                    {'--log-level' : GetLogLevel('stop_and_wait_plugin', env_log_levels) }
-                ],
-                remappings = [
-                    ("semantic_map", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/semantic_map" ] ),
-                    ("map_update", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/map_update" ] ),
-                    ("roadway_objects", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/roadway_objects" ] ),
-                    ("incoming_spat", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_spat" ] ),
-                    ("plugin_discovery", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/plugin_discovery" ] ),
-                    ("route", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/route" ] ),
-                ],
-                parameters=[
-                    stop_and_wait_plugin_param_file,
                     vehicle_config_param_file
                 ]
             ),
@@ -151,6 +130,46 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+        ]
+    )
+
+    carma_stop_and_wait_plugin_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_stop_and_wait_plugin_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
+
+            ComposableNode(
+                package='stop_and_wait_plugin',
+                plugin='stop_and_wait_plugin::StopandWaitNode',
+                name='stop_and_wait_plugin',
+                extra_arguments=[
+                    {'use_intra_process_comms': True}, 
+                    {'--log-level' : GetLogLevel('stop_and_wait_plugin', env_log_levels) }
+                ],
+                remappings = [
+                    ("semantic_map", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/semantic_map" ] ),
+                    ("map_update", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/map_update" ] ),
+                    ("roadway_objects", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/roadway_objects" ] ),
+                    ("incoming_spat", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_spat" ] ),
+                    ("plugin_discovery", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/plugin_discovery" ] ),
+                    ("route", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/route" ] ),
+                ],
+                parameters=[
+                    stop_and_wait_plugin_param_file,
+                    vehicle_config_param_file
+                ]
+            ),
+        ]
+    )
+
+    carma_stop_controlled_intersection_plugins_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_stop_controlled_intersection_plugins_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                 package='sci_strategic_plugin',
                 plugin='sci_strategic_plugin::SCIStrategicPlugin',
@@ -177,6 +196,36 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+            ComposableNode(
+                package='stop_controlled_intersection_tactical_plugin',
+                plugin='stop_controlled_intersection_tactical_plugin::StopControlledIntersectionTacticalPlugin',
+                name='stop_controlled_intersection_tactical_plugin',
+                extra_arguments=[
+                    {'use_intra_process_comms': True}, 
+                    {'--log-level' : GetLogLevel('stop_controlled_intersection_tactical_plugin', env_log_levels) }
+                ],
+                remappings = [
+                    ("semantic_map", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/semantic_map" ] ),
+                    ("map_update", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/map_update" ] ),
+                    ("roadway_objects", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/roadway_objects" ] ),
+                    ("incoming_spat", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_spat" ] ),
+                    ("plugin_discovery", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/plugin_discovery" ] ),
+                    ("route", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/route" ] )
+                ],
+                parameters=[
+                    stop_controlled_intersection_tactical_plugin_file_path,
+                    vehicle_config_param_file
+                ]
+            ),
+        ]
+    )
+
+    carma_cooperative_lanechange_plugins_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_cooperative_lanechange_plugins_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                 package='cooperative_lanechange',
                 plugin='cooperative_lanechange::CooperativeLaneChangePlugin',
@@ -206,6 +255,15 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+        ]
+    )
+
+    carma_yield_plugin_plugins_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_yield_plugin_plugins_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                     package='yield_plugin',
                     plugin='yield_plugin::YieldPluginNode',
@@ -232,6 +290,15 @@ def generate_launch_description():
                     vehicle_config_param_file
                 ]
             ),
+        ]
+    )
+
+    carma_light_controlled_intersection_tactical_plugins_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_light_controlled_intersection_tactical_plugins_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                 package='light_controlled_intersection_tactical_plugin',
                 plugin='light_controlled_intersection_tactical_plugin::LightControlledIntersectionTransitPluginNode',
@@ -253,27 +320,15 @@ def generate_launch_description():
                     light_controlled_intersection_tactical_plugin_param_file
                 ]     
             ),
-            ComposableNode(
-                package='stop_controlled_intersection_tactical_plugin',
-                plugin='stop_controlled_intersection_tactical_plugin::StopControlledIntersectionTacticalPlugin',
-                name='stop_controlled_intersection_tactical_plugin',
-                extra_arguments=[
-                    {'use_intra_process_comms': True}, 
-                    {'--log-level' : GetLogLevel('stop_controlled_intersection_tactical_plugin', env_log_levels) }
-                ],
-                remappings = [
-                    ("semantic_map", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/semantic_map" ] ),
-                    ("map_update", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/map_update" ] ),
-                    ("roadway_objects", [ EnvironmentVariable('CARMA_ENV_NS', default_value=''), "/roadway_objects" ] ),
-                    ("incoming_spat", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_spat" ] ),
-                    ("plugin_discovery", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/plugin_discovery" ] ),
-                    ("route", [ EnvironmentVariable('CARMA_GUIDE_NS', default_value=''), "/route" ] )
-                ],
-                parameters=[
-                    stop_controlled_intersection_tactical_plugin_file_path,
-                    vehicle_config_param_file
-                ]
-            ),
+        ]
+    )
+
+    carma_pure_pursuit_wrapper_container = ComposableNodeContainer(
+        package='carma_ros2_utils',
+        name='carma_pure_pursuit_wrapper_container',
+        executable='carma_component_container_mt',
+        namespace=GetCurrentNamespace(),
+        composable_node_descriptions=[
             ComposableNode(
                     package='pure_pursuit_wrapper',
                     plugin='pure_pursuit_wrapper::PurePursuitWrapperNode',
@@ -358,6 +413,12 @@ def generate_launch_description():
     )
 
     return LaunchDescription([    
-        carma_plugins_container,
-        platooning_plugins_container
-    ]) 
+        platooning_plugins_container,
+        carma_lane_follow_plugins_container,
+        carma_stop_and_wait_plugin_container,
+        carma_stop_controlled_intersection_plugins_container,
+        carma_cooperative_lanechange_plugins_container,
+        carma_yield_plugin_plugins_container,
+        carma_light_controlled_intersection_tactical_plugins_container,
+        carma_pure_pursuit_wrapper_container
+    ])


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Isolating plugins in plugins.launch,py in hopes to reduce failures of service calls. Please see the issue for more details.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1996
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UC3 integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
local integration tested to see if the plugins don't crash
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
