### PR TITLE
Remove conversion to UTM zone

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -72,11 +72,16 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
 
 struct MotionModelMapping
 {
-  std::uint8_t small_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
-  std::uint8_t large_vehicle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
-  std::uint8_t motorcycle_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
-  std::uint8_t pedestrian_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
-  std::uint8_t unknown_model{carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t small_vehicle_model{
+    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t large_vehicle_model{
+    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t motorcycle_model{
+    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t pedestrian_model{
+    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
+  std::uint8_t unknown_model{
+    carma_cooperative_perception_interfaces::msg::Detection::MOTION_MODEL_CTRV};
 };
 
 auto to_detection_msg(

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -184,10 +184,7 @@ auto ExternalObjectListToDetectionListNode::publish_as_detection_list(
   const input_msg_type & msg) const -> void
 {
   try {
-    const auto detection_list{transform_from_map_to_utm(
-      to_detection_list_msg(msg, motion_model_mapping_), map_georeference_)};
-
-    publisher_->publish(detection_list);
+    publisher_->publish(to_detection_list_msg(msg, motion_model_mapping_));
   } catch (const std::invalid_argument & e) {
     RCLCPP_ERROR(
       this->get_logger(), "Could not convert external object list to detection list: %s", e.what());

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -76,7 +76,8 @@ auto HostVehicleFilterNode::handle_on_configure(
             result.reason = "parameter is read-only while node is in 'Active' state";
 
             RCLCPP_ERROR(
-              get_logger(), "Cannot change parameter 'distance_threshold_meters': " + result.reason);
+              get_logger(),
+              "Cannot change parameter 'distance_threshold_meters': " + result.reason);
 
             break;
           }
@@ -86,7 +87,8 @@ auto HostVehicleFilterNode::handle_on_configure(
             result.reason = "parameter must be nonnegative";
 
             RCLCPP_ERROR(
-              get_logger(), "Cannot change parameter 'distance_threshold_meters': " + result.reason);
+              get_logger(),
+              "Cannot change parameter 'distance_threshold_meters': " + result.reason);
 
             break;
           } else {
@@ -190,10 +192,9 @@ auto euclidean_distance_squared(
 
 }  // namespace carma_cooperative_perception
 
-
 // This is not our macro, so we should not worry about linting it.
 // clang-tidy added support for ignoring system macros in release 14.0.0 (see the release notes
 // here: https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html), but
 // ament_clang_tidy for ROS 2 Foxy specifically looks for clang-tidy-6.0.
-RCLCPP_COMPONENTS_REGISTER_NODE(                               // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(                        // NOLINT
   carma_cooperative_perception::HostVehicleFilterNode)  // NOLINT


### PR DESCRIPTION
# PR Details
## Description

This PR removes the UTM zone conversions from the `ExternalObjectListToDetectionListNode`. Incoming detections use the map frame, and CARMA uses the map frame, so there is not point in converting to UTM then back to map.

## Related GitHub Issue

Closes #2204

## Related Jira Key

Closes [CDAR-545](https://usdot-carma.atlassian.net/browse/CDAR-545)

## Motivation and Context

This node was converting incoming detections to CARMA's current UTM zone, but the rest of CARMA uses the map frame, meaning we would have to do an unnecessary conversion back to the map frame.

## How Has This Been Tested?

Manually tested. Unit tests.

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-545]: https://usdot-carma.atlassian.net/browse/CDAR-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ