### PR TITLE
[cooperative percepion] Reorder parameter declaration for host vehicle filter

### DIFF
--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -61,8 +61,6 @@ auto HostVehicleFilterNode::handle_on_configure(
 
   RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully configured");
 
-  declare_parameter("distance_threshold_meters", 0.0);
-
   on_set_parameters_callback_ =
     add_on_set_parameters_callback([this](const std::vector<rclcpp::Parameter> & parameters) {
       rcl_interfaces::msg::SetParametersResult result;
@@ -103,6 +101,8 @@ auto HostVehicleFilterNode::handle_on_configure(
 
       return result;
     });
+
+  declare_parameter("distance_threshold_meters", 0.0);
 
   return carma_ros2_utils::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
# PR Details
## Description

This PR moves the filter distance parameter declaration for the host vehicle filter component to be after the `on_set_parameter` callback declaration. The parameter declaration should come after the on_set_parameters callback because declaring a new parameter will call the registered callback. This is what allows us to modify the distance threshold.

## Related GitHub Issue

Closes #2236 

## Related Jira Key

Closes [CDAR-625](https://usdot-carma.atlassian.net/browse/CDAR-625)

## Motivation and Context

This was preventing the distance threshold from being updated in launch files.

## How Has This Been Tested?

Manually in integration tests.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-625]: https://usdot-carma.atlassian.net/browse/CDAR-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ