### PR TITLE
[cooperative perception] Add new scoring metrics

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -562,6 +562,8 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     RCLCPP_DEBUG(
       get_logger(), "List of tracks is empty. Converting detections to tentative tracks");
 
+    // This clustering distance is an arbitrarily-chosen heuristic. It is working well for our
+    // current purposes, but there's no reason it couldn't be restricted or loosened.
     const auto clusters{mot::cluster_detections(detections_, 0.75)};
     for (const auto & cluster : clusters) {
       const auto detection{std::cbegin(cluster.get_detections())->second};
@@ -619,6 +621,8 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     }
   }
 
+  // This clustering distance is an arbitrarily-chosen heuristic. It is working well for our
+  // current purposes, but there's no reason it couldn't be restricted or loosened.
   const auto clusters{mot::cluster_detections(unassociated_detections, 0.75, MetricSe2{})};
   for (const auto & cluster : clusters) {
     const auto detection{std::cbegin(cluster.get_detections())->second};

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -518,7 +518,7 @@ private:
 };
 
 /**
- * @brief Calculates the distance between a point and detection's state in SE(2) space
+ * @brief Calculates distance between a point and detection in SE(2) (special Euclidean) space
 */
 struct MetricSe2
 {

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -467,20 +467,19 @@ struct SemanticDistance2dScore
   {
     if constexpr (std::is_same_v<decltype(track.state), decltype(detection.state)>) {
       const auto dist{two_dimensional_distance(track.state, detection.state)};
+
       if (
         track.semantic_class == mot::SemanticClass::kUnknown ||
         detection.semantic_class == mot::SemanticClass::kUnknown) {
         return dist;
       }
 
-      if (track.semantic_class != detection.semantic_class) {
-        return std::nullopt;
+      if (track.semantic_class == detection.semantic_class) {
+        return dist;
       }
-
-      return dist;
-    } else {
-      return std::nullopt;
     }
+
+    return std::nullopt;
   }
 
   template <typename... TrackAlternatives, typename... DetectionAlternatives>

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -468,6 +468,8 @@ struct SemanticDistance2dScore
     if constexpr (std::is_same_v<decltype(track.state), decltype(detection.state)>) {
       const auto dist{two_dimensional_distance(track.state, detection.state)};
 
+      // Fall back to 2D Euclidean distance if either semantic class if unknown. The unknown
+      // track/detection may actually be the same other track/detection we are scoring against.
       if (
         track.semantic_class == mot::SemanticClass::kUnknown ||
         detection.semantic_class == mot::SemanticClass::kUnknown) {

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -453,6 +453,13 @@ static auto predict_track_states(std::vector<Track> tracks, units::time::second_
   return tracks;
 }
 
+/**
+ * @brief Calculate 2D Euclidean distance between track and detection
+ *
+ * If both the track and detection semantic classes are known, this function
+ * object returns the 2D Euclidean distance between their states. Otherwise,
+ * it returns std::nullopt.
+*/
 struct SemanticDistance2dScore
 {
   template <typename Track, typename Detection>
@@ -509,6 +516,9 @@ private:
   }
 };
 
+/**
+ * @brief Calculates the distance between a point and detection's state in SE(2) space
+*/
 struct MetricSe2
 {
   template <typename Detection>
@@ -572,6 +582,8 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
   auto scores{
     mot::score_tracks_and_detections(predicted_tracks, detections_, SemanticDistance2dScore{})};
 
+  // This pruning distance is an arbitrarily-chosen heuristic. It is working well for our
+  // current purposes, but there's no reason it couldn't be restricted or loosened.
   mot::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 5.0; });
 
   const auto associations{

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -233,7 +233,10 @@ static auto to_ros_msg(const Track & track)
   static constexpr mot::Visitor visitor{
     [](const mot::CtrvTrack & t) { return to_ros_msg(t); },
     [](const mot::CtraTrack & t) { return to_ros_msg(t); },
-    [](const auto &) { throw std::runtime_error{"cannot make ROS 2 message from track type"}; }};
+    [](const auto &) {
+      // Currently on support CTRV and CTRA
+      throw std::runtime_error{"cannot make ROS 2 message from track type"};
+    }};
 
   return std::visit(visitor, track);
 }
@@ -544,7 +547,10 @@ struct MetricSe2
     const mot::Visitor visitor{
       [this](const mot::Point & p, const mot::CtrvDetection & d) { return this->operator()(p, d); },
       [this](const mot::Point & p, const mot::CtraDetection & d) { return this->operator()(p, d); },
-      [](const mot::Point &, const auto &) { return std::numeric_limits<double>::max(); }};
+      [](const mot::Point &, const auto &) {
+        // Currently on support CTRV and CTRA
+        return std::numeric_limits<double>::max();
+      }};
 
     return std::visit(visitor, std::variant<mot::Point>{point}, detection);
   }
@@ -555,7 +561,10 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
   static constexpr mot::Visitor make_track_visitor{
     [](const mot::CtrvDetection & d) { return Track{mot::make_track<mot::CtrvTrack>(d)}; },
     [](const mot::CtraDetection & d) { return Track{mot::make_track<mot::CtraTrack>(d)}; },
-    [](const auto &) { throw std::runtime_error("cannot make track from given detection"); },
+    [](const auto &) {
+      // Currently on support CTRV and CTRA
+      throw std::runtime_error("cannot make track from given detection");
+    },
   };
 
   if (track_manager_.get_all_tracks().empty()) {


### PR DESCRIPTION
# PR Details
## Description

The SemanticDistance2dScore combines the 2D Euclidean distance with the semantic classes between detections and tracks. The MetricSe2 is the SE(2) distance.

## Related GitHub Issue

Closes #2264

## Related Jira Key

Closes [CDAR-705](https://usdot-carma.atlassian.net/browse/CDAR-705)

## Motivation and Context

Improved performance

## How Has This Been Tested?

Manually in integration tests.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-705]: https://usdot-carma.atlassian.net/browse/CDAR-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ