### PR TITLE
Make plan_delegator's plan trajectory service call timeout value a configurable parameter

### DIFF
--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -25,3 +25,8 @@ min_speed: 2.2352
 # Double: If an upcoming lane change will begin in under this time threshold, a turn signal activation command will be published.
 # Units: Seconds
 duration_to_signal_before_lane_change: 2.5
+
+# Int: The maximum duration that Plan Delegator will wait after calling a tactical plugin's trajectory planning service; if trajectory 
+# generation takes longer than this, then trajectory planning will immediately end for the current trajectory planning iteration.
+# Units: Milliseconds
+tactical_plugin_service_call_timeout: 100

--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -28,5 +28,7 @@ duration_to_signal_before_lane_change: 2.5
 
 # Int: The maximum duration that Plan Delegator will wait after calling a tactical plugin's trajectory planning service; if trajectory 
 # generation takes longer than this, then trajectory planning will immediately end for the current trajectory planning iteration.
+# NOTE: It is highly desirable to maintain a timeout of 100 ms or less, but trajectory generation success cannot be guaranteed with this duration
+#       for tactical plugins (primarily cooperative_lanechange) in all test scenarios at this time.
 # Units: Milliseconds
 tactical_plugin_service_call_timeout: 100

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -76,6 +76,8 @@ namespace plan_delegator
         double max_trajectory_duration = 6.0;
         double min_crawl_speed = 2.2352; // Min crawl speed in m/s
         double duration_to_signal_before_lane_change = 2.5; // (Seconds) If an upcoming lane change will begin in under this time threshold, a turn signal activation command will be published.
+        int tactical_plugin_service_call_timeout = 100; // (Milliseconds) The maximum duration that Plan Delegator will wait after calling a tactical plugin's trajectory planning service; if trajectory 
+                                                        // generation takes longer than this, then planning will immediately end for the current trajectory planning iteration.
         
         // Stream operator for this config
         friend std::ostream &operator<<(std::ostream &output, const Config &c)

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -142,6 +142,7 @@ namespace plan_delegator
         config_.max_trajectory_duration = declare_parameter<double>("trajectory_duration_threshold", config_.max_trajectory_duration);
         config_.min_crawl_speed = declare_parameter<double>("min_speed", config_.min_crawl_speed);
         config_.duration_to_signal_before_lane_change = declare_parameter<double>("duration_to_signal_before_lane_change", config_.duration_to_signal_before_lane_change);
+        config_.tactical_plugin_service_call_timeout = declare_parameter<int>("tactical_plugin_service_call_timeout", config_.tactical_plugin_service_call_timeout);
     }
 
     carma_ros2_utils::CallbackReturn PlanDelegator::handle_on_configure(const rclcpp_lifecycle::State &)
@@ -155,6 +156,7 @@ namespace plan_delegator
         get_parameter<double>("trajectory_duration_threshold", config_.max_trajectory_duration);
         get_parameter<double>("min_speed", config_.min_crawl_speed);
         get_parameter<double>("duration_to_signal_before_lane_change", config_.duration_to_signal_before_lane_change);
+        get_parameter<int>("tactical_plugin_service_call_timeout", config_.tactical_plugin_service_call_timeout);
 
         RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Done loading parameters: " << config_);
 
@@ -604,7 +606,7 @@ namespace plan_delegator
             
             auto plan_response = client->async_send_request(plan_req);
             
-            auto future_status = plan_response.wait_for(std::chrono::milliseconds(100));
+            auto future_status = plan_response.wait_for(std::chrono::milliseconds(config_.tactical_plugin_service_call_timeout));
 
             // Wait for the result.
             if (future_status == std::future_status::ready)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR updates the timeout value of plan_delegator's service call to a tactical plugin's "plan_trajectory" service to be a configurable parameter. Originally, this value was hardcoded to be 100 ms; however, it has been found during integration testing at Suntrax that lane change trajectories can occasionally take longer than this. A recent PR #2074 speeds up the lane change trajectory generation considerably, but occasionally a lane change of longer length (greater than 50 meters) can still take longer than 100 ms. 

This PR makes it possible to increase the timeout duration when testing is conducted using a vector map or test environment with longer lanelet lengths (which correlates to longer lane change trajectory generation time). With this update, the timeout duration can be increased for specific test events without needing to push the updated value to the codebase.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
[Issue 2076](https://github.com/usdot-fhwa-stol/carma-platform/issues/2076)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Vector maps are updated to include longer lanelets to enable smooth lane change trajectories at higher speeds (35 mph currently), and currently lane change trajectories can take longer than 100 ms to complete for these lane geometries.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested at Suntrax

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
