### PR TITLE
[cooperative perception] Add semantic class to message generation

### DIFF
--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -273,15 +273,20 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
     switch (common_data.obj_type.object_type) {
       case common_data.obj_type.ANIMAL:
         detection.motion_model = detection.MOTION_MODEL_CTRV;
+        // We don't have a good semantic class mapping for animals
+        detection.semantic_class = detection.SEMANTIC_CLASS_UNKNOWN;
         break;
       case common_data.obj_type.VRU:
         detection.motion_model = detection.MOTION_MODEL_CTRV;
+        detection.semantic_class = detection.SEMANTIC_CLASS_PEDESTRIAN;
         break;
       case common_data.obj_type.VEHICLE:
         detection.motion_model = detection.MOTION_MODEL_CTRV;
+        detection.semantic_class = detection.SEMANTIC_CLASS_SMALL_VEHICLE;
         break;
       default:
         detection.motion_model = detection.MOTION_MODEL_CTRV;
+        detection.semantic_class = detection.SEMANTIC_CLASS_UNKNOWN;
     }
 
     detection_list.detections.push_back(std::move(detection));

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -322,19 +322,24 @@ auto to_detection_msg(
     switch (object.object_type) {
       case object.SMALL_VEHICLE:
         detection.motion_model = motion_model_mapping.small_vehicle_model;
+        detection.semantic_class = detection.SEMANTIC_CLASS_SMALL_VEHICLE;
         break;
       case object.LARGE_VEHICLE:
         detection.motion_model = motion_model_mapping.large_vehicle_model;
+        detection.semantic_class = detection.SEMANTIC_CLASS_LARGE_VEHICLE;
         break;
       case object.MOTORCYCLE:
         detection.motion_model = motion_model_mapping.motorcycle_model;
+        detection.semantic_class = detection.SEMANTIC_CLASS_MOTORCYCLE;
         break;
       case object.PEDESTRIAN:
         detection.motion_model = motion_model_mapping.pedestrian_model;
+        detection.semantic_class = detection.SEMANTIC_CLASS_PEDESTRIAN;
         break;
       case object.UNKNOWN:
       default:
         detection.motion_model = motion_model_mapping.unknown_model;
+        detection.semantic_class = detection.SEMANTIC_CLASS_UNKNOWN;
     }
   }
 
@@ -383,6 +388,25 @@ auto to_external_object_msg(
 
   external_object.presence_vector |= external_object.VELOCITY_PRESENCE_VECTOR;
   external_object.velocity = track.twist;
+
+  external_object.presence_vector |= external_object.OBJECT_TYPE_PRESENCE_VECTOR;
+  switch (track.semantic_class) {
+    case track.SEMANTIC_CLASS_SMALL_VEHICLE:
+      external_object.object_type = external_object.SMALL_VEHICLE;
+      break;
+    case track.SEMANTIC_CLASS_LARGE_VEHICLE:
+      external_object.object_type = external_object.LARGE_VEHICLE;
+      break;
+    case track.SEMANTIC_CLASS_MOTORCYCLE:
+      external_object.object_type = external_object.MOTORCYCLE;
+      break;
+    case track.SEMANTIC_CLASS_PEDESTRIAN:
+      external_object.object_type = external_object.PEDESTRIAN;
+      break;
+    case track.SEMANTIC_CLASS_UNKNOWN:
+    default:
+      external_object.object_type = external_object.UNKNOWN;
+  };
 
   return external_object;
 }


### PR DESCRIPTION
# PR Details
## Description

This PR adds semantic class information to the CP stack. Downstream CARMA components, such as the motion computation node, relies on this information to choose the appropriate propagation model. Previously, the semantic class information was being droppped.

## Related GitHub Issue

Closes #2232 

## Related Jira Key

Closes [CDAR-621](https://usdot-carma.atlassian.net/browse/CDAR-621)

## Motivation and Context

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-621]: https://usdot-carma.atlassian.net/browse/CDAR-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ