### PR TITLE
[cooperative perception] Drop unassociated duplicate detections

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -630,7 +630,9 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     }
   }
 
-  // This is the erase-remove idiom (https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)
+  // We want to remove unassociated tracks that are close enough to existing tracks
+  // to avoid creating duplicates. Duplicate tracks will cause association inconsistencies
+  // (flip flopping associations between the two tracks).
   auto remove_start{std::remove_if(
     std::begin(unassociated_detections), std::end(unassociated_detections),
     [&scores](const auto & detection) {

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -630,6 +630,7 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     }
   }
 
+  // This is the erase-remove idiom (https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)
   auto remove_start{std::remove_if(
     std::begin(unassociated_detections), std::end(unassociated_detections),
     [&scores](const auto & detection) {

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -630,6 +630,24 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     }
   }
 
+  auto remove_start{std::remove_if(
+    std::begin(unassociated_detections), std::end(unassociated_detections),
+    [&scores](const auto & detection) {
+      const auto uuid{mot::get_uuid(detection)};
+      auto min_score{std::numeric_limits<float>::infinity()};
+      for (const auto & [uuid_pair, score] : scores) {
+        if (uuid_pair.second == uuid) {
+          min_score = std::min(min_score, score);
+        }
+      }
+
+      // This distance is an arbitrarily-chosen heuristic. It is working well for our
+      // current purposes, but there's no reason it couldn't be restricted or loosened.
+      return min_score < 1.0;
+    })};
+
+  unassociated_detections.erase(remove_start, std::end(unassociated_detections));
+
   // This clustering distance is an arbitrarily-chosen heuristic. It is working well for our
   // current purposes, but there's no reason it couldn't be restricted or loosened.
   const auto clusters{mot::cluster_detections(unassociated_detections, 0.75, MetricSe2{})};


### PR DESCRIPTION
# PR Details
## Description

This PR adds a step to our tracking pipeline to drop any unassociated detections that are "close" enough to an existing track. Multiple actors publish detection lists that overlap with others. Our association algorithm currently supports only one-to-one associations, so some detections will go unassociated even though they represent an existing track. To reduce the number of duplicate tracks, we drop any unassociated detection that we deem close enough.

## Related GitHub Issue

Closes #2266 

## Related Jira Key

Closes [CDAR-711](https://usdot-carma.atlassian.net/browse/CDAR-711)

## Motivation and Context

Performance improvement

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-711]: https://usdot-carma.atlassian.net/browse/CDAR-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ