### PR TITLE
[cooperative perception] Move motion model mapping default values to `MotionModelMapping` class

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -72,11 +72,11 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
 
 struct MotionModelMapping
 {
-  std::uint8_t small_vehicle_model;
-  std::uint8_t large_vehicle_model;
-  std::uint8_t motorcycle_model;
-  std::uint8_t pedestrian_model;
-  std::uint8_t unknown_model;
+  std::uint8_t small_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t large_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t motorcycle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRA};
+  std::uint8_t pedestrian_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV};
+  std::uint8_t unknown_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV};
 };
 
 auto to_detection_msg(

--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -74,9 +74,9 @@ struct MotionModelMapping
 {
   std::uint8_t small_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
   std::uint8_t large_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
-  std::uint8_t motorcycle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRA};
-  std::uint8_t pedestrian_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV};
-  std::uint8_t unknown_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV};
+  std::uint8_t motorcycle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t pedestrian_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t unknown_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
 };
 
 auto to_detection_msg(

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -114,25 +114,11 @@ auto ExternalObjectListToDetectionListNode::handle_on_configure(
       }
     });
 
-  declare_parameter(
-    "small_vehicle_motion_model",
-    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV);
-
-  declare_parameter(
-    "large_vehicle_motion_model",
-    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV);
-
-  declare_parameter(
-    "motorcycle_motion_model",
-    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRA);
-
-  declare_parameter(
-    "pedestrian_motion_model",
-    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV);
-
-  declare_parameter(
-    "unknown_motion_model",
-    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CV);
+  declare_parameter("small_vehicle_motion_model", motion_model_mapping_.small_vehicle_model);
+  declare_parameter("large_vehicle_motion_model", motion_model_mapping_.large_vehicle_model);
+  declare_parameter("motorcycle_motion_model", motion_model_mapping_.motorcycle_model);
+  declare_parameter("pedestrian_motion_model", motion_model_mapping_.pedestrian_model);
+  declare_parameter("unknown_motion_model", motion_model_mapping_.unknown_model);
 
   on_set_parameters_callback_ =
     add_on_set_parameters_callback([this](const std::vector<rclcpp::Parameter> & parameters) {

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -114,12 +114,6 @@ auto ExternalObjectListToDetectionListNode::handle_on_configure(
       }
     });
 
-  declare_parameter("small_vehicle_motion_model", motion_model_mapping_.small_vehicle_model);
-  declare_parameter("large_vehicle_motion_model", motion_model_mapping_.large_vehicle_model);
-  declare_parameter("motorcycle_motion_model", motion_model_mapping_.motorcycle_model);
-  declare_parameter("pedestrian_motion_model", motion_model_mapping_.pedestrian_model);
-  declare_parameter("unknown_motion_model", motion_model_mapping_.unknown_model);
-
   on_set_parameters_callback_ =
     add_on_set_parameters_callback([this](const std::vector<rclcpp::Parameter> & parameters) {
       rcl_interfaces::msg::SetParametersResult result;
@@ -149,6 +143,19 @@ auto ExternalObjectListToDetectionListNode::handle_on_configure(
 
       return result;
     });
+
+  // TODO(Adam Morrissett): Look into how the motion model mapping can be re-architected
+  // to avoid requiring this sequence. Maybe something like a mapping class that calls the
+  // declared parameters. Then the to_detected_object() function could be templated on a
+  // mapping strategy.
+
+  // Declarations must come after on_set_parameters_callback_ assignment because the ROS
+  // runtime will call the callback if declare_parameter() succeeds.
+  declare_parameter("small_vehicle_motion_model", motion_model_mapping_.small_vehicle_model);
+  declare_parameter("large_vehicle_motion_model", motion_model_mapping_.large_vehicle_model);
+  declare_parameter("motorcycle_motion_model", motion_model_mapping_.motorcycle_model);
+  declare_parameter("pedestrian_motion_model", motion_model_mapping_.pedestrian_model);
+  declare_parameter("unknown_motion_model", motion_model_mapping_.unknown_model);
 
   return carma_ros2_utils::CallbackReturn::SUCCESS;
 }

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -112,7 +112,7 @@ auto make_detection(const carma_cooperative_perception_interfaces::msg::Detectio
       return make_ctra_detection(msg);
 
     case msg.MOTION_MODEL_CV:
-      break;
+      throw std::runtime_error("unsupported motion model type '3: constant velocity (CV)'");
   }
 
   throw std::runtime_error("unkown motion model type '" + std::to_string(msg.motion_model) + "'");


### PR DESCRIPTION
# PR Details
## Description

The default motion model mapping values were specified in the ROS parameter declarations, but this meant the `MotionModelMapper` instance never got them. Its values wouldn't be updated unless a user changed them. Now, the default values are stored in the class instance, and the ROS parameter declarations get their default values from the instance.

## Related GitHub Issue

Closes #2202 

## Related Jira Key

Closes [CDAR-531](https://usdot-carma.atlassian.net/browse/CDAR-531)

## Motivation and Context

See above

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-531]: https://usdot-carma.atlassian.net/browse/CDAR-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ