### PR TITLE
LCI Tactical plugin cuts trajectory based on distamce not on time

### DIFF
--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -14,6 +14,7 @@
  * the License.
  */
 #include "light_controlled_intersection_tactical_plugin/light_controlled_intersection_tactical_plugin_node.hpp"
+#include <valarray>
 
 namespace light_controlled_intersection_tactical_plugin
 {
@@ -119,24 +120,25 @@ namespace light_controlled_intersection_tactical_plugin
             RCLCPP_DEBUG_STREAM(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Not all variables are set...");
         }
 
-        carma_planning_msgs::msg::TrajectoryPlan reduced_last_traj;
-        std::vector<double> reduced_final_speeds;
+
 
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "traj points size: " << last_trajectory_.trajectory_points.size() << ", last_final_speeds_ size: " <<
                             last_final_speeds_.size() );
 
+        size_t idx_to_start_new_traj = 0;
         for (size_t i = 0; i < last_trajectory_.trajectory_points.size(); i++)
         {
-            if ((rclcpp::Time(last_trajectory_.trajectory_points[i].target_time) > rclcpp::Time(req->header.stamp) - rclcpp::Duration(0.1 * 1e9))) // Duration is in nanoseconds
+            auto dist = sqrt(pow(veh_pos.x() - last_trajectory_.trajectory_points.at(i).x, 2) + std::pow(veh_pos.y() - last_trajectory_.trajectory_points.at(i).y, 2));
+
+            if (dist < 2.0) // reduce until if 2 meters away
             {
-                reduced_last_traj.trajectory_points.emplace_back(last_trajectory_.trajectory_points[i]);
-                reduced_final_speeds.emplace_back(last_final_speeds_[i]);
+                idx_to_start_new_traj = i;
+                break;
             }
         }
 
-        last_final_speeds_ = reduced_final_speeds;
-        last_trajectory_.trajectory_points = reduced_last_traj.trajectory_points;
-
+        last_final_speeds_ = std::vector<double>(last_final_speeds_.begin() + idx_to_start_new_traj, last_final_speeds_.end());
+        last_trajectory_.trajectory_points = std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>(last_trajectory_.trajectory_points.begin() + idx_to_start_new_traj, last_trajectory_.trajectory_points.end());
 
         if (is_last_case_successful_ != boost::none && last_case_ != boost::none
             && last_case_.get() == new_case
@@ -249,7 +251,7 @@ namespace light_controlled_intersection_tactical_plugin
         }
         else
         {
-            RCLCPP_DEBUG(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Ignored Object Avoidance");
+            RCLCPP_ERROR(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Ignored Object Avoidance");
         }
 
         resp->maneuver_status.push_back(carma_planning_msgs::srv::PlanTrajectory::Response::MANEUVER_IN_PROGRESS);

--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -251,7 +251,7 @@ namespace light_controlled_intersection_tactical_plugin
         }
         else
         {
-            RCLCPP_ERROR(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Ignored Object Avoidance");
+            RCLCPP_DEBUG(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Ignored Object Avoidance");
         }
 
         resp->maneuver_status.push_back(carma_planning_msgs::srv::PlanTrajectory::Response::MANEUVER_IN_PROGRESS);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Previously, LCI tactical plugin would remove outdated trajectory points based on time. 
Although most tactical plugins regenerate trajectories every 0.1 seconds, this plugin is designed to keep the last trajectory if it is still "valid" according to its purpose. Initial reason why it was designed that way is because the algorithm to generate this trajectory can be noisy and may introduce undesirable deviations. So this makes the trajectory generation more stable.
Since the plugin cannot be using old trajectory forever, so the intention was to chop the "outdated" trajectory points and if it runs out of available points, the plugin would be forced to generate a new one. 

However, the plugin previously determined the outdated trajectory by looking at its time, which is changed to distance here. This is because if the controller reacts to the trajectory slow, the trajectory may not get used effectively before it gets shopped due to outdated time until new trajectory is forced from the strategic plugin. Therefore, the plugin should really use distance. 

This has not been an issue on live vehicle because they react faster than how CARLA's simulation controller is reacting.

<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2006
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-628
CDAR-628
<!-- e.g. CAR-123 -->

## Motivation and Context
Integration testing VRU on Simulation PC 1
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing VRU on Simulation PC 1
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
