### PR TITLE
Use detections' covariance matrices in multiple object tracking

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -63,7 +63,12 @@ auto make_ctrv_detection(
     mot::Angle{units::angle::radian_t{yaw}},
     units::angular_velocity::radians_per_second_t{msg.twist.twist.angular.z}};
 
-  const mot::CtrvStateCovariance covariance = mot::CtrvStateCovariance::Zero();
+  mot::CtrvStateCovariance covariance = mot::CtrvStateCovariance::Zero();
+  covariance(0, 0) = msg.pose.covariance.at(0);
+  covariance(1, 1) = msg.pose.covariance.at(7);
+  covariance(2, 2) = msg.twist.covariance.at(0);
+  covariance(3, 3) = msg.pose.covariance.at(35);
+  covariance(4, 4) = msg.twist.covariance.at(35);
 
   return mot::CtrvDetection{timestamp, state, covariance, mot::Uuid{msg.id}};
 }
@@ -96,7 +101,13 @@ auto make_ctra_detection(
     units::angular_velocity::radians_per_second_t{msg.twist.twist.angular.z},
     units::acceleration::meters_per_second_squared_t{msg.accel.accel.linear.x}};
 
-  const mot::CtraStateCovariance covariance = mot::CtraStateCovariance::Zero();
+  mot::CtraStateCovariance covariance = mot::CtraStateCovariance::Zero();
+  covariance(0, 0) = msg.pose.covariance.at(0);
+  covariance(1, 1) = msg.pose.covariance.at(7);
+  covariance(2, 2) = msg.twist.covariance.at(0);
+  covariance(3, 3) = msg.pose.covariance.at(35);
+  covariance(4, 4) = msg.twist.covariance.at(35);
+  covariance(5, 5) = msg.accel.covariance.at(0);
 
   return mot::CtraDetection{timestamp, state, covariance, mot::Uuid{msg.id}};
 }


### PR DESCRIPTION
# PR Details
## Description

This PR modifies the `MultipleObjectTrackerComponent` to use incoming detections' actual covariance matrix values instead of the zero matrix.

## Related GitHub Issue

Closes #2215 

## Related Jira Key

Closes [CDAR-605](https://usdot-carma.atlassian.net/browse/CDAR-605)

## Motivation and Context

Using the incorrect covariance matrix will lead to tracking errors. Using the zero matrix leads to tracking system crashes.

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-605]: https://usdot-carma.atlassian.net/browse/CDAR-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ