### PR TITLE
Hotfix - Update BSM processing frequency for BSMs received from non-approaching active Emergency Response Vehicles

### DIFF
--- a/approaching_emergency_vehicle_plugin/include/approaching_emergency_vehicle_plugin/approaching_emergency_vehicle_plugin_node.hpp
+++ b/approaching_emergency_vehicle_plugin/include/approaching_emergency_vehicle_plugin/approaching_emergency_vehicle_plugin_node.hpp
@@ -443,6 +443,9 @@ namespace approaching_emergency_vehicle_plugin
     // Boolean flag to indicate whether if each ERV and CMV are going on same direction
     std::unordered_map<std::string, bool> is_same_direction_;
 
+    // Unordered map to store the latest time a BSM was processed for a given active ERV
+    std::unordered_map<std::string, rclcpp::Time> latest_erv_update_times_;
+
     // Pointer for map projector
     boost::optional<std::string> map_projector_;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes a fix in approaching_emergency_vehicle_plugin in order to limit the frequency at which BSMs from non-approaching active Emergency Response Vehicles are processed by the plugin. Due to the amount of processing involved on these BSMs, in rare circumstances (due to the CARMA Platform computer reaching computational limits), it is possible that the BSMs cannot be processed at 10 Hz. This fix enables the BSMs from these vehicles to be processed in accordance with the plugin's `bsm_processing_frequency` configuration parameter

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
Issue #2104 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested and integration tested as part of Emergency Response test scenarios with the Silver Truck and Chevy Tahoe (ERV) at Suntrax.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
