### PR TITLE
[cooperative perception] Add "map" to external object list frame ID

### DIFF
--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -80,6 +80,7 @@ auto TrackListToExternalObjectListNode::publish_as_external_object_list(
 {
   auto external_object_list{to_external_object_list_msg(msg)};
   external_object_list.header.stamp = now();
+  external_object_list.header.frame_id = "map";
 
   publisher_->publish(external_object_list);
 }
@@ -90,4 +91,5 @@ auto TrackListToExternalObjectListNode::publish_as_external_object_list(
 // clang-tidy added support for ignoring system macros in release 14.0.0 (see the release notes
 // here: https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html), but
 // ament_clang_tidy for ROS 2 Foxy specifically looks for clang-tidy-6.0.
-RCLCPP_COMPONENTS_REGISTER_NODE(carma_cooperative_perception::TrackListToExternalObjectListNode)  // NOLINT
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  carma_cooperative_perception::TrackListToExternalObjectListNode)  // NOLINT


### PR DESCRIPTION
# PR Details
## Description

The `TrackListToExternalObjectListNode` was not setting the `frame_id` for the message, which caused visualization issues for downstream packages.

## Related GitHub Issue

Closes #2214 

## Related Jira Key

Closes [CDAR-597](https://usdot-carma.atlassian.net/browse/CDAR-597)

## Motivation and Context

Needed for visualizing external objects in rviz/foxglove studio

## How Has This Been Tested?

Manually in integration tests

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-597]: https://usdot-carma.atlassian.net/browse/CDAR-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ