### PR TITLE
Relocate MultipleObjectTrackerNode params

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -265,15 +265,6 @@ auto MultipleObjectTrackerNode::handle_on_configure(
       }
     });
 
-  declare_parameter(
-    "execution_frequency_hz", mot::remove_units(units::frequency::hertz_t{1 / execution_period_}));
-
-  declare_parameter(
-    "track_promotion_threshold", static_cast<int>(track_manager_.get_promotion_threshold().value));
-
-  declare_parameter(
-    "track_removal_threshold", static_cast<int>(track_manager_.get_promotion_threshold().value));
-
   on_set_parameters_callback_ =
     add_on_set_parameters_callback([this](const std::vector<rclcpp::Parameter> & parameters) {
       rcl_interfaces::msg::SetParametersResult result;
@@ -337,6 +328,15 @@ auto MultipleObjectTrackerNode::handle_on_configure(
 
       return result;
     });
+
+  declare_parameter(
+    "execution_frequency_hz", mot::remove_units(units::frequency::hertz_t{1 / execution_period_}));
+
+  declare_parameter(
+    "track_promotion_threshold", static_cast<int>(track_manager_.get_promotion_threshold().value));
+
+  declare_parameter(
+    "track_removal_threshold", static_cast<int>(track_manager_.get_promotion_threshold().value));
 
   RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully configured");
 


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a parameter update issue for changing parameters through launch files. Relocate parameter declarations to after the on_set_parameters callback declaration. This is needed because declaring parameters will trigger the callback, which needs to be set in order for the parameter changes to take effect.

## Related GitHub Issue

Closes #2243 

## Related Jira Key

Closes [CDAR-630](https://usdot-carma.atlassian.net/browse/CDAR-630)

## Motivation and Context

## How Has This Been Tested?

Manually through integration testing.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-630]: https://usdot-carma.atlassian.net/browse/CDAR-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ