### PR TITLE
[cooperative perception] Remove all noexcept specifiers from function declarations

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_detection_list_component.hpp
@@ -55,7 +55,7 @@ public:
 
   auto publish_as_detection_list(const input_msg_type & msg) const -> void;
 
-  auto update_georeference(const std_msgs::msg::String & msg)  -> void;
+  auto update_georeference(const std_msgs::msg::String & msg) -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};

--- a/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_detection_list_component.hpp
@@ -55,7 +55,7 @@ public:
 
   auto publish_as_detection_list(const input_msg_type & msg) const -> void;
 
-  auto update_georeference(const std_msgs::msg::String & msg) noexcept -> void;
+  auto update_georeference(const std_msgs::msg::String & msg)  -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<output_msg_type>::SharedPtr publisher_{nullptr};

--- a/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_sdsm_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_sdsm_component.hpp
@@ -53,9 +53,9 @@ public:
 
   auto publish_as_sdsm(const external_objects_msg_type & msg) const -> void;
 
-  auto update_georeference(const georeference_msg_type & proj_string) noexcept -> void;
+  auto update_georeference(const georeference_msg_type & proj_string)  -> void;
 
-  auto update_current_pose(const pose_msg_type & pose) noexcept -> void;
+  auto update_current_pose(const pose_msg_type & pose)  -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<sdsm_msg_type>::SharedPtr sdsm_publisher_{nullptr};

--- a/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_sdsm_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/external_object_list_to_sdsm_component.hpp
@@ -53,9 +53,9 @@ public:
 
   auto publish_as_sdsm(const external_objects_msg_type & msg) const -> void;
 
-  auto update_georeference(const georeference_msg_type & proj_string)  -> void;
+  auto update_georeference(const georeference_msg_type & proj_string) -> void;
 
-  auto update_current_pose(const pose_msg_type & pose)  -> void;
+  auto update_current_pose(const pose_msg_type & pose) -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<sdsm_msg_type>::SharedPtr sdsm_publisher_{nullptr};

--- a/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
@@ -65,8 +65,8 @@ struct UtmDisplacement
  *
  * @return Reference to the coordinate's updated position
 */
-inline constexpr auto operator+=(
-  UtmCoordinate & coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate &
+inline constexpr auto operator+=(UtmCoordinate & coordinate, const UtmDisplacement & displacement)
+  -> UtmCoordinate &
 {
   coordinate.easting += displacement.easting;
   coordinate.northing += displacement.northing;
@@ -83,8 +83,8 @@ inline constexpr auto operator+=(
  *
  * @return A new UtmCoordinate representing the new position
 */
-inline constexpr auto operator+(
-  UtmCoordinate coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate
+inline constexpr auto operator+(UtmCoordinate coordinate, const UtmDisplacement & displacement)
+  -> UtmCoordinate
 {
   return coordinate += displacement;
 }
@@ -97,8 +97,8 @@ inline constexpr auto operator+(
  *
  * @return A new UtmCoordinate representing the new position
 */
-inline constexpr auto operator+(
-  const UtmDisplacement & displacement, UtmCoordinate coordinate)  -> UtmCoordinate
+inline constexpr auto operator+(const UtmDisplacement & displacement, UtmCoordinate coordinate)
+  -> UtmCoordinate
 {
   return coordinate += displacement;
 }
@@ -111,8 +111,8 @@ inline constexpr auto operator+(
  *
  * @return Reference to the coordinate's updated position
 */
-inline constexpr auto operator-=(
-  UtmCoordinate & coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate &
+inline constexpr auto operator-=(UtmCoordinate & coordinate, const UtmDisplacement & displacement)
+  -> UtmCoordinate &
 {
   coordinate.easting += displacement.easting;
   coordinate.northing += displacement.northing;
@@ -129,8 +129,8 @@ inline constexpr auto operator-=(
  *
  * @return A new UtmCoordinate representing the new position
 */
-inline constexpr auto operator-(
-  UtmCoordinate coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate
+inline constexpr auto operator-(UtmCoordinate coordinate, const UtmDisplacement & displacement)
+  -> UtmCoordinate
 {
   return coordinate -= displacement;
 }
@@ -143,8 +143,8 @@ inline constexpr auto operator-(
  *
  * @return A new UtmCoordinate representing the new position
 */
-inline constexpr auto operator-(
-  const UtmDisplacement & displacement, UtmCoordinate coordinate)  -> UtmCoordinate
+inline constexpr auto operator-(const UtmDisplacement & displacement, UtmCoordinate coordinate)
+  -> UtmCoordinate
 {
   return coordinate -= displacement;
 }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
@@ -66,7 +66,7 @@ struct UtmDisplacement
  * @return Reference to the coordinate's updated position
 */
 inline constexpr auto operator+=(
-  UtmCoordinate & coordinate, const UtmDisplacement & displacement) noexcept -> UtmCoordinate &
+  UtmCoordinate & coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate &
 {
   coordinate.easting += displacement.easting;
   coordinate.northing += displacement.northing;
@@ -84,7 +84,7 @@ inline constexpr auto operator+=(
  * @return A new UtmCoordinate representing the new position
 */
 inline constexpr auto operator+(
-  UtmCoordinate coordinate, const UtmDisplacement & displacement) noexcept -> UtmCoordinate
+  UtmCoordinate coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate
 {
   return coordinate += displacement;
 }
@@ -98,7 +98,7 @@ inline constexpr auto operator+(
  * @return A new UtmCoordinate representing the new position
 */
 inline constexpr auto operator+(
-  const UtmDisplacement & displacement, UtmCoordinate coordinate) noexcept -> UtmCoordinate
+  const UtmDisplacement & displacement, UtmCoordinate coordinate)  -> UtmCoordinate
 {
   return coordinate += displacement;
 }
@@ -112,7 +112,7 @@ inline constexpr auto operator+(
  * @return Reference to the coordinate's updated position
 */
 inline constexpr auto operator-=(
-  UtmCoordinate & coordinate, const UtmDisplacement & displacement) noexcept -> UtmCoordinate &
+  UtmCoordinate & coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate &
 {
   coordinate.easting += displacement.easting;
   coordinate.northing += displacement.northing;
@@ -130,7 +130,7 @@ inline constexpr auto operator-=(
  * @return A new UtmCoordinate representing the new position
 */
 inline constexpr auto operator-(
-  UtmCoordinate coordinate, const UtmDisplacement & displacement) noexcept -> UtmCoordinate
+  UtmCoordinate coordinate, const UtmDisplacement & displacement)  -> UtmCoordinate
 {
   return coordinate -= displacement;
 }
@@ -144,7 +144,7 @@ inline constexpr auto operator-(
  * @return A new UtmCoordinate representing the new position
 */
 inline constexpr auto operator-(
-  const UtmDisplacement & displacement, UtmCoordinate coordinate) noexcept -> UtmCoordinate
+  const UtmDisplacement & displacement, UtmCoordinate coordinate)  -> UtmCoordinate
 {
   return coordinate -= displacement;
 }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
@@ -43,10 +43,10 @@ public:
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
-  auto update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg)  -> void;
+  auto update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg) -> void;
 
-  auto attempt_filter_and_republish(
-    carma_cooperative_perception_interfaces::msg::DetectionList msg)  -> void;
+  auto attempt_filter_and_republish(carma_cooperative_perception_interfaces::msg::DetectionList msg)
+    -> void;
 
 private:
   rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
@@ -66,7 +66,7 @@ private:
 };
 
 auto euclidean_distance_squared(
-  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)  -> double;
+  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) -> double;
 
 }  // namespace carma_cooperative_perception
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/host_vehicle_filter_component.hpp
@@ -43,10 +43,10 @@ public:
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
-  auto update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg) noexcept -> void;
+  auto update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg)  -> void;
 
   auto attempt_filter_and_republish(
-    carma_cooperative_perception_interfaces::msg::DetectionList msg) noexcept -> void;
+    carma_cooperative_perception_interfaces::msg::DetectionList msg)  -> void;
 
 private:
   rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
@@ -66,7 +66,7 @@ private:
 };
 
 auto euclidean_distance_squared(
-  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) noexcept -> double;
+  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)  -> double;
 
 }  // namespace carma_cooperative_perception
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
@@ -43,7 +43,7 @@ struct DDateTime
   std::optional<units::time::second_t> second;
   std::optional<units::time::minute_t> time_zone_offset;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) noexcept
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::DDateTime & msg)
     -> DDateTime;
 };
 
@@ -54,10 +54,10 @@ struct AccelerationSet4Way
   units::acceleration::two_centi_standard_gravities_t vert;
   units::angular_velocity::centi_degrees_per_second_t yaw_rate;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::AccelerationSet4Way & msg) noexcept
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::AccelerationSet4Way & msg)
     -> AccelerationSet4Way;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::AccelerationSet4Way & msg) noexcept
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::AccelerationSet4Way & msg)
     -> AccelerationSet4Way;
 };
 
@@ -67,10 +67,10 @@ struct Position3D
   units::angle::deci_micro_degrees_t longitude{0.0};
   std::optional<units::length::deca_centimeters_t> elevation;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Position3D & msg) noexcept
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Position3D & msg)
     -> Position3D;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Position3D & msg) noexcept
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Position3D & msg)
     -> Position3D;
 };
 
@@ -78,10 +78,10 @@ struct Heading
 {
   units::angle::eighth_deci_degrees_t heading;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Heading & heading) noexcept
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Heading & heading)
     -> Heading;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Heading & heading) noexcept
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Heading & heading)
     -> Heading;
 };
 
@@ -89,9 +89,9 @@ struct Speed
 {
   units::velocity::two_centi_meters_per_second_t speed;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Speed & speed) noexcept -> Speed;
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Speed & speed)  -> Speed;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Speed & speed) noexcept -> Speed;
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Speed & speed)  -> Speed;
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
@@ -43,8 +43,7 @@ struct DDateTime
   std::optional<units::time::second_t> second;
   std::optional<units::time::minute_t> time_zone_offset;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::DDateTime & msg)
-    -> DDateTime;
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) -> DDateTime;
 };
 
 struct AccelerationSet4Way
@@ -67,31 +66,27 @@ struct Position3D
   units::angle::deci_micro_degrees_t longitude{0.0};
   std::optional<units::length::deca_centimeters_t> elevation;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Position3D & msg)
-    -> Position3D;
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Position3D & msg) -> Position3D;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Position3D & msg)
-    -> Position3D;
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Position3D & msg) -> Position3D;
 };
 
 struct Heading
 {
   units::angle::eighth_deci_degrees_t heading;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Heading & heading)
-    -> Heading;
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Heading & heading) -> Heading;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Heading & heading)
-    -> Heading;
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Heading & heading) -> Heading;
 };
 
 struct Speed
 {
   units::velocity::two_centi_meters_per_second_t speed;
 
-  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Speed & speed)  -> Speed;
+  [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::Speed & speed) -> Speed;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Speed & speed)  -> Speed;
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::Speed & speed) -> Speed;
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/j3224_types.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/j3224_types.hpp
@@ -31,10 +31,10 @@ struct PositionOffsetXYZ
   units::length::decimeter_t offset_y{0.0};
   std::optional<units::length::decimeter_t> offset_z;
 
-  [[nodiscard]] static auto from_msg(const j3224_v2x_msgs::msg::PositionOffsetXYZ & msg) noexcept
+  [[nodiscard]] static auto from_msg(const j3224_v2x_msgs::msg::PositionOffsetXYZ & msg)
     -> PositionOffsetXYZ;
 
-  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & msg) noexcept
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & msg)
     -> PositionOffsetXYZ;
 };
 
@@ -43,10 +43,10 @@ struct MeasurementTimeOffset
   units::time::millisecond_t measurement_time_offset;
 
   [[nodiscard]] static auto from_msg(
-    const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg) noexcept -> MeasurementTimeOffset;
+    const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset;
 
   [[nodiscard]] static auto from_msg(
-    const carma_v2x_msgs::msg::MeasurementTimeOffset & msg) noexcept -> MeasurementTimeOffset;
+    const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset;
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/j3224_types.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/j3224_types.hpp
@@ -42,11 +42,11 @@ struct MeasurementTimeOffset
 {
   units::time::millisecond_t measurement_time_offset;
 
-  [[nodiscard]] static auto from_msg(
-    const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset;
+  [[nodiscard]] static auto from_msg(const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)
+    -> MeasurementTimeOffset;
 
-  [[nodiscard]] static auto from_msg(
-    const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset;
+  [[nodiscard]] static auto from_msg(const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)
+    -> MeasurementTimeOffset;
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/month.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/month.hpp
@@ -36,14 +36,14 @@ public:
    *
    * @param[in] month_value Numerical value of the month; typically between [1, 12]
   */
-  constexpr explicit Month(std::uint8_t month_value)  : month_value_{month_value} {}
+  constexpr explicit Month(std::uint8_t month_value) : month_value_{month_value} {}
 
   /**
    * @brief Pre-increment operator overload
    *
    * @return Reference to Month instance being incremented
   */
-  constexpr auto operator++()  -> Month &
+  constexpr auto operator++() -> Month &
   {
     constexpr auto jan_value{1U};
     constexpr auto dec_value{12U};
@@ -64,7 +64,7 @@ public:
    *
    * @return Copy of Month instance before it was incremented
   */
-  constexpr auto operator++(int /* dummy parameter */)  -> Month
+  constexpr auto operator++(int /* dummy parameter */) -> Month
   {
     Month previous{*this};
     ++(*this);
@@ -77,7 +77,7 @@ public:
    *
    * @return Reference to Month instance being decremented
   */
-  constexpr auto operator--()  -> Month &
+  constexpr auto operator--() -> Month &
   {
     constexpr auto dec_value{12U};
 
@@ -97,7 +97,7 @@ public:
    *
    * @return Copy of Month instance before it was decremented
   */
-  constexpr auto operator--(int /* dummy parameter */)  -> Month
+  constexpr auto operator--(int /* dummy parameter */) -> Month
   {
     Month previous{*this};
     --(*this);
@@ -108,17 +108,14 @@ public:
   /**
    * @brief Conversion function to convert Month instance to unsigned type
   */
-  constexpr explicit operator unsigned() const
-  {
-    return static_cast<unsigned>(month_value_);
-  }
+  constexpr explicit operator unsigned() const { return static_cast<unsigned>(month_value_); }
 
   /**
    * @brief Checks if Month instance's value is within valid Gregorian calendar range
    *
    * @return true if Month instance's value is within [1, 12]; false otherwise
   */
-  [[nodiscard]] constexpr auto ok() const  -> bool
+  [[nodiscard]] constexpr auto ok() const -> bool
   {
     constexpr auto jan_value{1U};
     constexpr auto dec_value{12U};
@@ -134,7 +131,7 @@ public:
    *
    * @return true is Month instances are equal; false otherwise
   */
-  friend constexpr auto operator==(const Month & x, const Month & y)  -> bool
+  friend constexpr auto operator==(const Month & x, const Month & y) -> bool
   {
     return x.month_value_ == y.month_value_;
   }
@@ -147,10 +144,7 @@ public:
    *
    * @return true is Month instances are not equal; false otherwise
   */
-  friend constexpr auto operator!=(const Month & x, const Month & y)  -> bool
-  {
-    return !(x == y);
-  }
+  friend constexpr auto operator!=(const Month & x, const Month & y) -> bool { return !(x == y); }
 
   /**
    * @brief Check if one Month instance is less than another
@@ -160,7 +154,7 @@ public:
    *
    * @return true is x comes before y in the calendar; false otherwise
   */
-  friend constexpr auto operator<(const Month & x, const Month & y)  -> bool
+  friend constexpr auto operator<(const Month & x, const Month & y) -> bool
   {
     return x.month_value_ < y.month_value_;
   }
@@ -173,7 +167,7 @@ public:
    *
    * @return true is x comes before y in the calendar or if instances are equal; false otherwise
   */
-  friend constexpr auto operator<=(const Month & x, const Month & y)  -> bool
+  friend constexpr auto operator<=(const Month & x, const Month & y) -> bool
   {
     return x < y || x == y;
   }
@@ -186,7 +180,7 @@ public:
    *
    * @return true is x comes after y in the calendar; false otherwise
   */
-  friend constexpr auto operator>(const Month & x, const Month & y)  -> bool
+  friend constexpr auto operator>(const Month & x, const Month & y) -> bool
   {
     return x.month_value_ > y.month_value_;
   }
@@ -199,7 +193,7 @@ public:
    *
    * @return true is x comes after y in the calendar or if instances are equal; false otherwise
   */
-  friend constexpr auto operator>=(const Month & x, const Month & y)  -> bool
+  friend constexpr auto operator>=(const Month & x, const Month & y) -> bool
   {
     return x > y || x == y;
   }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/month.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/month.hpp
@@ -36,14 +36,14 @@ public:
    *
    * @param[in] month_value Numerical value of the month; typically between [1, 12]
   */
-  constexpr explicit Month(std::uint8_t month_value) noexcept : month_value_{month_value} {}
+  constexpr explicit Month(std::uint8_t month_value)  : month_value_{month_value} {}
 
   /**
    * @brief Pre-increment operator overload
    *
    * @return Reference to Month instance being incremented
   */
-  constexpr auto operator++() noexcept -> Month &
+  constexpr auto operator++()  -> Month &
   {
     constexpr auto jan_value{1U};
     constexpr auto dec_value{12U};
@@ -64,7 +64,7 @@ public:
    *
    * @return Copy of Month instance before it was incremented
   */
-  constexpr auto operator++(int /* dummy parameter */) noexcept -> Month
+  constexpr auto operator++(int /* dummy parameter */)  -> Month
   {
     Month previous{*this};
     ++(*this);
@@ -77,7 +77,7 @@ public:
    *
    * @return Reference to Month instance being decremented
   */
-  constexpr auto operator--() noexcept -> Month &
+  constexpr auto operator--()  -> Month &
   {
     constexpr auto dec_value{12U};
 
@@ -97,7 +97,7 @@ public:
    *
    * @return Copy of Month instance before it was decremented
   */
-  constexpr auto operator--(int /* dummy parameter */) noexcept -> Month
+  constexpr auto operator--(int /* dummy parameter */)  -> Month
   {
     Month previous{*this};
     --(*this);
@@ -108,7 +108,7 @@ public:
   /**
    * @brief Conversion function to convert Month instance to unsigned type
   */
-  constexpr explicit operator unsigned() const noexcept
+  constexpr explicit operator unsigned() const
   {
     return static_cast<unsigned>(month_value_);
   }
@@ -118,7 +118,7 @@ public:
    *
    * @return true if Month instance's value is within [1, 12]; false otherwise
   */
-  [[nodiscard]] constexpr auto ok() const noexcept -> bool
+  [[nodiscard]] constexpr auto ok() const  -> bool
   {
     constexpr auto jan_value{1U};
     constexpr auto dec_value{12U};
@@ -134,7 +134,7 @@ public:
    *
    * @return true is Month instances are equal; false otherwise
   */
-  friend constexpr auto operator==(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator==(const Month & x, const Month & y)  -> bool
   {
     return x.month_value_ == y.month_value_;
   }
@@ -147,7 +147,7 @@ public:
    *
    * @return true is Month instances are not equal; false otherwise
   */
-  friend constexpr auto operator!=(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator!=(const Month & x, const Month & y)  -> bool
   {
     return !(x == y);
   }
@@ -160,7 +160,7 @@ public:
    *
    * @return true is x comes before y in the calendar; false otherwise
   */
-  friend constexpr auto operator<(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator<(const Month & x, const Month & y)  -> bool
   {
     return x.month_value_ < y.month_value_;
   }
@@ -173,7 +173,7 @@ public:
    *
    * @return true is x comes before y in the calendar or if instances are equal; false otherwise
   */
-  friend constexpr auto operator<=(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator<=(const Month & x, const Month & y)  -> bool
   {
     return x < y || x == y;
   }
@@ -186,7 +186,7 @@ public:
    *
    * @return true is x comes after y in the calendar; false otherwise
   */
-  friend constexpr auto operator>(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator>(const Month & x, const Month & y)  -> bool
   {
     return x.month_value_ > y.month_value_;
   }
@@ -199,7 +199,7 @@ public:
    *
    * @return true is x comes after y in the calendar or if instances are equal; false otherwise
   */
-  friend constexpr auto operator>=(const Month & x, const Month & y) noexcept -> bool
+  friend constexpr auto operator>=(const Month & x, const Month & y)  -> bool
   {
     return x > y || x == y;
   }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -40,34 +40,34 @@
 
 namespace carma_cooperative_perception
 {
-auto to_time_msg(const DDateTime & d_date_time) noexcept -> builtin_interfaces::msg::Time;
+auto to_time_msg(const DDateTime & d_date_time)  -> builtin_interfaces::msg::Time;
 
-auto calc_detection_time_stamp(DDateTime d_date_time, const MeasurementTimeOffset & offset) noexcept
+auto calc_detection_time_stamp(DDateTime d_date_time, const MeasurementTimeOffset & offset)
   -> DDateTime;
 
-auto to_ddate_time_msg(const builtin_interfaces::msg::Time & builtin_time) noexcept
+auto to_ddate_time_msg(const builtin_interfaces::msg::Time & builtin_time)
   -> j2735_v2x_msgs::msg::DDateTime;
 
 auto calc_sdsm_time_offset(
   const builtin_interfaces::msg::Time & external_object_list_time,
-  const builtin_interfaces::msg::Time & external_object_time) noexcept
+  const builtin_interfaces::msg::Time & external_object_time)
   -> carma_v2x_msgs::msg::MeasurementTimeOffset;
 
-auto to_position_msg(const UtmCoordinate & position_utm) noexcept -> geometry_msgs::msg::Point;
+auto to_position_msg(const UtmCoordinate & position_utm)  -> geometry_msgs::msg::Point;
 
-auto heading_to_enu_yaw(const units::angle::degree_t & heading) noexcept -> units::angle::degree_t;
+auto heading_to_enu_yaw(const units::angle::degree_t & heading)  -> units::angle::degree_t;
 
 auto calc_relative_position(
   const geometry_msgs::msg::PoseStamped & current_pose,
-  const carma_v2x_msgs::msg::PositionOffsetXYZ & detected_object_data) noexcept
+  const carma_v2x_msgs::msg::PositionOffsetXYZ & detected_object_data)
   -> carma_v2x_msgs::msg::PositionOffsetXYZ;
 
 auto transform_pose_from_map_to_wgs84(
   const geometry_msgs::msg::PoseStamped & source_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::Position3D;
 
-auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm) noexcept
+auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm)
   -> carma_cooperative_perception_interfaces::msg::DetectionList;
 
 struct MotionModelMapping
@@ -86,36 +86,35 @@ struct MotionModelMapping
 
 auto to_detection_msg(
   const carma_perception_msgs::msg::ExternalObject & object,
-  const MotionModelMapping & motion_model_mapping) noexcept
+  const MotionModelMapping & motion_model_mapping)
   -> carma_cooperative_perception_interfaces::msg::Detection;
 
 auto to_detection_list_msg(
   const carma_perception_msgs::msg::ExternalObjectList & object_list,
-  const MotionModelMapping & motion_model_mapping) noexcept
-  -> carma_cooperative_perception_interfaces::msg::DetectionList;
+  const MotionModelMapping & motion_model_mapping)   -> carma_cooperative_perception_interfaces::msg::DetectionList;
 
 auto to_external_object_msg(
-  const carma_cooperative_perception_interfaces::msg::Track & track) noexcept
+  const carma_cooperative_perception_interfaces::msg::Track & track)
   -> carma_perception_msgs::msg::ExternalObject;
 
 auto to_external_object_list_msg(
-  const carma_cooperative_perception_interfaces::msg::TrackList & track_list) noexcept
+  const carma_cooperative_perception_interfaces::msg::TrackList & track_list)
   -> carma_perception_msgs::msg::ExternalObjectList;
 
 auto to_sdsm_msg(
   const carma_perception_msgs::msg::ExternalObjectList & external_object_list,
   const geometry_msgs::msg::PoseStamped & current_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::SensorDataSharingMessage;
 
 auto to_detected_object_data_msg(
   const carma_perception_msgs::msg::ExternalObject & external_object,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::DetectedObjectData;
 
 auto enu_orientation_to_true_heading(
   double yaw, const lanelet::BasicPoint3d & obj_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> units::angle::degree_t;
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -40,7 +40,7 @@
 
 namespace carma_cooperative_perception
 {
-auto to_time_msg(const DDateTime & d_date_time)  -> builtin_interfaces::msg::Time;
+auto to_time_msg(const DDateTime & d_date_time) -> builtin_interfaces::msg::Time;
 
 auto calc_detection_time_stamp(DDateTime d_date_time, const MeasurementTimeOffset & offset)
   -> DDateTime;
@@ -53,9 +53,9 @@ auto calc_sdsm_time_offset(
   const builtin_interfaces::msg::Time & external_object_time)
   -> carma_v2x_msgs::msg::MeasurementTimeOffset;
 
-auto to_position_msg(const UtmCoordinate & position_utm)  -> geometry_msgs::msg::Point;
+auto to_position_msg(const UtmCoordinate & position_utm) -> geometry_msgs::msg::Point;
 
-auto heading_to_enu_yaw(const units::angle::degree_t & heading)  -> units::angle::degree_t;
+auto heading_to_enu_yaw(const units::angle::degree_t & heading) -> units::angle::degree_t;
 
 auto calc_relative_position(
   const geometry_msgs::msg::PoseStamped & current_pose,
@@ -91,10 +91,10 @@ auto to_detection_msg(
 
 auto to_detection_list_msg(
   const carma_perception_msgs::msg::ExternalObjectList & object_list,
-  const MotionModelMapping & motion_model_mapping)   -> carma_cooperative_perception_interfaces::msg::DetectionList;
+  const MotionModelMapping & motion_model_mapping)
+  -> carma_cooperative_perception_interfaces::msg::DetectionList;
 
-auto to_external_object_msg(
-  const carma_cooperative_perception_interfaces::msg::Track & track)
+auto to_external_object_msg(const carma_cooperative_perception_interfaces::msg::Track & track)
   -> carma_perception_msgs::msg::ExternalObject;
 
 auto to_external_object_list_msg(

--- a/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
@@ -59,7 +59,7 @@ public:
     -> carma_ros2_utils::CallbackReturn override;
 
   auto store_new_detections(
-    const carma_cooperative_perception_interfaces::msg::DetectionList & msg) noexcept -> void;
+    const carma_cooperative_perception_interfaces::msg::DetectionList & msg)  -> void;
 
   auto execute_pipeline() -> void;
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
@@ -33,7 +33,8 @@ namespace carma_cooperative_perception
 
 using Detection =
   std::variant<multiple_object_tracking::CtrvDetection, multiple_object_tracking::CtraDetection>;
-using Track = std::variant<multiple_object_tracking::CtrvTrack, multiple_object_tracking::CtraTrack>;
+using Track =
+  std::variant<multiple_object_tracking::CtrvTrack, multiple_object_tracking::CtraTrack>;
 
 auto make_detection(const carma_cooperative_perception_interfaces::msg::Detection & msg)
   -> Detection;
@@ -58,8 +59,8 @@ public:
   auto handle_on_shutdown(const rclcpp_lifecycle::State & /* previous_state */)
     -> carma_ros2_utils::CallbackReturn override;
 
-  auto store_new_detections(
-    const carma_cooperative_perception_interfaces::msg::DetectionList & msg)  -> void;
+  auto store_new_detections(const carma_cooperative_perception_interfaces::msg::DetectionList & msg)
+    -> void;
 
   auto execute_pipeline() -> void;
 
@@ -75,7 +76,8 @@ private:
   std::vector<Detection> detections_;
   std::unordered_map<multiple_object_tracking::Uuid, std::size_t> uuid_index_map_;
   multiple_object_tracking::FixedThresholdTrackManager<Track> track_manager_{
-    multiple_object_tracking::PromotionThreshold{3U}, multiple_object_tracking::RemovalThreshold{0U}};
+    multiple_object_tracking::PromotionThreshold{3U},
+    multiple_object_tracking::RemovalThreshold{0U}};
   units::time::nanosecond_t execution_period_{1 / units::frequency::hertz_t{2.0}};
   OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
 };

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -39,7 +39,7 @@ public:
   {
   }
 
-  auto sdsm_msg_callback(const input_msg_type & msg) const noexcept -> void
+  auto sdsm_msg_callback(const input_msg_type & msg) const  -> void
   {
     publisher_->publish(to_detection_list_msg(msg));
   }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -39,7 +39,7 @@ public:
   {
   }
 
-  auto sdsm_msg_callback(const input_msg_type & msg) const  -> void
+  auto sdsm_msg_callback(const input_msg_type & msg) const -> void
   {
     publisher_->publish(to_detection_list_msg(msg));
   }

--- a/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
@@ -44,7 +44,7 @@ public:
     -> carma_ros2_utils::CallbackReturn override;
 
   auto publish_as_external_object_list(
-    const carma_cooperative_perception_interfaces::msg::TrackList & msg) const noexcept -> void;
+    const carma_cooperative_perception_interfaces::msg::TrackList & msg) const  -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<carma_perception_msgs::msg::ExternalObjectList>::SharedPtr

--- a/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/track_list_to_external_object_list_component.hpp
@@ -44,7 +44,7 @@ public:
     -> carma_ros2_utils::CallbackReturn override;
 
   auto publish_as_external_object_list(
-    const carma_cooperative_perception_interfaces::msg::TrackList & msg) const  -> void;
+    const carma_cooperative_perception_interfaces::msg::TrackList & msg) const -> void;
 
 private:
   rclcpp_lifecycle::LifecyclePublisher<carma_perception_msgs::msg::ExternalObjectList>::SharedPtr

--- a/carma_cooperative_perception/include/carma_cooperative_perception/units_extensions.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/units_extensions.hpp
@@ -22,7 +22,7 @@
 namespace carma_cooperative_perception
 {
 template <typename T>
-constexpr auto remove_units(const T & value) noexcept
+constexpr auto remove_units(const T & value)
 {
   return units::unit_cast<typename T::underlying_type>(value);
 }

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -192,7 +192,7 @@ auto ExternalObjectListToDetectionListNode::publish_as_detection_list(
 }
 
 auto ExternalObjectListToDetectionListNode::update_georeference(
-  const std_msgs::msg::String & msg) noexcept -> void
+  const std_msgs::msg::String & msg)  -> void
 {
   map_georeference_ = msg.data;
 }

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_component.cpp
@@ -191,8 +191,8 @@ auto ExternalObjectListToDetectionListNode::publish_as_detection_list(
   }
 }
 
-auto ExternalObjectListToDetectionListNode::update_georeference(
-  const std_msgs::msg::String & msg)  -> void
+auto ExternalObjectListToDetectionListNode::update_georeference(const std_msgs::msg::String & msg)
+  -> void
 {
   map_georeference_ = msg.data;
 }

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_node.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[])  -> int
+auto main(int argc, char * argv[]) -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/external_object_list_to_detection_list_node.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_detection_list_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[]) noexcept -> int
+auto main(int argc, char * argv[])  -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
@@ -128,14 +128,14 @@ auto ExternalObjectListToSdsmNode::publish_as_sdsm(const external_objects_msg_ty
   }
 }
 
-auto ExternalObjectListToSdsmNode::update_georeference(const georeference_msg_type & msg) noexcept
+auto ExternalObjectListToSdsmNode::update_georeference(const georeference_msg_type & msg)
   -> void
 {
   map_georeference_ = msg.data;
   map_projector_ = std::make_shared<lanelet::projection::LocalFrameProjector>(msg.data.c_str());
 }
 
-auto ExternalObjectListToSdsmNode::update_current_pose(const pose_msg_type & msg) noexcept
+auto ExternalObjectListToSdsmNode::update_current_pose(const pose_msg_type & msg)
   -> void
 {
   current_pose_ = msg;

--- a/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
@@ -17,8 +17,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 
-#include "carma_cooperative_perception/msg_conversion.hpp"
 #include <memory>
+#include "carma_cooperative_perception/msg_conversion.hpp"
 
 namespace carma_cooperative_perception
 {
@@ -128,15 +128,13 @@ auto ExternalObjectListToSdsmNode::publish_as_sdsm(const external_objects_msg_ty
   }
 }
 
-auto ExternalObjectListToSdsmNode::update_georeference(const georeference_msg_type & msg)
-  -> void
+auto ExternalObjectListToSdsmNode::update_georeference(const georeference_msg_type & msg) -> void
 {
   map_georeference_ = msg.data;
   map_projector_ = std::make_shared<lanelet::projection::LocalFrameProjector>(msg.data.c_str());
 }
 
-auto ExternalObjectListToSdsmNode::update_current_pose(const pose_msg_type & msg)
-  -> void
+auto ExternalObjectListToSdsmNode::update_current_pose(const pose_msg_type & msg) -> void
 {
   current_pose_ = msg;
 }

--- a/carma_cooperative_perception/src/external_object_list_to_sdsm_node.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_sdsm_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[])  -> int
+auto main(int argc, char * argv[]) -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/external_object_list_to_sdsm_node.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_sdsm_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[]) noexcept -> int
+auto main(int argc, char * argv[])  -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -153,14 +153,14 @@ auto HostVehicleFilterNode::handle_on_shutdown(const rclcpp_lifecycle::State & /
   return carma_ros2_utils::CallbackReturn::SUCCESS;
 }
 
-auto HostVehicleFilterNode::update_host_vehicle_pose(
-  const geometry_msgs::msg::PoseStamped & msg)  -> void
+auto HostVehicleFilterNode::update_host_vehicle_pose(const geometry_msgs::msg::PoseStamped & msg)
+  -> void
 {
   host_vehicle_pose_ = msg;
 }
 
 auto HostVehicleFilterNode::attempt_filter_and_republish(
-  carma_cooperative_perception_interfaces::msg::DetectionList msg)  -> void
+  carma_cooperative_perception_interfaces::msg::DetectionList msg) -> void
 {
   if (!host_vehicle_pose_.has_value()) {
     RCLCPP_WARN(get_logger(), "Could not filter detection list: host vehicle pose unknown");
@@ -181,7 +181,7 @@ auto HostVehicleFilterNode::attempt_filter_and_republish(
 }
 
 auto euclidean_distance_squared(
-  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)  -> double
+  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) -> double
 {
   return std::pow(a.position.x - b.position.x, 2) + std::pow(a.position.y - b.position.y, 2) +
          std::pow(a.position.z - b.position.z, 2) + std::pow(a.orientation.x - b.orientation.x, 2) +

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -154,13 +154,13 @@ auto HostVehicleFilterNode::handle_on_shutdown(const rclcpp_lifecycle::State & /
 }
 
 auto HostVehicleFilterNode::update_host_vehicle_pose(
-  const geometry_msgs::msg::PoseStamped & msg) noexcept -> void
+  const geometry_msgs::msg::PoseStamped & msg)  -> void
 {
   host_vehicle_pose_ = msg;
 }
 
 auto HostVehicleFilterNode::attempt_filter_and_republish(
-  carma_cooperative_perception_interfaces::msg::DetectionList msg) noexcept -> void
+  carma_cooperative_perception_interfaces::msg::DetectionList msg)  -> void
 {
   if (!host_vehicle_pose_.has_value()) {
     RCLCPP_WARN(get_logger(), "Could not filter detection list: host vehicle pose unknown");
@@ -181,7 +181,7 @@ auto HostVehicleFilterNode::attempt_filter_and_republish(
 }
 
 auto euclidean_distance_squared(
-  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) noexcept -> double
+  const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b)  -> double
 {
   return std::pow(a.position.x - b.position.x, 2) + std::pow(a.position.y - b.position.y, 2) +
          std::pow(a.position.z - b.position.z, 2) + std::pow(a.orientation.x - b.orientation.x, 2) +

--- a/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[])  -> int
+auto main(int argc, char * argv[]) -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[]) noexcept -> int
+auto main(int argc, char * argv[])  -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/j2735_types.cpp
+++ b/carma_cooperative_perception/src/j2735_types.cpp
@@ -16,7 +16,7 @@
 
 namespace carma_cooperative_perception
 {
-auto DDateTime::from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) noexcept -> DDateTime
+auto DDateTime::from_msg(const j2735_v2x_msgs::msg::DDateTime & msg)  -> DDateTime
 {
   DDateTime d_date_time;
 
@@ -52,7 +52,7 @@ auto DDateTime::from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) noexcept ->
   return d_date_time;
 }
 
-auto AccelerationSet4Way::from_msg(const j2735_v2x_msgs::msg::AccelerationSet4Way & msg) noexcept
+auto AccelerationSet4Way::from_msg(const j2735_v2x_msgs::msg::AccelerationSet4Way & msg)
   -> AccelerationSet4Way
 {
   return {
@@ -62,7 +62,7 @@ auto AccelerationSet4Way::from_msg(const j2735_v2x_msgs::msg::AccelerationSet4Wa
     units::angular_velocity::centi_degrees_per_second_t{static_cast<double>(msg.yaw_rate)}};
 }
 
-auto AccelerationSet4Way::from_msg(const carma_v2x_msgs::msg::AccelerationSet4Way & msg) noexcept
+auto AccelerationSet4Way::from_msg(const carma_v2x_msgs::msg::AccelerationSet4Way & msg)
   -> AccelerationSet4Way
 {
   return {
@@ -72,7 +72,7 @@ auto AccelerationSet4Way::from_msg(const carma_v2x_msgs::msg::AccelerationSet4Wa
     units::angular_velocity::degrees_per_second_t{static_cast<double>(msg.yaw_rate)}};
 }
 
-auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg) noexcept -> Position3D
+auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg)  -> Position3D
 {
   Position3D position{
     units::angle::deci_micro_degrees_t{static_cast<double>(msg.latitude)},
@@ -85,7 +85,7 @@ auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg) noexcept 
   return position;
 }
 
-auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg) noexcept -> Position3D
+auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg)  -> Position3D
 {
   Position3D position{
     units::angle::degree_t{static_cast<double>(msg.latitude)},
@@ -98,22 +98,22 @@ auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg) noexcept 
   return position;
 }
 
-auto Heading::from_msg(const j2735_v2x_msgs::msg::Heading & heading) noexcept -> Heading
+auto Heading::from_msg(const j2735_v2x_msgs::msg::Heading & heading)  -> Heading
 {
   return {units::angle::eighth_deci_degrees_t{static_cast<double>(heading.heading)}};
 }
 
-auto Heading::from_msg(const carma_v2x_msgs::msg::Heading & heading) noexcept -> Heading
+auto Heading::from_msg(const carma_v2x_msgs::msg::Heading & heading)  -> Heading
 {
   return {units::angle::degree_t{static_cast<double>(heading.heading)}};
 }
 
-auto Speed::from_msg(const j2735_v2x_msgs::msg::Speed & speed) noexcept -> Speed
+auto Speed::from_msg(const j2735_v2x_msgs::msg::Speed & speed)  -> Speed
 {
   return {units::velocity::two_centi_meters_per_second_t{static_cast<double>(speed.speed)}};
 }
 
-auto Speed::from_msg(const carma_v2x_msgs::msg::Speed & speed) noexcept -> Speed
+auto Speed::from_msg(const carma_v2x_msgs::msg::Speed & speed)  -> Speed
 {
   return {units::velocity::meters_per_second_t{static_cast<double>(speed.speed)}};
 }

--- a/carma_cooperative_perception/src/j2735_types.cpp
+++ b/carma_cooperative_perception/src/j2735_types.cpp
@@ -16,7 +16,7 @@
 
 namespace carma_cooperative_perception
 {
-auto DDateTime::from_msg(const j2735_v2x_msgs::msg::DDateTime & msg)  -> DDateTime
+auto DDateTime::from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) -> DDateTime
 {
   DDateTime d_date_time;
 
@@ -72,7 +72,7 @@ auto AccelerationSet4Way::from_msg(const carma_v2x_msgs::msg::AccelerationSet4Wa
     units::angular_velocity::degrees_per_second_t{static_cast<double>(msg.yaw_rate)}};
 }
 
-auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg)  -> Position3D
+auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg) -> Position3D
 {
   Position3D position{
     units::angle::deci_micro_degrees_t{static_cast<double>(msg.latitude)},
@@ -85,7 +85,7 @@ auto Position3D::from_msg(const j2735_v2x_msgs::msg::Position3D & msg)  -> Posit
   return position;
 }
 
-auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg)  -> Position3D
+auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg) -> Position3D
 {
   Position3D position{
     units::angle::degree_t{static_cast<double>(msg.latitude)},
@@ -98,22 +98,22 @@ auto Position3D::from_msg(const carma_v2x_msgs::msg::Position3D & msg)  -> Posit
   return position;
 }
 
-auto Heading::from_msg(const j2735_v2x_msgs::msg::Heading & heading)  -> Heading
+auto Heading::from_msg(const j2735_v2x_msgs::msg::Heading & heading) -> Heading
 {
   return {units::angle::eighth_deci_degrees_t{static_cast<double>(heading.heading)}};
 }
 
-auto Heading::from_msg(const carma_v2x_msgs::msg::Heading & heading)  -> Heading
+auto Heading::from_msg(const carma_v2x_msgs::msg::Heading & heading) -> Heading
 {
   return {units::angle::degree_t{static_cast<double>(heading.heading)}};
 }
 
-auto Speed::from_msg(const j2735_v2x_msgs::msg::Speed & speed)  -> Speed
+auto Speed::from_msg(const j2735_v2x_msgs::msg::Speed & speed) -> Speed
 {
   return {units::velocity::two_centi_meters_per_second_t{static_cast<double>(speed.speed)}};
 }
 
-auto Speed::from_msg(const carma_v2x_msgs::msg::Speed & speed)  -> Speed
+auto Speed::from_msg(const carma_v2x_msgs::msg::Speed & speed) -> Speed
 {
   return {units::velocity::meters_per_second_t{static_cast<double>(speed.speed)}};
 }

--- a/carma_cooperative_perception/src/j3224_types.cpp
+++ b/carma_cooperative_perception/src/j3224_types.cpp
@@ -16,7 +16,7 @@
 
 namespace carma_cooperative_perception
 {
-auto PositionOffsetXYZ::from_msg(const j3224_v2x_msgs::msg::PositionOffsetXYZ & msg) noexcept
+auto PositionOffsetXYZ::from_msg(const j3224_v2x_msgs::msg::PositionOffsetXYZ & msg)
   -> PositionOffsetXYZ
 {
   PositionOffsetXYZ offset{
@@ -30,7 +30,7 @@ auto PositionOffsetXYZ::from_msg(const j3224_v2x_msgs::msg::PositionOffsetXYZ & 
   return offset;
 }
 
-auto PositionOffsetXYZ::from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & msg) noexcept
+auto PositionOffsetXYZ::from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & msg)
   -> PositionOffsetXYZ
 {
   PositionOffsetXYZ offset{
@@ -45,13 +45,13 @@ auto PositionOffsetXYZ::from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & 
 }
 
 auto MeasurementTimeOffset::from_msg(
-  const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg) noexcept -> MeasurementTimeOffset
+  const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset
 {
   return {units::time::millisecond_t{static_cast<double>(msg.measurement_time_offset)}};
 }
 
 auto MeasurementTimeOffset::from_msg(
-  const carma_v2x_msgs::msg::MeasurementTimeOffset & msg) noexcept -> MeasurementTimeOffset
+  const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset
 {
   return {units::time::second_t{static_cast<double>(msg.measurement_time_offset)}};
 }

--- a/carma_cooperative_perception/src/j3224_types.cpp
+++ b/carma_cooperative_perception/src/j3224_types.cpp
@@ -44,14 +44,14 @@ auto PositionOffsetXYZ::from_msg(const carma_v2x_msgs::msg::PositionOffsetXYZ & 
   return offset;
 }
 
-auto MeasurementTimeOffset::from_msg(
-  const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset
+auto MeasurementTimeOffset::from_msg(const j3224_v2x_msgs::msg::MeasurementTimeOffset & msg)
+  -> MeasurementTimeOffset
 {
   return {units::time::millisecond_t{static_cast<double>(msg.measurement_time_offset)}};
 }
 
-auto MeasurementTimeOffset::from_msg(
-  const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)  -> MeasurementTimeOffset
+auto MeasurementTimeOffset::from_msg(const carma_v2x_msgs::msg::MeasurementTimeOffset & msg)
+  -> MeasurementTimeOffset
 {
   return {units::time::second_t{static_cast<double>(msg.measurement_time_offset)}};
 }

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -48,7 +48,7 @@
 
 namespace carma_cooperative_perception
 {
-auto to_time_msg(const DDateTime & d_date_time)  -> builtin_interfaces::msg::Time
+auto to_time_msg(const DDateTime & d_date_time) -> builtin_interfaces::msg::Time
 {
   double seconds;
   const auto fractional_secs{
@@ -127,7 +127,7 @@ auto calc_sdsm_time_offset(
   return time_offset;
 }
 
-auto to_position_msg(const UtmCoordinate & position_utm)  -> geometry_msgs::msg::Point
+auto to_position_msg(const UtmCoordinate & position_utm) -> geometry_msgs::msg::Point
 {
   geometry_msgs::msg::Point msg;
 
@@ -138,7 +138,7 @@ auto to_position_msg(const UtmCoordinate & position_utm)  -> geometry_msgs::msg:
   return msg;
 }
 
-auto heading_to_enu_yaw(const units::angle::degree_t & heading)  -> units::angle::degree_t
+auto heading_to_enu_yaw(const units::angle::degree_t & heading) -> units::angle::degree_t
 {
   return units::angle::degree_t{std::fmod(-(remove_units(heading) - 90.0) + 360.0, 360.0)};
 }
@@ -353,7 +353,8 @@ auto to_detection_msg(
 
 auto to_detection_list_msg(
   const carma_perception_msgs::msg::ExternalObjectList & object_list,
-  const MotionModelMapping & motion_model_mapping) -> carma_cooperative_perception_interfaces::msg::DetectionList
+  const MotionModelMapping & motion_model_mapping)
+  -> carma_cooperative_perception_interfaces::msg::DetectionList
 {
   carma_cooperative_perception_interfaces::msg::DetectionList detection_list;
 
@@ -367,8 +368,7 @@ auto to_detection_list_msg(
   return detection_list;
 }
 
-auto to_external_object_msg(
-  const carma_cooperative_perception_interfaces::msg::Track & track)
+auto to_external_object_msg(const carma_cooperative_perception_interfaces::msg::Track & track)
   -> carma_perception_msgs::msg::ExternalObject
 {
   carma_perception_msgs::msg::ExternalObject external_object;
@@ -501,8 +501,8 @@ auto to_detected_object_data_msg(
 
   // speed/speed_z - convert vector velocity to scalar speed val given x/y components
   if (external_object.presence_vector & external_object.VELOCITY_PRESENCE_VECTOR) {
-    detected_object_common_data.speed.speed = std::hypot(
-      external_object.velocity.twist.linear.x, external_object.velocity.twist.linear.y);
+    detected_object_common_data.speed.speed =
+      std::hypot(external_object.velocity.twist.linear.x, external_object.velocity.twist.linear.y);
 
     detected_object_common_data.presence_vector |=
       carma_v2x_msgs::msg::DetectedObjectCommonData::HAS_SPEED_Z;

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -48,7 +48,7 @@
 
 namespace carma_cooperative_perception
 {
-auto to_time_msg(const DDateTime & d_date_time) noexcept -> builtin_interfaces::msg::Time
+auto to_time_msg(const DDateTime & d_date_time)  -> builtin_interfaces::msg::Time
 {
   double seconds;
   const auto fractional_secs{
@@ -61,7 +61,7 @@ auto to_time_msg(const DDateTime & d_date_time) noexcept -> builtin_interfaces::
   return msg;
 }
 
-auto calc_detection_time_stamp(DDateTime sdsm_time, const MeasurementTimeOffset & offset) noexcept
+auto calc_detection_time_stamp(DDateTime sdsm_time, const MeasurementTimeOffset & offset)
   -> DDateTime
 {
   sdsm_time.second.value() += offset.measurement_time_offset;
@@ -69,7 +69,7 @@ auto calc_detection_time_stamp(DDateTime sdsm_time, const MeasurementTimeOffset 
   return sdsm_time;
 }
 
-auto to_ddate_time_msg(const builtin_interfaces::msg::Time & builtin_time) noexcept
+auto to_ddate_time_msg(const builtin_interfaces::msg::Time & builtin_time)
   -> j2735_v2x_msgs::msg::DDateTime
 {
   j2735_v2x_msgs::msg::DDateTime ddate_time_output;
@@ -106,7 +106,7 @@ auto to_ddate_time_msg(const builtin_interfaces::msg::Time & builtin_time) noexc
 
 auto calc_sdsm_time_offset(
   const builtin_interfaces::msg::Time & external_object_list_stamp,
-  const builtin_interfaces::msg::Time & external_object_stamp) noexcept
+  const builtin_interfaces::msg::Time & external_object_stamp)
   -> carma_v2x_msgs::msg::MeasurementTimeOffset
 {
   carma_v2x_msgs::msg::MeasurementTimeOffset time_offset;
@@ -127,7 +127,7 @@ auto calc_sdsm_time_offset(
   return time_offset;
 }
 
-auto to_position_msg(const UtmCoordinate & position_utm) noexcept -> geometry_msgs::msg::Point
+auto to_position_msg(const UtmCoordinate & position_utm)  -> geometry_msgs::msg::Point
 {
   geometry_msgs::msg::Point msg;
 
@@ -138,14 +138,14 @@ auto to_position_msg(const UtmCoordinate & position_utm) noexcept -> geometry_ms
   return msg;
 }
 
-auto heading_to_enu_yaw(const units::angle::degree_t & heading) noexcept -> units::angle::degree_t
+auto heading_to_enu_yaw(const units::angle::degree_t & heading)  -> units::angle::degree_t
 {
   return units::angle::degree_t{std::fmod(-(remove_units(heading) - 90.0) + 360.0, 360.0)};
 }
 
 auto enu_orientation_to_true_heading(
   double yaw, const lanelet::BasicPoint3d & obj_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> units::angle::degree_t
 {
   // Get object geodetic position
@@ -172,7 +172,7 @@ auto enu_orientation_to_true_heading(
 // in map frame and external object pose
 auto calc_relative_position(
   const geometry_msgs::msg::PoseStamped & source_pose,
-  const carma_v2x_msgs::msg::PositionOffsetXYZ & position_offset) noexcept
+  const carma_v2x_msgs::msg::PositionOffsetXYZ & position_offset)
   -> carma_v2x_msgs::msg::PositionOffsetXYZ
 {
   carma_v2x_msgs::msg::PositionOffsetXYZ adjusted_offset;
@@ -190,7 +190,7 @@ auto calc_relative_position(
 
 auto transform_pose_from_map_to_wgs84(
   const geometry_msgs::msg::PoseStamped & source_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::Position3D
 {
   carma_v2x_msgs::msg::Position3D ref_pos;
@@ -207,7 +207,7 @@ auto transform_pose_from_map_to_wgs84(
   return ref_pos;
 }
 
-auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm) noexcept
+auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm)
   -> carma_cooperative_perception_interfaces::msg::DetectionList
 {
   carma_cooperative_perception_interfaces::msg::DetectionList detection_list;
@@ -297,7 +297,7 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
 
 auto to_detection_msg(
   const carma_perception_msgs::msg::ExternalObject & object,
-  const MotionModelMapping & motion_model_mapping) noexcept
+  const MotionModelMapping & motion_model_mapping)
   -> carma_cooperative_perception_interfaces::msg::Detection
 {
   carma_cooperative_perception_interfaces::msg::Detection detection;
@@ -353,8 +353,7 @@ auto to_detection_msg(
 
 auto to_detection_list_msg(
   const carma_perception_msgs::msg::ExternalObjectList & object_list,
-  const MotionModelMapping & motion_model_mapping) noexcept
-  -> carma_cooperative_perception_interfaces::msg::DetectionList
+  const MotionModelMapping & motion_model_mapping) -> carma_cooperative_perception_interfaces::msg::DetectionList
 {
   carma_cooperative_perception_interfaces::msg::DetectionList detection_list;
 
@@ -369,7 +368,7 @@ auto to_detection_list_msg(
 }
 
 auto to_external_object_msg(
-  const carma_cooperative_perception_interfaces::msg::Track & track) noexcept
+  const carma_cooperative_perception_interfaces::msg::Track & track)
   -> carma_perception_msgs::msg::ExternalObject
 {
   carma_perception_msgs::msg::ExternalObject external_object;
@@ -417,7 +416,7 @@ auto to_external_object_msg(
 }
 
 auto to_external_object_list_msg(
-  const carma_cooperative_perception_interfaces::msg::TrackList & track_list) noexcept
+  const carma_cooperative_perception_interfaces::msg::TrackList & track_list)
   -> carma_perception_msgs::msg::ExternalObjectList
 {
   carma_perception_msgs::msg::ExternalObjectList external_object_list;
@@ -432,7 +431,7 @@ auto to_external_object_list_msg(
 auto to_sdsm_msg(
   const carma_perception_msgs::msg::ExternalObjectList & external_object_list,
   const geometry_msgs::msg::PoseStamped & current_pose,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::SensorDataSharingMessage
 {
   carma_v2x_msgs::msg::SensorDataSharingMessage sdsm;
@@ -463,7 +462,7 @@ auto to_sdsm_msg(
 
 auto to_detected_object_data_msg(
   const carma_perception_msgs::msg::ExternalObject & external_object,
-  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection) noexcept
+  const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::DetectedObjectData
 {
   carma_v2x_msgs::msg::DetectedObjectData detected_object_data;

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -72,8 +72,8 @@ auto semantic_class_to_numeric_value(mot::SemanticClass semantic_class)
   return 0;
 }
 
-auto make_ctrv_detection(
-  const carma_cooperative_perception_interfaces::msg::Detection & msg) noexcept -> Detection
+auto make_ctrv_detection(const carma_cooperative_perception_interfaces::msg::Detection & msg)
+  -> Detection
 {
   const auto timestamp{
     units::time::second_t{static_cast<double>(msg.header.stamp.sec)} +
@@ -110,8 +110,8 @@ auto make_ctrv_detection(
     timestamp, state, covariance, mot::Uuid{msg.id}, make_semantic_class(msg.semantic_class)};
 }
 
-auto make_ctra_detection(
-  const carma_cooperative_perception_interfaces::msg::Detection & msg) noexcept -> Detection
+auto make_ctra_detection(const carma_cooperative_perception_interfaces::msg::Detection & msg)
+  -> Detection
 {
   const auto timestamp{
     units::time::second_t{static_cast<double>(msg.header.stamp.sec)} +
@@ -167,7 +167,7 @@ auto make_detection(const carma_cooperative_perception_interfaces::msg::Detectio
   throw std::runtime_error("unkown motion model type '" + std::to_string(msg.motion_model) + "'");
 }
 
-static auto to_ros_msg(const mot::CtraTrack & track) noexcept
+static auto to_ros_msg(const mot::CtraTrack & track)
 {
   carma_cooperative_perception_interfaces::msg::Track msg;
 
@@ -198,7 +198,7 @@ static auto to_ros_msg(const mot::CtraTrack & track) noexcept
   return msg;
 }
 
-static auto to_ros_msg(const mot::CtrvTrack & track) noexcept
+static auto to_ros_msg(const mot::CtrvTrack & track)
 {
   carma_cooperative_perception_interfaces::msg::Track msg;
 
@@ -405,7 +405,7 @@ auto MultipleObjectTrackerNode::handle_on_shutdown(
 }
 
 auto MultipleObjectTrackerNode::store_new_detections(
-  const carma_cooperative_perception_interfaces::msg::DetectionList & msg) noexcept -> void
+  const carma_cooperative_perception_interfaces::msg::DetectionList & msg) -> void
 {
   if (std::size(msg.detections) == 0) {
     RCLCPP_WARN(this->get_logger(), "Not storing detections: incoming detection list is empty");
@@ -435,14 +435,14 @@ auto MultipleObjectTrackerNode::store_new_detections(
 }
 
 static auto temporally_align_detections(
-  std::vector<Detection> & detections, units::time::second_t end_time) noexcept -> void
+  std::vector<Detection> & detections, units::time::second_t end_time) -> void
 {
   for (auto & detection : detections) {
     mot::propagate_to_time(detection, end_time, mot::default_unscented_transform);
   }
 }
 
-static auto predict_track_states(std::vector<Track> tracks, units::time::second_t end_time) noexcept
+static auto predict_track_states(std::vector<Track> tracks, units::time::second_t end_time)
 {
   for (auto & track : tracks) {
     mot::propagate_to_time(track, end_time, mot::default_unscented_transform);

--- a/carma_cooperative_perception/src/multiple_object_tracker_node.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[])  -> int
+auto main(int argc, char * argv[]) -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/multiple_object_tracker_node.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[]) noexcept -> int
+auto main(int argc, char * argv[])  -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -76,7 +76,7 @@ auto TrackListToExternalObjectListNode::handle_on_shutdown(
 }
 
 auto TrackListToExternalObjectListNode::publish_as_external_object_list(
-  const carma_cooperative_perception_interfaces::msg::TrackList & msg) const  -> void
+  const carma_cooperative_perception_interfaces::msg::TrackList & msg) const -> void
 {
   auto external_object_list{to_external_object_list_msg(msg)};
   external_object_list.header.stamp = now();

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_component.cpp
@@ -76,7 +76,7 @@ auto TrackListToExternalObjectListNode::handle_on_shutdown(
 }
 
 auto TrackListToExternalObjectListNode::publish_as_external_object_list(
-  const carma_cooperative_perception_interfaces::msg::TrackList & msg) const noexcept -> void
+  const carma_cooperative_perception_interfaces::msg::TrackList & msg) const  -> void
 {
   auto external_object_list{to_external_object_list_msg(msg)};
   external_object_list.header.stamp = now();

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[])  -> int
+auto main(int argc, char * argv[]) -> int
 {
   rclcpp::init(argc, argv);
 

--- a/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
+++ b/carma_cooperative_perception/src/track_list_to_external_object_list_node.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-auto main(int argc, char * argv[]) noexcept -> int
+auto main(int argc, char * argv[])  -> int
 {
   rclcpp::init(argc, argv);
 


### PR DESCRIPTION
# PR Details
## Description

This PR removes all `noexcept` function declaration specifiers from the `carma_cooperative_perception` package. The specifiers were added too liberally without checking to see if they were appropriate for that function. While we could selectively remove inappropriate `noexcept` specifiers, the effort involved in properly checking doesn't seem worth it. We're unsure of the tangible benefits for our use case. It also makes troubleshooting significantly more difficult due to the `std::terminate` requirement.

## Related GitHub Issue

Closes #2255 

## Related Jira Key

Closes [CDAR-658](https://usdot-carma.atlassian.net/browse/CDAR-658)

## Motivation and Context

See above

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-658]: https://usdot-carma.atlassian.net/browse/CDAR-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ