### PR TITLE
Add ROS 2 Node for converting TrackList messages to ExternalObjectList messages

### DIFF
--- a/carma_cooperative_perception/CMakeLists.txt
+++ b/carma_cooperative_perception/CMakeLists.txt
@@ -103,6 +103,26 @@ if(carma_cooperative_perception_BUILD_TESTS)
   target_link_libraries(carma_cooperative_perception_tests
     carma_cooperative_perception
   )
+
+  add_launch_test(test/track_list_to_external_object_list_launch_test.py)
+
 endif()
 
 ament_auto_package()
+
+include(GNUInstallDirs)
+
+# ament_auto does not provide file pattern matching
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/test/
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/carma_cooperative_perception/test
+  FILES_MATCHING
+    PATTERN *.py
+    PATTERN *.cpp
+    PATTERN __pycache__ EXCLUDE
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/test/data/
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/carma_cooperative_perception/test/data
+  FILES_MATCHING
+    PATTERN *.yaml
+)

--- a/carma_cooperative_perception/CMakeLists.txt
+++ b/carma_cooperative_perception/CMakeLists.txt
@@ -60,6 +60,7 @@ ament_auto_add_library(carma_cooperative_perception SHARED
   src/j3224_types.cpp
   src/msg_conversion.cpp
   src/sdsm_to_detection_list_component.cpp
+  src/track_list_to_external_object_list_component.cpp
   src/utm_zone.cpp
 )
 
@@ -72,10 +73,15 @@ target_link_libraries(carma_cooperative_perception
 rclcpp_components_register_nodes(carma_cooperative_perception
   "carma_cooperative_perception::ExternalObjectListToDetectionListNode"
   "carma_cooperative_perception::SdsmToDetectionListNode"
+  "carma_cooperative_perception::TrackListToExternalObjectListComponent"
 )
 
 ament_auto_add_executable(external_object_list_to_detection_list_node
   src/external_object_list_to_detection_list_node.cpp
+)
+
+ament_auto_add_executable(track_list_to_external_object_list_node
+  src/track_list_to_external_object_list_node.cpp
 )
 
 if(carma_cooperative_perception_BUILD_TESTS)

--- a/carma_cooperative_perception/docs/package_design.md
+++ b/carma_cooperative_perception/docs/package_design.md
@@ -25,9 +25,11 @@ flow with its neighboring actors (e.g., other connected vehicles or infrastructu
 
 - Sensor data sharing message (SDSM) to detection list Node: [`sdsm_to_detection_list_node`][sdsm_to_detection_list_node_docs]
 - External object list to detection list Node:
-[`external_object_list_to_detection_list_node`][external_object_list_to_detection_list_node_docs]
+  [`external_object_list_to_detection_list_node`][external_object_list_to_detection_list_node_docs]
+- Track list to external object list Node: [`track_list_to_external_object_list_node`][track_list_to_external_object_list_node_docs]
 
 [ros2_lifecycle_nodes_link]: https://design.ros2.org/articles/node_lifecycle.html
 [ros2_components_link]: https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Composition.html
 [sdsm_to_detection_list_node_docs]: sdsm_to_detection_list_node.md
 [external_object_list_to_detection_list_node_docs]: external_object_list_to_detection_list_node.md
+[track_list_to_external_object_list_node_docs]: track_list_to_external_object_list_node.md

--- a/carma_cooperative_perception/docs/track_list_to_external_object_list_node.md
+++ b/carma_cooperative_perception/docs/track_list_to_external_object_list_node.md
@@ -1,0 +1,37 @@
+# Track to external object list
+
+This Node generates `carma_perception_msgs/ExternalObjectList.msg` messages from the tracking pipeline's outputted `carma_cooperative_perception_interfaces/TrackList.msg` messages. We designed `carma_cooperative_perception` package to be transparent to CARMA Platform, so we need this conversion Node to inject the fused obstacle data back into CARMA Platform's perception pipeline.
+
+> [!IMPORTANT]\
+> The `carma_cooperative_perception_interfaces/msg/Track.msg` messages store
+> tracks' identifiers (IDs) as strings, but the `carma_perception_msgs/msg/
+ExternalObject.msg` messages use unsigned integers. If the string-to-integer
+> conversion fails during message conversion, the resulting `ExternalObject`'s
+> `id` field will be unpopulated.
+
+## Subscriptions
+
+| Topic                | Message Type                                                              | Description     |
+| -------------------- | ------------------------------------------------------------------------- | --------------- |
+| `~/input/track_list` | [`carma_cooperative_perception_interfaces/TrackList.msg`][track_list_msg] | Incoming tracks |
+
+## Publishers
+
+| Topic                           | Message Type                                                               | Frequency           | Description                            |
+| ------------------------------- | -------------------------------------------------------------------------- | ------------------- | -------------------------------------- |
+| `~/output/external_object_list` | [`carma_perception_msgs/ExternalObjectList.msg`][external_object_list_msg] | Subscription-driven | External objects generated from tracks |
+
+## Parameters
+
+This Node does not provide parameters.
+
+## Services
+
+This Node does not provide services.
+
+## Actions
+
+This Node does not provide actions.
+
+[track_list_msg]: https://github.com/usdot-fhwa-stol/carma-msgs/blob/develop/carma_cooperative_perception_interfaces/msg/TrackList.msg
+[external_object_list_msg]: https://github.com/usdot-fhwa-stol/carma-msgs/blob/develop/carma_perception_msgs/msg/ExternalObjectList.msg

--- a/carma_cooperative_perception/docs/track_list_to_external_object_list_node.md
+++ b/carma_cooperative_perception/docs/track_list_to_external_object_list_node.md
@@ -1,13 +1,19 @@
 # Track to external object list
 
-This Node generates `carma_perception_msgs/ExternalObjectList.msg` messages from the tracking pipeline's outputted `carma_cooperative_perception_interfaces/TrackList.msg` messages. We designed `carma_cooperative_perception` package to be transparent to CARMA Platform, so we need this conversion Node to inject the fused obstacle data back into CARMA Platform's perception pipeline.
+This Node generates `carma_perception_msgs/ExternalObjectList.msg` messages
+from the tracking pipeline's outputted
+`carma_cooperative_perception_interfaces/TrackList.msg` messages. We designed
+`carma_cooperative_perception` package to be transparent to CARMA Platform, so
+we need this conversion Node to inject the fused obstacle data back into CARMA
+Platform's perception pipeline.
 
 > [!IMPORTANT]\
 > The `carma_cooperative_perception_interfaces/msg/Track.msg` messages store
-> tracks' identifiers (IDs) as strings, but the `carma_perception_msgs/msg/
-ExternalObject.msg` messages use unsigned integers. If the string-to-integer
-> conversion fails during message conversion, the resulting `ExternalObject`'s
-> `id` field will be unpopulated.
+> tracks' identifiers (IDs) as strings, but the
+> `carma_perception_msgs/msg/ExternalObject.msg` messages use unsigned
+> integers for the `id` field (which is different than the `bsm_id` field). If
+> the string-to-integer conversion fails during message conversion, the
+> resulting `ExternalObject`'s `id` field will be unpopulated.
 
 ## Subscriptions
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -18,6 +18,9 @@
 #include <units.h>
 
 #include <carma_cooperative_perception_interfaces/msg/detection_list.hpp>
+#include <carma_cooperative_perception_interfaces/msg/track.hpp>
+#include <carma_cooperative_perception_interfaces/msg/track_list.hpp>
+#include <carma_perception_msgs/msg/external_object.hpp>
 #include <carma_perception_msgs/msg/external_object_list.hpp>
 #include <carma_v2x_msgs/msg/sensor_data_sharing_message.hpp>
 
@@ -57,6 +60,14 @@ auto to_detection_list_msg(
   const carma_perception_msgs::msg::ExternalObjectList & object_list,
   const MotionModelMapping & motion_model_mapping) noexcept
   -> carma_cooperative_perception_interfaces::msg::DetectionList;
+
+auto to_external_object_msg(
+  const carma_cooperative_perception_interfaces::msg::Track & track) noexcept
+  -> carma_perception_msgs::msg::ExternalObject;
+
+auto to_external_object_list_msg(
+  const carma_cooperative_perception_interfaces::msg::TrackList & track_list) noexcept
+  -> carma_perception_msgs::msg::ExternalObjectList;
 
 }  // namespace carma_cooperative_perception
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_
-#define CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_
+#ifndef CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_COMPONENT_HPP_
+#define CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_COMPONENT_HPP_
 
 #include <proj.h>
 
@@ -29,11 +29,9 @@
 
 namespace carma_cooperative_perception
 {
-
-auto transform_from_map_origin_to_local( // improve name scheme
+auto transform_from_map_origin_to_local(  // improve name scheme
   carma_cooperative_perception_interfaces::msg::TrackList track_list,
-  const std::string &map_origin) -> carma_perception_msgs::msg::ExternalObjectList;
-
+  const std::string & map_origin) -> carma_perception_msgs::msg::ExternalObjectList;
 
 class TrackListToExternalObjectListNode : public carma_ros2_utils::CarmaLifecycleNode
 {
@@ -41,8 +39,8 @@ class TrackListToExternalObjectListNode : public carma_ros2_utils::CarmaLifecycl
   using input_msg_shared_pointer = typename input_msg_type::sjaredPtr;
   using output_msg_type = carma_perception_msgs::msg::ExternalObjectList;
 
-  public:
-    explicit TrackListToExternalObjectListNode(const rclcpp::NodeOptions &options);
+public:
+  explicit TrackListToExternalObjectListNode(const rclcpp::NodeOptions & options);
 
   auto handle_on_configure(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
@@ -53,18 +51,17 @@ class TrackListToExternalObjectListNode : public carma_ros2_utils::CarmaLifecycl
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
-  auto publish_as_external_object_list(const input_msg_type &msg) const -> void;
+  auto publish_as_external_object_list(const input_msg_type & msg) const -> void;
 
-
-  private:
-    rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};
-    rclcpp::Subscription<input_msg_type>::SharedPtr track_subscription_{nullptr};
-    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr georeference_subscription_{nullptr};
-    std::string map_georeference_{""};
-    // MotionModelMapping motion_model_mapping_{};
-    OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
+private:
+  rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};
+  rclcpp::Subscription<input_msg_type>::SharedPtr track_subscription_{nullptr};
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr georeference_subscription_{nullptr};
+  std::string map_georeference_{""};
+  // MotionModelMapping motion_model_mapping_{};
+  OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
 };
 
-} // namespace carma_cooperative_perception
+}  // namespace carma_cooperative_perception
 
-#endif // CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_
+#endif  // CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_COMPONENT_HPP_

--- a/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
@@ -29,16 +29,8 @@
 
 namespace carma_cooperative_perception
 {
-auto transform_from_map_origin_to_local(  // improve name scheme
-  carma_cooperative_perception_interfaces::msg::TrackList track_list,
-  const std::string & map_origin) -> carma_perception_msgs::msg::ExternalObjectList;
-
 class TrackListToExternalObjectListNode : public carma_ros2_utils::CarmaLifecycleNode
 {
-  using input_msg_type = carma_cooperative_perception_interfaces::msg::TrackList;
-  using input_msg_shared_pointer = typename input_msg_type::sjaredPtr;
-  using output_msg_type = carma_perception_msgs::msg::ExternalObjectList;
-
 public:
   explicit TrackListToExternalObjectListNode(const rclcpp::NodeOptions & options);
 
@@ -51,14 +43,15 @@ public:
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
-  auto publish_as_external_object_list(const input_msg_type & msg) const -> void;
+  auto publish_as_external_object_list(
+    const carma_cooperative_perception_interfaces::msg::TrackList & msg) const noexcept -> void;
 
 private:
-  rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};
-  rclcpp::Subscription<input_msg_type>::SharedPtr track_subscription_{nullptr};
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr georeference_subscription_{nullptr};
+  rclcpp_lifecycle::LifecyclePublisher<carma_perception_msgs::msg::ExternalObjectList>::SharedPtr
+    publisher_{nullptr};
+  rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::TrackList>::SharedPtr
+    track_list_subscription_{nullptr};
   std::string map_georeference_{""};
-  // MotionModelMapping motion_model_mapping_{};
   OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
 };
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
@@ -1,0 +1,70 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_
+#define CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_
+
+#include <proj.h>
+
+#include <carma_cooperative_perception_interfaces/msg/track_list.hpp>
+#include <carma_perception_msgs/msg/external_object_list.hpp>
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <string>
+
+#include "carma_cooperative_perception/msg_conversion.hpp"
+
+namespace carma_cooperative_perception
+{
+
+auto transform_from_map_origin_to_local( // improve name scheme
+  carma_cooperative_perception_interfaces::msg::TrackList track_list,
+  const std::string &map_origin) -> carma_perception_msgs::msg::ExternalObjectList;
+
+
+class TrackListToExternalObjectListNode : public carma_ros2_utils::CarmaLifecycleNode
+{
+  using input_msg_type = carma_cooperative_perception_interfaces::msg::TrackList;
+  using input_msg_shared_pointer = typename input_msg_type::sjaredPtr;
+  using output_msg_type = carma_perception_msgs::msg::ExternalObjectList;
+
+  public:
+    explicit TrackListToExternalObjectListNode(const rclcpp::NodeOptions &options);
+
+  auto handle_on_configure(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_cleanup(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto publish_as_external_object_list(const input_msg_type &msg) const -> void;
+
+
+  private:
+    rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};
+    rclcpp::Subscription<input_msg_type>::SharedPtr track_subscription_{nullptr};
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr georeference_subscription_{nullptr};
+    std::string map_georeference_{""};
+    // MotionModelMapping motion_model_mapping_{};
+    OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
+};
+
+} // namespace carma_cooperative_perception
+
+#endif // CARMA_COOPERATIVE_PERCEPTION__TRACK_LIST_TO_EXTERNAL_OBJECT_LIST_HPP_

--- a/carma_cooperative_perception/package.xml
+++ b/carma_cooperative_perception/package.xml
@@ -42,6 +42,11 @@ limitations under the License.
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>carma_launch_testing</test_depend>
+  <test_depend>carma_message_utilities</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rclcpy</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -15,13 +15,13 @@
 #include "carma_cooperative_perception/msg_conversion.hpp"
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <carma_cooperative_perception_interfaces/msg/track.hpp>
+#include <carma_cooperative_perception_interfaces/msg/track_list.hpp>
 #include <carma_perception_msgs/msg/external_object.hpp>
 #include <carma_perception_msgs/msg/external_object_list.hpp>
 #include <j2735_v2x_msgs/msg/d_date_time.hpp>
 #include <j3224_v2x_msgs/msg/detected_object_data.hpp>
 #include <j3224_v2x_msgs/msg/measurement_time_offset.hpp>
-#include <carma_cooperative_perception_interfaces/msg/track.hpp>
-#include <carma_cooperative_perception_interfaces/msg/track_list.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -222,17 +222,12 @@ auto to_detection_list_msg(
   return detection_list;
 }
 
-// TODO
+// TODO(username)
 auto to_external_object_list_msg(
-  const carma_cooperative_perception_interfaces::msg::TrackList &track_list) noexcept
+  const carma_cooperative_perception_interfaces::msg::TrackList & track_list) noexcept
   -> carma_perception_msgs::msg::ExternalObjectList
 {
-
   carma_perception_msgs::msg::ExternalObjectList external_object_list;
-
-
 }
-
-
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -20,6 +20,8 @@
 #include <j2735_v2x_msgs/msg/d_date_time.hpp>
 #include <j3224_v2x_msgs/msg/detected_object_data.hpp>
 #include <j3224_v2x_msgs/msg/measurement_time_offset.hpp>
+#include <carma_cooperative_perception_interfaces/msg/track.hpp>
+#include <carma_cooperative_perception_interfaces/msg/track_list.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -219,5 +221,18 @@ auto to_detection_list_msg(
 
   return detection_list;
 }
+
+// TODO
+auto to_external_object_list_msg(
+  const carma_cooperative_perception_interfaces::msg::TrackList &track_list) noexcept
+  -> carma_perception_msgs::msg::ExternalObjectList
+{
+
+  carma_perception_msgs::msg::ExternalObjectList external_object_list;
+
+
+}
+
+
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -37,7 +37,7 @@ auto TrackListToExternalObjectListNode::handle_on_configure(
   const rclcpp_lifecycle::State & /* previous_state */) -> carma_ros2_utils::CallbackReturn
 {
   publisher_ = create_publisher<carma_perception_msgs::msg::ExternalObjectList>(
-    "output/external_objects_list", 1);
+    "output/external_object_list", 1);
 
   track_list_subscription_ = create_subscription<
     carma_cooperative_perception_interfaces::msg::TrackList>(

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -12,28 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "carma_cooperative_perception/external_object_list_to_detection_list_component.hpp"
+#include "carma_cooperative_perception/track_list_to_external_object_list_component.hpp"
 
 #include <rclcpp_components/register_node_macro.hpp>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "carma_cooperative_perception/external_object_list_to_detection_list_component.hpp"
 #include "carma_cooperative_perception/geodetic.hpp"
 #include "carma_cooperative_perception/units_extensions.hpp"
 
 namespace carma_cooperative_perception
 {
-
-auto transform_from_map_origin_to_local( // improve name scheme
+auto transform_from_map_origin_to_local(  // improve name scheme
   carma_cooperative_perception_interfaces::msg::TrackList track_list,
-  const std::string &map_origin) -> carma_cooperative_perception_interfaces::msg::DetectionList
+  const std::string & map_origin) -> carma_cooperative_perception_interfaces::msg::DetectionList
 {
-
-    // TODO
-
+  // TODO(username)
 }
-
 
 TrackListToExternalObjectListNode::TrackListToExternalObjectListNode(
   const rclcpp::NodeOptions & options)
@@ -46,25 +43,24 @@ TrackListToExternalObjectListNode::TrackListToExternalObjectListNode(
 auto TrackListToExternalObjectListNode::handle_on_configure(
   const rclcpp_lifecycle::State & /* previous_state */) -> carma_ros2_utils::CallbackReturn
 {
-  publisher_ = create_publisher<output_msg_type("output/external_objects_list", 1);
+  publisher_ = create_publisher < output_msg_type("output/external_objects_list", 1);
 
   track_list_subscription = create_subscription<input_msg_type>(
-    "input/track_list", 1, [this](input_msg_shared_pointer msg_ptr){
+    "input/track_list", 1, [this](input_msg_shared_pointer msg_ptr) {
       const auto current_State{this->get_current_state().label()};
 
-      if(current_state == "active"){
+      if (current_state == "active") {
         publish_as_external_object_list(*msg_ptr);
-      } else{
+      } else {
         RCLCPP_WARN(
           this->get_logger(),
           "Trying to receive message on the topic '%s', but the containing node is not activated. "
           "Current node state: '%s'",
-          this->track_subscription_->get_topic_name(), current_state.c_str()); 
+          this->track_subscription_->get_topic_name(), current_state.c_str());
       }
     });
 
-    // TODO
-
+  // TODO(username)
 }
 
 auto TrackListToExternalObjectListNode::handle_on_cleanup(
@@ -107,5 +103,4 @@ auto TrackListToExternalObjectListNode::update_georeference(
   map_georeference_ = msg.data;
 }
 
-
-} // namespace carma_cooperative_perception
+}  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -1,0 +1,111 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_cooperative_perception/external_object_list_to_detection_list_component.hpp"
+
+#include <rclcpp_components/register_node_macro.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "carma_cooperative_perception/geodetic.hpp"
+#include "carma_cooperative_perception/units_extensions.hpp"
+
+namespace carma_cooperative_perception
+{
+
+auto transform_from_map_origin_to_local( // improve name scheme
+  carma_cooperative_perception_interfaces::msg::TrackList track_list,
+  const std::string &map_origin) -> carma_cooperative_perception_interfaces::msg::DetectionList
+{
+
+    // TODO
+
+}
+
+
+TrackListToExternalObjectListNode::TrackListToExternalObjectListNode(
+  const rclcpp::NodeOptions & options)
+: CarmaLifecycleNode{options}
+{
+  lifecycle_publishers_.push_back(publisher_);
+  param_callback_handles_.push_back(on_set_parameters_callback_);
+}
+
+auto TrackListToExternalObjectListNode::handle_on_configure(
+  const rclcpp_lifecycle::State & /* previous_state */) -> carma_ros2_utils::CallbackReturn
+{
+  publisher_ = create_publisher<output_msg_type("output/external_objects_list", 1);
+
+  track_list_subscription = create_subscription<input_msg_type>(
+    "input/track_list", 1, [this](input_msg_shared_pointer msg_ptr){
+      const auto current_State{this->get_current_state().label()};
+
+      if(current_state == "active"){
+        publish_as_external_object_list(*msg_ptr);
+      } else{
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Trying to receive message on the topic '%s', but the containing node is not activated. "
+          "Current node state: '%s'",
+          this->track_subscription_->get_topic_name(), current_state.c_str()); 
+      }
+    });
+
+    // TODO
+
+}
+
+auto TrackListToExternalObjectListNode::handle_on_cleanup(
+  const rclcpp_lifecycle::State & /* previous_state */) -> carma_ros2_utils::CallbackReturn
+{
+  // CarmaLifecycleNode does not handle subscriber pointer reseting for us
+  track_subscription_.reset();
+  georeference_subscription_.reset();
+
+  return carma_ros2_utils::CallbackReturn::SUCCESS;
+}
+
+auto TrackListToExternalObjectListNode::handle_on_shutdown(
+  const rclcpp_lifecycle::State & /* previous_state */) -> carma_ros2_utils::CallbackReturn
+{
+  // CarmaLifecycleNode does not handle subscriber pointer reseting for us
+  track_subscription_.reset();
+  georeference_subscription_.reset();
+
+  return carma_ros2_utils::CallbackReturn::SUCCESS;
+}
+
+auto TrackListToExternalObjectListNode::publish_as_external_object_list(
+  const input_msg_type & msg) const -> void
+{
+  try {
+    const auto detection_list{transform_from_map_to_utm(
+      to_detection_list_msg(msg, motion_model_mapping_), map_georeference_)};
+
+    publisher_->publish(detection_list);
+  } catch (const std::invalid_argument & e) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Could not convert external object list to detection list: %s", e.what());
+  }
+}
+
+auto TrackListToExternalObjectListNode::update_georeference(
+  const std_msgs::msg::String & msg) noexcept -> void
+{
+  map_georeference_ = msg.data;
+}
+
+
+} // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
@@ -1,0 +1,35 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <carma_cooperative_perception/track_list_to_external_object_list_component.hpp>
+
+#include <memory>
+
+auto main(int argc, char * argv[]) noexcept -> int
+{
+  rclcpp::init(argc, argv);
+
+  auto node{std::make_shared<carma_cooperative_perception::TrackListToExternalObjectListNode>(
+    rclcpp::NodeOptions{})};
+    
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
@@ -24,7 +24,7 @@ auto main(int argc, char * argv[]) noexcept -> int
 
   auto node{std::make_shared<carma_cooperative_perception::TrackListToExternalObjectListNode>(
     rclcpp::NodeOptions{})};
-    
+
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());
   executor.spin();

--- a/carma_cooperative_perception/test/data/track_list.yaml
+++ b/carma_cooperative_perception/test/data/track_list.yaml
@@ -1,0 +1,7 @@
+---
+message_type: carma_cooperative_perception_interfaces/msg/TrackList
+message_fields:
+  tracks:
+  - id: "1"
+  - id: "2"
+  - id: "3"

--- a/carma_cooperative_perception/test/test_msg_conversion.cpp
+++ b/carma_cooperative_perception/test/test_msg_conversion.cpp
@@ -19,6 +19,8 @@
 #include <carma_perception_msgs/msg/external_object.hpp>
 #include <carma_perception_msgs/msg/external_object_list.hpp>
 
+#include <numeric>
+
 TEST(ToTimeMsg, HasSeconds)
 {
   carma_cooperative_perception::DDateTime d_date_time;
@@ -209,4 +211,189 @@ TEST(ToDetectionListMsg, FromExternalObjectList)
     carma_cooperative_perception::to_detection_list_msg(object_list, motion_model_mapping)};
 
   EXPECT_EQ(std::size(detection_list.detections), 2U);
+}
+
+TEST(ToExternalObject, FromTrack)
+{
+  carma_cooperative_perception_interfaces::msg::Track track;
+  track.header.stamp.sec = 1;
+  track.header.stamp.nanosec = 2;
+  track.header.frame_id = "test_frame";
+
+  track.id = "1234";
+
+  track.pose.pose.position.x = 1;
+  track.pose.pose.position.y = 2;
+  track.pose.pose.position.z = 3;
+
+  track.pose.pose.orientation.x = 4;
+  track.pose.pose.orientation.y = 5;
+  track.pose.pose.orientation.z = 6;
+  track.pose.pose.orientation.w = 7;
+
+  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  track.twist.twist.linear.x = 1;
+  track.twist.twist.linear.y = 2;
+  track.twist.twist.linear.z = 3;
+
+  track.twist.twist.angular.x = 4;
+  track.twist.twist.angular.y = 5;
+  track.twist.twist.angular.z = 6;
+
+  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
+
+  EXPECT_TRUE(external_object.presence_vector & external_object.ID_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.POSE_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR);
+
+  EXPECT_EQ(external_object.id, 1234U);
+
+  EXPECT_EQ(external_object.header, track.header);
+  EXPECT_EQ(external_object.pose, track.pose);
+  EXPECT_EQ(external_object.velocity, track.twist);
+}
+
+TEST(ToExternalObject, FromTrackNonNumericId)
+{
+  carma_cooperative_perception_interfaces::msg::Track track;
+  track.header.stamp.sec = 1;
+  track.header.stamp.nanosec = 2;
+  track.header.frame_id = "test_frame";
+
+  track.id = "abcd";
+
+  track.pose.pose.position.x = 1;
+  track.pose.pose.position.y = 2;
+  track.pose.pose.position.z = 3;
+
+  track.pose.pose.orientation.x = 4;
+  track.pose.pose.orientation.y = 5;
+  track.pose.pose.orientation.z = 6;
+  track.pose.pose.orientation.w = 7;
+
+  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  track.twist.twist.linear.x = 1;
+  track.twist.twist.linear.y = 2;
+  track.twist.twist.linear.z = 3;
+
+  track.twist.twist.angular.x = 4;
+  track.twist.twist.angular.y = 5;
+  track.twist.twist.angular.z = 6;
+
+  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
+
+  EXPECT_FALSE(external_object.presence_vector & external_object.ID_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.POSE_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR);
+
+  EXPECT_EQ(external_object.header, track.header);
+  EXPECT_EQ(external_object.pose, track.pose);
+  EXPECT_EQ(external_object.velocity, track.twist);
+}
+
+TEST(ToExternalObject, FromTrackNegativeId)
+{
+  carma_cooperative_perception_interfaces::msg::Track track;
+  track.header.stamp.sec = 1;
+  track.header.stamp.nanosec = 2;
+  track.header.frame_id = "test_frame";
+
+  track.id = "-1234";
+
+  track.pose.pose.position.x = 1;
+  track.pose.pose.position.y = 2;
+  track.pose.pose.position.z = 3;
+
+  track.pose.pose.orientation.x = 4;
+  track.pose.pose.orientation.y = 5;
+  track.pose.pose.orientation.z = 6;
+  track.pose.pose.orientation.w = 7;
+
+  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  track.twist.twist.linear.x = 1;
+  track.twist.twist.linear.y = 2;
+  track.twist.twist.linear.z = 3;
+
+  track.twist.twist.angular.x = 4;
+  track.twist.twist.angular.y = 5;
+  track.twist.twist.angular.z = 6;
+
+  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+
+  const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
+
+  EXPECT_FALSE(external_object.presence_vector & external_object.ID_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.POSE_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR);
+
+  EXPECT_EQ(external_object.header, track.header);
+  EXPECT_EQ(external_object.pose, track.pose);
+  EXPECT_EQ(external_object.velocity, track.twist);
+}
+
+TEST(ToExternalObject, FromTrackIdTooLarge)
+{
+  carma_cooperative_perception_interfaces::msg::Track track;
+  track.header.stamp.sec = 1;
+  track.header.stamp.nanosec = 2;
+  track.header.frame_id = "test_frame";
+
+  track.id = "5294967295";
+
+  track.pose.pose.position.x = 1;
+  track.pose.pose.position.y = 2;
+  track.pose.pose.position.z = 3;
+
+  track.pose.pose.orientation.x = 4;
+  track.pose.pose.orientation.y = 5;
+  track.pose.pose.orientation.z = 6;
+  track.pose.pose.orientation.w = 7;
+
+  std::iota(std::begin(track.pose.covariance), std::end(track.pose.covariance), 1U);
+
+  track.twist.twist.linear.x = 1;
+  track.twist.twist.linear.y = 2;
+  track.twist.twist.linear.z = 3;
+
+  track.twist.twist.angular.x = 4;
+  track.twist.twist.angular.y = 5;
+  track.twist.twist.angular.z = 6;
+
+  std::iota(std::begin(track.twist.covariance), std::end(track.twist.covariance), 1U);
+
+  const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
+
+  EXPECT_FALSE(external_object.presence_vector & external_object.ID_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.POSE_PRESENCE_VECTOR);
+  EXPECT_TRUE(external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR);
+
+  EXPECT_EQ(external_object.header, track.header);
+  EXPECT_EQ(external_object.pose, track.pose);
+  EXPECT_EQ(external_object.velocity, track.twist);
+}
+
+TEST(ToExternalObjectList, FromTrackList)
+{
+  carma_cooperative_perception_interfaces::msg::TrackList track_list;
+  track_list.tracks.push_back(carma_cooperative_perception_interfaces::msg::Track{});
+  track_list.tracks.push_back(carma_cooperative_perception_interfaces::msg::Track{});
+  track_list.tracks.push_back(carma_cooperative_perception_interfaces::msg::Track{});
+
+  const auto external_object_list{
+    carma_cooperative_perception::to_external_object_list_msg(track_list)};
+
+  ASSERT_EQ(std::size(external_object_list.objects), 3U);
 }

--- a/carma_cooperative_perception/test/test_msg_conversion.cpp
+++ b/carma_cooperative_perception/test/test_msg_conversion.cpp
@@ -231,8 +231,7 @@ TEST(ToExternalObject, FromTrack)
   track.pose.pose.orientation.z = 6;
   track.pose.pose.orientation.w = 7;
 
-  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.pose.covariance), std::end(track.pose.covariance), 1U);
 
   track.twist.twist.linear.x = 1;
   track.twist.twist.linear.y = 2;
@@ -242,8 +241,7 @@ TEST(ToExternalObject, FromTrack)
   track.twist.twist.angular.y = 5;
   track.twist.twist.angular.z = 6;
 
-  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.twist.covariance), std::end(track.twist.covariance), 1U);
 
   const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
 
@@ -276,8 +274,7 @@ TEST(ToExternalObject, FromTrackNonNumericId)
   track.pose.pose.orientation.z = 6;
   track.pose.pose.orientation.w = 7;
 
-  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.pose.covariance), std::end(track.pose.covariance), 1U);
 
   track.twist.twist.linear.x = 1;
   track.twist.twist.linear.y = 2;
@@ -287,8 +284,7 @@ TEST(ToExternalObject, FromTrackNonNumericId)
   track.twist.twist.angular.y = 5;
   track.twist.twist.angular.z = 6;
 
-  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.twist.covariance), std::end(track.twist.covariance), 1U);
 
   const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
 
@@ -319,8 +315,7 @@ TEST(ToExternalObject, FromTrackNegativeId)
   track.pose.pose.orientation.z = 6;
   track.pose.pose.orientation.w = 7;
 
-  track.pose.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                           19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.pose.covariance), std::end(track.pose.covariance), 1U);
 
   track.twist.twist.linear.x = 1;
   track.twist.twist.linear.y = 2;
@@ -330,8 +325,7 @@ TEST(ToExternalObject, FromTrackNegativeId)
   track.twist.twist.angular.y = 5;
   track.twist.twist.angular.z = 6;
 
-  track.twist.covariance = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
-                            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36};
+  std::iota(std::begin(track.twist.covariance), std::end(track.twist.covariance), 1U);
 
   const auto external_object{carma_cooperative_perception::to_external_object_msg(track)};
 

--- a/carma_cooperative_perception/test/track_list_to_external_object_list_launch_test.py
+++ b/carma_cooperative_perception/test/track_list_to_external_object_list_launch_test.py
@@ -1,0 +1,129 @@
+# Copyright 2023 Leidos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from ament_index_python import get_package_share_path
+
+from carma_launch_testing.transitions import transition_node
+from carma_launch_testing.predicates import LenIncreases
+from carma_launch_testing.spinning import spin_node_until
+
+import carma_message_utilities
+
+from carma_cooperative_perception_interfaces.msg import TrackList
+from carma_perception_msgs.msg import ExternalObjectList
+
+import launch_ros.actions
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+
+from launch_testing import post_shutdown_test
+from launch_testing.actions import ReadyToTest
+from launch_testing.asserts import assertExitCodes
+
+from lifecycle_msgs.msg import Transition
+
+import pytest
+
+import rclpy
+from rclpy.context import Context
+import rclpy.node
+
+
+class TestHarnessNode(rclpy.node.Node):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__("test_harness", *args, **kwargs)
+
+        self.track_list_list_pub = self.create_publisher(
+            TrackList, "input/track_list", 1
+        )
+
+        self.external_object_list_sub = self.create_subscription(
+            ExternalObjectList,
+            "output/external_object_list",
+            lambda msg: self.external_object_list_msgs.append(msg),
+            1,
+        )
+
+        self.external_object_list_msgs = []
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    node_under_test = launch_ros.actions.Node(
+        package="carma_cooperative_perception",
+        executable="track_list_to_external_object_list_node",
+        name="node_under_test",
+    )
+
+    launch_description = LaunchDescription(
+        [node_under_test, TimerAction(period=1.0, actions=[ReadyToTest()])]
+    )
+
+    return launch_description
+
+
+class TestMotionComputation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.context = Context()
+
+        rclpy.init(context=cls.context)
+        cls.test_harness_node = TestHarnessNode(context=cls.context)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+
+        rclpy.shutdown(context=cls.context)
+
+    def test_track_list_conversion(self):
+        transition_id = Transition.TRANSITION_CONFIGURE
+        transition_node("node_under_test", transition_id, self.context)
+
+        transition_id = Transition.TRANSITION_ACTIVATE
+        transition_node("node_under_test", transition_id, self.context)
+
+        package_share_path = get_package_share_path("carma_cooperative_perception")
+
+        msg_file = package_share_path / "test/data/track_list.yaml"
+        msg = carma_message_utilities.msg_from_yaml_file(msg_file)
+        self.test_harness_node.track_list_list_pub.publish(msg)
+
+        spin_node_until(
+            self.test_harness_node,
+            LenIncreases(self.test_harness_node.external_object_list_msgs),
+            self.context,
+        )
+
+        self.assertGreaterEqual(
+            len(self.test_harness_node.external_object_list_msgs), 0
+        )
+        external_object_list = self.test_harness_node.external_object_list_msgs[-1]
+
+        self.assertEqual(len(external_object_list.objects), 3)
+
+        self.assertEqual(external_object_list.objects[0].id, 1)
+        self.assertEqual(external_object_list.objects[1].id, 2)
+        self.assertEqual(external_object_list.objects[2].id, 3)
+
+
+@post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_codes(self, proc_info):
+        assertExitCodes(proc_info)


### PR DESCRIPTION
# PR Details
## Description

This PR adds a ROS 2 Node that converts incoming `carma_cooperative_perception_interfaces/msg/TrackList.msg` messages into `carma_perception_msgs/msg/ExternalObjectList.msg` ones. This conversion Node is necessary because the rest of CARMA Platform uses a different message format than the cooperative perception stack uses internally.

## Related GitHub Issue

Closes #2158

## Related Jira Key

[CDAR-253](https://usdot-carma.atlassian.net/browse/CDAR-253)

## Motivation and Context

See description

## How Has This Been Tested?

- Unit tests for the message conversion functions
- a launch test for the conversion Node

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-253]: https://usdot-carma.atlassian.net/browse/CDAR-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ