### PR TITLE
[cooperative perception] Refactor track update calls after fusion

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -497,7 +497,11 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     if (has_association(track)) {
       const auto detection_uuids{associations.at(get_uuid(track))};
       const auto first_detection{detection_map[detection_uuids.at(0)]};
-      track = std::visit(mot::covariance_intersection_visitor, track, first_detection);
+      auto predicted_track{track};
+      mot::propagate_to_time(predicted_track, current_time, mot::UnscentedTransform{1.0, 2.0, 0.0});
+      const auto fused_track{
+        std::visit(mot::covariance_intersection_visitor, track, first_detection)};
+      track_manager_.update_track(mot::get_uuid(track), fused_track);
     }
   }
 


### PR DESCRIPTION
# PR Details
## Description

This PR resolves the issue were post-fusion track updates did not propagate. The new implementation uses the track manager's update functionality (the `update_track` function).

## Related GitHub Issue

Closes #2213 

## Related Jira Key

Closes [CDAR-595](https://usdot-carma.atlassian.net/browse/CDAR-595)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-595]: https://usdot-carma.atlassian.net/browse/CDAR-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ