### PR TITLE
Fix to  maintain original estimated 'seconds until passing' for approaching ERV when it is far away from host vehicle

### DIFF
--- a/approaching_emergency_vehicle_plugin/src/approaching_emergency_vehicle_plugin_node.cpp
+++ b/approaching_emergency_vehicle_plugin/src/approaching_emergency_vehicle_plugin_node.cpp
@@ -299,7 +299,6 @@ namespace approaching_emergency_vehicle_plugin
     }
     else{
       fmter %false;
-      tracked_erv_.seconds_until_passing = 0.0;
     }
 
     // Index 1 of formatted string; indicates estimated time until tracked ERV passes the ego vehicle


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
TODO

This hotfix corrects an issue within carma-platforms approaching_emergency_vehicle_plugin. Prior to this fix, if an approaching ERV was not passing the host vehicle in less than `config_.approaching_threshold`, the ERV's `seconds_until_passing` was updated to 0.0 seconds. With this fix, the ERV's `seconds_until_passing` will maintain its estimated value when it is greater than the approaching threshold.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes bug that triggers the host vehicle to transition to the `SLOWING_DOWN_FOR_ERV` state since the ERV's seconds_until_passing is updated to 0.0 seconds when the ERV is a significant distance away from the CMV.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested on the White Truck at Suntrax with ERV interactions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
