### PR TITLE
Arbitrator should retry the failed service calls

### DIFF
--- a/arbitrator/include/capabilities_interface.hpp
+++ b/arbitrator/include/capabilities_interface.hpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <carma_planning_msgs/srv/plugin_list.hpp>
 #include <carma_planning_msgs/srv/get_plugin_api.hpp>
+#include <carma_planning_msgs/srv/plan_maneuvers.hpp>
+
 
 
 namespace arbitrator
@@ -80,6 +82,7 @@ namespace arbitrator
         protected:
         private:
             std::shared_ptr<carma_ros2_utils::CarmaLifecycleNode> nh_;
+            std::unordered_map<std::string,carma_ros2_utils::ClientPtr<carma_planning_msgs::srv::PlanManeuvers>> registered_strategic_plugins_;
 
             carma_ros2_utils::ClientPtr<carma_planning_msgs::srv::GetPluginApi> sc_s_;
             std::unordered_set <std::string> capabilities_ ;

--- a/arbitrator/include/capabilities_interface.tpp
+++ b/arbitrator/include/capabilities_interface.tpp
@@ -73,7 +73,7 @@ namespace arbitrator
                 try {
                     using std::literals::chrono_literals::operator""ms;
 
-                    if (registered_strategic_plugins_.find(topic) == registered_strategic_plugins_.end())
+                    if (registered_strategic_plugins_.count(topic) == 0)
                         registered_strategic_plugins_[topic] = nh_->create_client<carma_planning_msgs::srv::PlanManeuvers>(topic);
 
                     auto client = registered_strategic_plugins_[topic];
@@ -92,6 +92,8 @@ namespace arbitrator
                         case std::future_status::ready:
                             responses.emplace(topic, response.get());
                             break;
+                        case std::future_status::deferred:
+                        case std::future_status::timeout:
                         default:
                             RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "failed...: " << topic);
                     }

--- a/arbitrator/include/capabilities_interface.tpp
+++ b/arbitrator/include/capabilities_interface.tpp
@@ -94,9 +94,14 @@ namespace arbitrator
                             responses.emplace(topic, response.get());
                             break;
                         case std::future_status::deferred:
+                            RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "service call to " << topic << " is deferred... Please check if the plugin is active");
+                            break;
                         case std::future_status::timeout:
+                            RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "service call to " << topic << " is timed out... Please check if the plugin is active");
+                            break;
                         default:
-                            RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "failed...: " << topic);
+                            RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "service call to " << topic << " is failed... Please check if the plugin is active");
+                            break;
                     }
                     if (retry_attempt > 0)
                     {

--- a/arbitrator/include/capabilities_interface.tpp
+++ b/arbitrator/include/capabilities_interface.tpp
@@ -84,6 +84,7 @@ namespace arbitrator
                     {
                         topics_to_retry.push_back(topic);
                         RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "Following client timed out: " << topic << ", retrying, attempt no: " << retry_attempt);
+                        continue;
                     }
 
                     const auto response = client->async_send_request(msg);

--- a/arbitrator/src/tree_planner.cpp
+++ b/arbitrator/src/tree_planner.cpp
@@ -103,8 +103,8 @@ namespace arbitrator
 
         if (final_open_list.empty())
         {
-            RCLCPP_ERROR_STREAM(rclcpp::get_logger("arbitrator"), "None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator...");
-            throw std::runtime_error("None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator...");
+            RCLCPP_ERROR_STREAM(rclcpp::get_logger("arbitrator"), "None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers...");
+            throw std::runtime_error("None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers...");
         }
 
         final_open_list = search_strategy_->prioritize_plans(final_open_list);

--- a/arbitrator/src/tree_planner.cpp
+++ b/arbitrator/src/tree_planner.cpp
@@ -22,7 +22,7 @@
 
 namespace arbitrator
 {
-    carma_planning_msgs::msg::ManeuverPlan TreePlanner::generate_plan(const VehicleState& start_state) 
+    carma_planning_msgs::msg::ManeuverPlan TreePlanner::generate_plan(const VehicleState& start_state)
     {
         carma_planning_msgs::msg::ManeuverPlan root;
         std::vector<std::pair<carma_planning_msgs::msg::ManeuverPlan, double>> open_list_to_evaluate;
@@ -33,7 +33,7 @@ namespace arbitrator
 
         carma_planning_msgs::msg::ManeuverPlan longest_plan = root; // Track longest plan in case target length is never reached
         rclcpp::Duration longest_plan_duration = rclcpp::Duration(0);
-        
+
 
         while (!open_list_to_evaluate.empty())
         {
@@ -45,39 +45,39 @@ namespace arbitrator
                 carma_planning_msgs::msg::ManeuverPlan cur_plan = it->first;
 
                 RCLCPP_DEBUG_STREAM(rclcpp::get_logger("arbitrator"), "START");
-                
+
                 for (auto mvr : cur_plan.maneuvers)
                 {
                     RCLCPP_DEBUG_STREAM(rclcpp::get_logger("arbitrator"), "Printing cur_plan: mvr: "<< (int)mvr.type);
-                }   
+                }
 
                 RCLCPP_DEBUG_STREAM(rclcpp::get_logger("arbitrator"), "PRINT END");
 
                 auto plan_duration = rclcpp::Duration(0, 0); // zero duration
 
                 // If we're not at the root, plan_duration is nonzero (our plan should have maneuvers)
-                if (!cur_plan.maneuvers.empty()) 
+                if (!cur_plan.maneuvers.empty())
                 {
                     // get plan duration
-                    plan_duration = arbitrator_utils::get_plan_end_time(cur_plan) - arbitrator_utils::get_plan_start_time(cur_plan); 
+                    plan_duration = arbitrator_utils::get_plan_end_time(cur_plan) - arbitrator_utils::get_plan_start_time(cur_plan);
                 }
-                
+
                 // save longest if none of the plans have enough target duration
-                if (plan_duration > longest_plan_duration) 
+                if (plan_duration > longest_plan_duration)
                 {
                     longest_plan_duration = plan_duration;
                     longest_plan = cur_plan;
                 }
 
                 // Evaluate plan_duration is sufficient do not expand more
-                if (plan_duration >= target_plan_duration_) 
+                if (plan_duration >= target_plan_duration_)
                 {
                     final_open_list.push_back((*it));
                     RCLCPP_DEBUG_STREAM(rclcpp::get_logger("arbitrator"), "Has enough duration, skipping that which has following mvrs..:");
                     for (auto mvr : it->first.maneuvers)
                     {
                         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("arbitrator"), "Printing mvr: "<< (int)mvr.type);
-                    }  
+                    }
                     continue;
                 }
 
@@ -87,18 +87,24 @@ namespace arbitrator
                 // Compute cost for each child and store in open list
                 for (auto child = children.begin(); child != children.end(); child++)
                 {
-                    
+
                     if (child->maneuvers.empty())
                     {
                         RCLCPP_WARN_STREAM(rclcpp::get_logger("arbitrator"), "Child was empty for id: " << std::string(child->maneuver_plan_id));
-                        continue;   
+                        continue;
                     }
 
                     temp_open_list.push_back(std::make_pair(*child, cost_function_->compute_cost_per_unit_distance(*child)));
                 }
             }
-            
+
             open_list_to_evaluate = temp_open_list;
+        }
+
+        if (final_open_list.empty())
+        {
+            RCLCPP_ERROR_STREAM(rclcpp::get_logger("arbitrator"), "None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator...");
+            throw std::runtime_error("None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator...");
         }
 
         final_open_list = search_strategy_->prioritize_plans(final_open_list);
@@ -111,10 +117,10 @@ namespace arbitrator
             rclcpp::Duration plan_duration(0,0); // zero duration
 
             // get plan duration
-            plan_duration = arbitrator_utils::get_plan_end_time(cur_plan) - arbitrator_utils::get_plan_start_time(cur_plan); 
+            plan_duration = arbitrator_utils::get_plan_end_time(cur_plan) - arbitrator_utils::get_plan_start_time(cur_plan);
 
             // Evaluate plan_duration is sufficient do not expand more
-            if (plan_duration >= target_plan_duration_) 
+            if (plan_duration >= target_plan_duration_)
             {
                 return cur_plan;
             }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR caches the strategic_plugin clients previously created instead of recreating it every 1hz as before.
This PR adds a guard for when none of the strategic plugins return any valid maneuvers (due to ROS failing the service calls or somehow the node froze or shut down), arbitrator should shut down with error. Currently there is no guard for empty responses, which I am guessing is the potential segfault place. Tested it by running platform and forcing shut down the only available strategic plugin and got the following error:

> [environment_perception_controller-8] 1703074934.381615035 | INFO | on_system_alert:59 | Received SystemAlert message of type: 6 with message: SHUTDOWN /guidance subsytem has failed with error: Uncaught Exception from node: arbitrator exception: None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator... while in ACTIVE state.
[v2x_controller-19] 1703074934.381624890 | INFO | on_system_alert:59 | Received SystemAlert message of type: 6 with message: SHUTDOWN /guidance subsytem has failed with error: Uncaught Exception from node: arbitrator exception: None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator... while in ACTIVE state.
[drivers_controller-2] 1703074934.381628844 | INFO | on_system_alert:59 | Received SystemAlert message of type: 6 with message: SHUTDOWN /guidance subsytem has failed with error: Uncaught Exception from node: arbitrator exception: None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator... while in ACTIVE state.
[guidance_controller-32] 1703074934.381633900 | INFO | on_system_alert:59 | Received SystemAlert message of type: 6 with message: SHUTDOWN /guidance subsytem has failed with error: Uncaught Exception from node: arbitrator exception: None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator... while in ACTIVE state.
[localization_controller-17] 1703074934.381671092 | INFO | on_system_alert:59 | Received SystemAlert message of type: 6 with message: SHUTDOWN /guidance subsytem has failed with error: Uncaught Exception from node: arbitrator exception: None of the strategic plugins generated any valid plans! Please check if any is turned and returning valid maneuvers, shutting down arbitrator... while in ACTIVE state.
[localization_controller-17] 1703074934.381698191 | INFO | on_system_alert:79 | Alert not from a sensor node. Alerting node: /system_controller
[INFO] [system_controller-35]: process has finished cleanly [pid 388]

- this PR also added functionality to retry some of the strategic_plugin service calls because sometimes they could fail due to ROS unknown DDS error. Since strategic plugins are only ran at 1Hz, it is relatively important that we don't miss this planning. So added retry attempt, and the most calls are successful only in its 2nd or 3rd try on Simulation PC1 with fastdds rmw. These failed service calls gave a clue that arbitrator maybe segfaulting if by chance none of the strategic plugins' service call succeeded (or had non-empty maneuver). 

## Related GitHub Issue
Potentially fixes this issue: https://github.com/usdot-fhwa-stol/carma-platform/issues/2245
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-631
CDAR-631
<!-- e.g. CAR-123 -->

## Motivation and Context
integration testing VRU use case in simulation
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Simulation PC 1
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
