### PR TITLE
[cooperative perception] Add improved error logging for PROJ

### DIFF
--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -40,7 +40,8 @@ auto transform_from_map_to_utm(
 
   if (map_transformation == nullptr) {
     const std::string error_string{proj_errno_string(proj_context_errno(context))};
-    throw std::invalid_argument("Could not create PROJ transform: " + error_string + '.');
+    throw std::invalid_argument(
+      "Could not create PROJ transform to origin '" + map_origin + "': " + error_string + '.');
   }
 
   std::vector<carma_cooperative_perception_interfaces::msg::Detection> new_detections;


### PR DESCRIPTION
# PR Details
## Description

This PR adds improved logging for PROJ transform failures. When PROJ fails to create a transformation, it throws an error. The error string we were using did not include information about the target frame.

## Related GitHub Issue

Closes #2206 

## Related Jira Key

Closes [CDAR-547](https://usdot-carma.atlassian.net/browse/CDAR-547)

## Motivation and Context

Quality of life/debugging enhancement.

## How Has This Been Tested?

Manually 

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-547]: https://usdot-carma.atlassian.net/browse/CDAR-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ