### PR TITLE
[cooperative perception] Change multiple object tracker timer

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -354,7 +354,8 @@ auto MultipleObjectTrackerNode::handle_on_activate(
   }
 
   const std::chrono::duration<double, std::nano> period_ns{mot::remove_units(execution_period_)};
-  pipeline_execution_timer_ = create_wall_timer(period_ns, [this] { execute_pipeline(); });
+  pipeline_execution_timer_ =
+    rclcpp::create_timer(this, this->get_clock(), period_ns, [this] { execute_pipeline(); });
 
   RCLCPP_INFO(get_logger(), "Lifecycle transition: successfully activated");
 


### PR DESCRIPTION
# PR Details
## Description

This PR replaces the timer type for the `MultipleObjectTrackerComponent`. The timer was a wall timer, which is tied to system time. The new general timer can switch between system and simulation time.

## Related GitHub Issue

Closes #2260 

## Related Jira Key

Closes [CDAR-699](https://usdot-carma.atlassian.net/browse/CDAR-699)

## Motivation and Context

Improves the node's ability to integrate with simualation.

## How Has This Been Tested?

Manually in integration testing.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-699]: https://usdot-carma.atlassian.net/browse/CDAR-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ