### PR TITLE
[cooperative perception] Convert body frame velocities to map frame

### DIFF
--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -382,7 +382,20 @@ auto to_external_object_msg(
   external_object.pose = track.pose;
 
   external_object.presence_vector |= external_object.VELOCITY_PRESENCE_VECTOR;
-  external_object.velocity = track.twist;
+
+  const auto track_longitudinal_velocity{track.twist.twist.linear.x};
+  const auto track_orientation = track.pose.pose.orientation;
+
+  tf2::Quaternion q(
+    track_orientation.x, track_orientation.y, track_orientation.z, track_orientation.w);
+  tf2::Matrix3x3 m(q);
+  double roll, pitch, yaw;
+  m.getRPY(roll, pitch, yaw);
+
+  external_object.velocity.twist.linear.x = track_longitudinal_velocity * std::cos(yaw);
+  external_object.velocity.twist.linear.y = track_longitudinal_velocity * std::sin(yaw);
+
+  external_object.object_type = track.semantic_class;
 
   return external_object;
 }
@@ -473,8 +486,8 @@ auto to_detected_object_data_msg(
 
   // speed/speed_z - convert vector velocity to scalar speed val given x/y components
   if (external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR) {
-    detected_object_common_data.speed.speed = std::hypot(
-      external_object.velocity.twist.linear.x, external_object.velocity.twist.linear.y);
+    detected_object_common_data.speed.speed =
+      std::hypot(external_object.velocity.twist.linear.x, external_object.velocity.twist.linear.y);
 
     detected_object_common_data.presence_vector |=
       carma_v2x_msgs::msg::DetectedObjectCommonData::HAS_SPEED_Z;


### PR DESCRIPTION
# PR Details
## Description

This PR fixes the twist frame mismatch between the CP stack's outputted tracks and the rest of CARMA's conventions. The track to external object conversion function now also converts twist frames.

## Related GitHub Issue

Closes #2238 

## Related Jira Key

Closes [CDAR-626](https://usdot-carma.atlassian.net/browse/CDAR-626)

## Motivation and Context

The frame mismatch was causing issues for downstream components.

## How Has This Been Tested?

Manually in integration testing.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-626]: https://usdot-carma.atlassian.net/browse/CDAR-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ