### PR TITLE
[cooperative perception] Add host vehicle filter node

### DIFF
--- a/carma_cooperative_perception/CMakeLists.txt
+++ b/carma_cooperative_perception/CMakeLists.txt
@@ -64,6 +64,7 @@ ament_auto_add_library(carma_cooperative_perception SHARED
   src/track_list_to_external_object_list_component.cpp
   src/utm_zone.cpp
   src/multiple_object_tracker_component.cpp
+  src/host_vehicle_filter_component.cpp
 )
 
 target_link_libraries(carma_cooperative_perception
@@ -95,6 +96,10 @@ ament_auto_add_executable(multiple_object_tracker_node
 
 ament_auto_add_executable(external_object_list_to_sdsm_node
   src/external_object_list_to_sdsm_node.cpp
+)
+
+ament_auto_add_executable(host_vehicle_filter_node
+  src/host_vehicle_filter_node.cpp
 )
 
 # boost::posix_time definition for using nanoseconds

--- a/carma_cooperative_perception/CMakeLists.txt
+++ b/carma_cooperative_perception/CMakeLists.txt
@@ -128,6 +128,7 @@ if(carma_cooperative_perception_BUILD_TESTS)
   add_launch_test(test/track_list_to_external_object_list_launch_test.py)
   add_launch_test(test/multiple_object_tracker_duplicates_launch_test.py)
   add_launch_test(test/multiple_object_tracker_static_obstacle_launch_test.py)
+  add_launch_test(test/host_vehicle_filter_launch_test.py)
 
 endif()
 

--- a/carma_cooperative_perception/config/params.yaml
+++ b/carma_cooperative_perception/config/params.yaml
@@ -3,3 +3,7 @@ multiple_object_tracker:
     execution_frequency_hz: 5.0
     track_promotion_threshold: 3
     track_removal_threshold: 0
+
+host_vehicle_filter:
+  ros__parameters:
+    distance_threshold: 2.0

--- a/carma_cooperative_perception/docs/host_vehicle_filter_node.md
+++ b/carma_cooperative_perception/docs/host_vehicle_filter_node.md
@@ -7,22 +7,24 @@ republish the (possibly pruned) list.
 
 ## Subscriptions
 
-| Topic                       | Message Type                                                | Description                     |
-| --------------------------- | ----------------------------------------------------------- | ------------------------------- |
-| `~/input/detections`        | `carma_cooperative_perception_interfaces/DetectionList.msg` | Incoming detections             |
-| `~/input/host_vehicle_pose` | `??`                                                        | The host vehicle's current pose |
+| Topic                       | Message Type                                                                      | Description                     |
+| --------------------------- | --------------------------------------------------------------------------------- | ------------------------------- |
+| `~/input/detection_list`    | [`carma_cooperative_perception_interfaces/DetectionList.msg`][detection_list_msg] | Incoming detections             |
+| `~/input/host_vehicle_pose` | [`geometry_msgs/PoseStamped.msg`][pose_stamped_msg]                               | The host vehicle's current pose |
+
+[pose_stamped_msg]: https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/PoseStamped.html
 
 ## Publishers
 
-| Topic                 | Message Type                                                | Frequency           | Description                                                                            |
-| --------------------- | ----------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- |
-| `~/output/detections` | `carma_cooperative_perception_interfaces/DetectionList.msg` | Subscription-driven | Incoming detections excluding any detections likely associating with the host vehicle. |
+| Topic                     | Message Type                                                                      | Frequency           | Description                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- |
+| `~/output/detection_list` | [`carma_cooperative_perception_interfaces/DetectionList.msg`][detection_list_msg] | Subscription-driven | Incoming detections excluding any detections likely associating with the host vehicle. |
 
 ## Parameters
 
 | Topic                  | Data Type | Default Value | Required | Read Only | Description                                                                       |
 | ---------------------- | --------- | ------------- | -------- | --------- | --------------------------------------------------------------------------------- |
-| `~/distance_threshold` | `float`   | ``            | No       | No        | Distance below which a detection will be considered to represent the host vehicle |
+| `~/distance_threshold` | `float`   | `0.0`         | No       | No        | Distance below which a detection will be considered to represent the host vehicle |
 
 ## Services
 
@@ -31,3 +33,5 @@ This Node does not provide services.
 ## Actions
 
 This Node does not provide actions.
+
+[detection_list_msg]: https://github.com/usdot-fhwa-stol/carma-msgs/blob/develop/carma_cooperative_perception_interfaces/msg/DetectionList.msg

--- a/carma_cooperative_perception/docs/host_vehicle_filter_node.md
+++ b/carma_cooperative_perception/docs/host_vehicle_filter_node.md
@@ -1,0 +1,33 @@
+# Host vehicle filter Node
+
+This Node removes detections that are likely to associate with the host vehicle. For each detection in the received
+detection list, the Node will check the distance between it and the host vehicle's current pose. Any detections that
+fall below the specified distance threshold will be pruned from the incoming detection list. The Node will then
+republish the (possibly pruned) list.
+
+## Subscriptions
+
+| Topic                       | Message Type                                                | Description                     |
+| --------------------------- | ----------------------------------------------------------- | ------------------------------- |
+| `~/input/detections`        | `carma_cooperative_perception_interfaces/DetectionList.msg` | Incoming detections             |
+| `~/input/host_vehicle_pose` | `??`                                                        | The host vehicle's current pose |
+
+## Publishers
+
+| Topic                 | Message Type                                                | Frequency           | Description                                                                            |
+| --------------------- | ----------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------- |
+| `~/output/detections` | `carma_cooperative_perception_interfaces/DetectionList.msg` | Subscription-driven | Incoming detections excluding any detections likely associating with the host vehicle. |
+
+## Parameters
+
+| Topic                  | Data Type | Default Value | Required | Read Only | Description                                                                       |
+| ---------------------- | --------- | ------------- | -------- | --------- | --------------------------------------------------------------------------------- |
+| `~/distance_threshold` | `float`   | ``            | No       | No        | Distance below which a detection will be considered to represent the host vehicle |
+
+## Services
+
+This Node does not provide services.
+
+## Actions
+
+This Node does not provide actions.

--- a/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
@@ -1,0 +1,60 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_COOPERATIVE_PERCEPTION__HOST_VEHICLE_FILTER_COMPONENT_HPP_
+#define CARMA_COOPERATIVE_PERCEPTION__HOST_VEHICLE_FILTER_COMPONENT_HPP_
+
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <carma_cooperative_perception_interfaces/msg/detection_list.hpp>
+
+namespace carma_cooperative_perception
+{
+
+class HostVehicleFilterNode : public carma_ros2_utils::CarmaLifecycleNode
+{
+public:
+  explicit HostVehicleFilterNode(const rclcpp::NodeOptions & options);
+
+  auto handle_on_configure(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_activate(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_deactivate(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_cleanup(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+  auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
+    -> carma_ros2_utils::CallbackReturn override;
+
+private:
+  rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
+    detection_list_sub_{nullptr};
+
+  rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
+    host_vehicle_pose_sub_{nullptr};
+
+  rclcpp_lifecycle::LifecyclePublisher<
+    carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr detection_list_pub_{
+    nullptr};
+};
+
+}  // namespace carma_cooperative_perception
+
+#endif  // CARMA_COOPERATIVE_PERCEPTION__HOST_VEHICLE_FILTER_COMPONENT_HPP_

--- a/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
@@ -15,10 +15,10 @@
 #ifndef CARMA_COOPERATIVE_PERCEPTION__HOST_VEHICLE_FILTER_COMPONENT_HPP_
 #define CARMA_COOPERATIVE_PERCEPTION__HOST_VEHICLE_FILTER_COMPONENT_HPP_
 
-#include <carma_ros2_utils/carma_lifecycle_node.hpp>
-#include <rclcpp/rclcpp.hpp>
-
 #include <carma_cooperative_perception_interfaces/msg/detection_list.hpp>
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace carma_cooperative_perception
 {
@@ -26,7 +26,7 @@ namespace carma_cooperative_perception
 class HostVehicleFilterNode : public carma_ros2_utils::CarmaLifecycleNode
 {
 public:
-  explicit HostVehicleFilterNode(const rclcpp::NodeOptions & options);
+  using carma_ros2_utils::CarmaLifecycleNode::CarmaLifecycleNode;
 
   auto handle_on_configure(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
@@ -43,17 +43,30 @@ public:
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
+  auto update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg) noexcept -> void;
+
+  auto attempt_filter_and_republish(
+    carma_cooperative_perception_interfaces::msg::DetectionList msg) noexcept -> void;
+
 private:
   rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
     detection_list_sub_{nullptr};
 
-  rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
-    host_vehicle_pose_sub_{nullptr};
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr host_vehicle_pose_sub_{nullptr};
 
   rclcpp_lifecycle::LifecyclePublisher<
     carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr detection_list_pub_{
     nullptr};
+
+  std::optional<geometry_msgs::msg::PoseStamped> host_vehicle_pose_{std::nullopt};
+
+  OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
+
+  double squared_distance_threshold_{0.0};
 };
+
+auto euclidean_distance_squared(
+  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) noexcept -> double;
 
 }  // namespace carma_cooperative_perception
 

--- a/carma_cooperative_perception/launch/cooperative_perception_launch.py
+++ b/carma_cooperative_perception/launch/cooperative_perception_launch.py
@@ -27,4 +27,11 @@ def generate_launch_description():
         parameters=[package_share_path / "config/params.yaml"],
     )
 
-    return LaunchDescription([multiple_object_tracker_node])
+    host_vehicle_filter_node = Node(
+        package="carma_cooperative_perception",
+        executable="host_vehicle_filter_node",
+        name="host_vehicle_filter",
+        parameters=[package_share_path / "config/params.yaml"],
+    )
+
+    return LaunchDescription([multiple_object_tracker_node, host_vehicle_filter_node])

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -1,0 +1,119 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_cooperative_perception/host_vehicle_filter_component.hpp"
+
+#include <carma_ros2_utils/carma_lifecycle_node.hpp>
+
+namespace carma_cooperative_perception
+{
+
+static auto pose_mahalanobis_distance(
+  const carma_cooperative_perception_interfaces::Detection & a,
+  const carma_cooperative_perception_interfaces::Detection & b) noexcept -> double
+{
+  return 0;
+}
+
+HostVehicleFilterNode::HostVehicleFilterNode(const rclcpp::NodeOptions & options)
+: CarmaLifecycleNode{options}
+{
+  lifecycle_publishers_.push_back(track_list_pub_);
+}
+
+auto handle_on_configure(const rclcpp_lifecycle::State & /* previous_state */)
+  -> carma_ros2_utils::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: configuring");
+
+  detection_list_sub_ = create_subscription<
+    carma_cooperative_perception_interfaces::msg::DetectionList>(
+    "input/detection_list", 1,
+    [this](const carma_cooperative_perception_interfaces::msg::DetectionList::SharedPtr msg_ptr) {
+      if (const auto current_state{this->get_current_state().label()}; current_state == "active") {
+        // ...
+      } else {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Trying to receive message on the topic '%s', but the containing node is not activated. "
+          "Current node state: '%s'",
+          this->detection_list_sub_->get_topic_name(), current_state.c_str());
+      }
+    });
+
+  host_vehicle_pose_sub_ =
+    create_subscription<>("input/host_vehicle_pose", 1, [this](const auto & msg_ptr) {
+      if (const auto current_state{this->get_current_state().label()}; current_state == "active") {
+        // ...
+      } else {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Trying to receive message on the topic '%s', but the containing node is not activated. "
+          "Current node state: '%s'",
+          this->detection_list_sub_->get_topic_name(), current_state.c_str());
+      }
+    });
+
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully configured");
+
+  return carma_ros2_utils::CallbackReturn::Success;
+}
+
+auto handle_on_activate(const rclcpp_lifecycle::State & /* previous_state */)
+  -> carma_ros2_utils::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: actiavting");
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully activated");
+
+  return carma_ros2_utils::CallbackReturn::Success;
+}
+
+auto handle_on_deactivate(const rclcpp_lifecycle::State & /* previous_state */)
+  -> carma_ros2_utils::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: deactivating");
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully deactivated");
+
+  return carma_ros2_utils::CallbackReturn::Success;
+}
+
+auto handle_on_cleanup(const rclcpp_lifecycle::State & /* previous_state */)
+  -> carma_ros2_utils::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: cleaning up");
+
+  // CarmaLifecycleNode does not handle subscriber pointer reseting for us
+  detection_list_sub_.reset();
+  host_vehicle_pose_sub_.reset();
+
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully cleaned up");
+
+  return carma_ros2_utils::CallbackReturn::Success;
+}
+
+auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
+  -> carma_ros2_utils::CallbackReturn
+{
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: shutting down");
+
+  // CarmaLifecycleNode does not handle subscriber pointer reseting for us
+  detection_list_sub_.reset();
+  host_vehicle_pose_sub_.reset();
+
+  RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully shut down");
+
+  return carma_ros2_utils::CallbackReturn::Success;
+}
+
+}  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -17,6 +17,8 @@
 #include <carma_cooperative_perception_interfaces/msg/detection.hpp>
 #include <carma_ros2_utils/carma_lifecycle_node.hpp>
 
+#include <vector>
+
 namespace carma_cooperative_perception
 {
 auto HostVehicleFilterNode::handle_on_configure(

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -160,7 +160,7 @@ auto HostVehicleFilterNode::attempt_filter_and_republish(
   carma_cooperative_perception_interfaces::msg::DetectionList msg) noexcept -> void
 {
   if (!host_vehicle_pose_.has_value()) {
-    RCLCPP_ERROR(get_logger(), "Could not filter detection list: host vehicle pose unknown");
+    RCLCPP_WARN(get_logger(), "Could not filter detection list: host vehicle pose unknown");
     return;
   }
 

--- a/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
@@ -1,0 +1,35 @@
+// Copyright 2023 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <carma_cooperative_perception/host_vehicle_filter_component.hpp>
+
+#include <memory>
+
+auto main(int argc, char * argv[]) noexcept -> int
+{
+  rclcpp::init(argc, argv);
+
+  auto node{
+    std::make_shared<carma_cooperative_perception::HostVehicleFilterNode>(rclcpp::NodeOptions{})};
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/carma_cooperative_perception/test/data/detection_list.yaml
+++ b/carma_cooperative_perception/test/data/detection_list.yaml
@@ -1,0 +1,19 @@
+---
+message_type: carma_cooperative_perception_interfaces/msg/DetectionList
+message_fields:
+  detections:
+    - id: "1"
+      pose:
+        pose:
+          position:
+            x: 1.0
+    - id: "2"
+      pose:
+        pose:
+          position:
+            x: 10.0
+    - id: "3"
+      pose:
+        pose:
+          position:
+            x: 20.0

--- a/carma_cooperative_perception/test/host_vehicle_filter_launch_test.py
+++ b/carma_cooperative_perception/test/host_vehicle_filter_launch_test.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Leidos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from ament_index_python import get_package_share_path
+
+from carma_launch_testing.transitions import transition_node
+from carma_launch_testing.predicates import LenIncreases
+from carma_launch_testing.spinning import spin_node_until
+
+import carma_message_utilities
+
+from carma_cooperative_perception_interfaces.msg import DetectionList
+
+from geometry_msgs.msg import PoseStamped
+
+import launch_ros.actions
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+
+from launch_testing import post_shutdown_test
+from launch_testing.actions import ReadyToTest
+from launch_testing.asserts import assertExitCodes
+
+from lifecycle_msgs.msg import Transition
+
+import pytest
+
+import rclpy
+from rclpy.context import Context
+import rclpy.node
+
+
+class TestHarnessNode(rclpy.node.Node):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__("test_harness", *args, **kwargs)
+
+        self.detection_list_pub = self.create_publisher(
+            DetectionList, "input/detection_list", 1
+        )
+
+        self.host_vehicle_pose_pub = self.create_publisher(
+            PoseStamped, "input/host_vehicle_pose", 1
+        )
+
+        self.detection_list_sub = self.create_subscription(
+            DetectionList,
+            "output/detection_list",
+            lambda msg: self.detection_list_msgs.append(msg),
+            1,
+        )
+
+        self.detection_list_msgs = []
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    node_under_test = launch_ros.actions.Node(
+        package="carma_cooperative_perception",
+        executable="host_vehicle_filter_node",
+        name="node_under_test",
+        parameters=[{"distance_threshold": 2.0}],
+    )
+
+    launch_description = LaunchDescription(
+        [node_under_test, TimerAction(period=1.0, actions=[ReadyToTest()])]
+    )
+
+    return launch_description
+
+
+class TestMotionComputation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.context = Context()
+
+        rclpy.init(context=cls.context)
+        cls.test_harness_node = TestHarnessNode(context=cls.context)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+
+        rclpy.shutdown(context=cls.context)
+
+    def test_track_list_conversion(self):
+        transition_id = Transition.TRANSITION_CONFIGURE
+        transition_node("node_under_test", transition_id, self.context)
+
+        transition_id = Transition.TRANSITION_ACTIVATE
+        transition_node("node_under_test", transition_id, self.context)
+
+        host_vehicle_pose = PoseStamped()
+        host_vehicle_pose.pose.position.x = 1.0
+
+        self.test_harness_node.host_vehicle_pose_pub.publish(host_vehicle_pose)
+
+        package_share_path = get_package_share_path("carma_cooperative_perception")
+
+        msg_file = package_share_path / "test/data/detection_list.yaml"
+        msg = carma_message_utilities.msg_from_yaml_file(msg_file)
+        self.test_harness_node.detection_list_pub.publish(msg)
+
+        spin_node_until(
+            self.test_harness_node,
+            LenIncreases(self.test_harness_node.detection_list_msgs),
+            self.context,
+        )
+
+        self.assertGreaterEqual(len(self.test_harness_node.detection_list_msgs), 0)
+        detection_list = self.test_harness_node.detection_list_msgs[-1]
+
+        self.assertEqual(len(detection_list.detections), 2)
+
+        self.assertEqual(detection_list.detections[0].id, '2')
+        self.assertEqual(detection_list.detections[1].id, '3')
+
+
+@post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_codes(self, proc_info):
+        assertExitCodes(proc_info)


### PR DESCRIPTION
# PR Details
## Description

This PR introduces a new Node in the cooperative perception stack to remove any incoming detections that likely represent the host vehicle. Detections are removed based on a configurable distance threshold from the host vehicle's current pose.

## Related GitHub Issue

Closes #2182

## Related Jira Key

Closes [CDAR-420](https://usdot-carma.atlassian.net/browse/CDAR-420)

## Motivation and Context

If we don't remove detections that are associated with the host vehicle's current pose, then it will appear that we are always colliding with an external object.

## How Has This Been Tested?

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-420]: https://usdot-carma.atlassian.net/browse/CDAR-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ