### PR TITLE
Refactor yield_plugin and assorted fixes

### DIFF
--- a/yield_plugin/config/parameters.yaml
+++ b/yield_plugin/config/parameters.yaml
@@ -7,27 +7,27 @@ acceleration_adjustment_factor: 1.0
 # NOTE: not applied for pedestrians or other non-vehicle obstacles on the road
 # Units: s
 # Value type: Desired
-on_route_vehicle_collision_horizon: 10.0
+on_route_vehicle_collision_horizon_in_s: 10.0
 # Minimum speed for moving obstacle
 # Units: m/s
 # Value type: Desired
-min_obstacle_speed: 0.5
+min_obstacle_speed_in_ms: 0.5
 # Minimum object avoidance planning time
 # Units: s
 # Value type: Desired
-tpmin: 2.0
+min_obj_avoidance_plan_time_in_s: 2.0
 # Deceleration value used for yielding trajectories
 # Units: m/s^2
 # Value type: Desired
-yield_max_deceleration: 3.0
+yield_max_deceleration_in_ms2: 3.0
 # Minimum safety gap with an Object/Obstacle
 # Units: meters
 # Value type: Desired
-x_gap: 20.0
+minimum_safety_gap_in_meters: 20.0
 # Maximum speed value to consider the ego vehicle stopped
 # Units: m/s
 # Value type: Desired
-max_stop_speed: 1.0
+max_stop_speed_in_ms: 1.0
 # parameter to enable cooperative behavior
 # Value type: Desired
 enable_cooperative_behavior: false
@@ -40,15 +40,15 @@ acceptable_passed_timesteps: 5
 # Intervehicle distance that is considered a collision
 # Unit: m
 # Value type: Desired
-intervehicle_collision_distance: 6.0
+intervehicle_collision_distance_in_m: 6.0
 # Radius to check for potential collision
 # Unit: m
 # Value type: Desired
-collision_check_radius: 150.0
+collision_check_radius_in_m: 150.0
 # Time gap to finish planning a yield earlier than collision time
 # Unit: s
 # Value type: Desired
-safety_collision_time_gap: 2.0
+safety_collision_time_gap_in_s: 2.0
 # Flag to enable yield plugin to check for adjustable gap (for example digital gap from map)
 # Value type: Desired
 enable_adjustable_gap: true

--- a/yield_plugin/config/parameters.yaml
+++ b/yield_plugin/config/parameters.yaml
@@ -2,7 +2,7 @@
 # Adjustment factor for safe and comfortable acceleration/deceleration
 # Value type: Desired
 # No unit
-acceleration_adjustment_factor: 4.0
+acceleration_adjustment_factor: 1.0
 # Time horizon for collision detection for vehicles on the route
 # NOTE: not applied for pedestrians or other non-vehicle obstacles on the road
 # Units: s
@@ -23,36 +23,24 @@ yield_max_deceleration: 3.0
 # Minimum safety gap with an Object/Obstacle
 # Units: meters
 # Value type: Desired
-x_gap: 10.0
-# Host vehicle length
-# Units: m
-# Value type: Measured
-vehicle_length: 5.0
-# Host vehicle width
-# Units: m
-# Value type: Measured
-vehicle_width: 2.5
-# Host vehicle height
-# Units: m
-# Value type: Measured
-vehicle_height: 3.0
+x_gap: 20.0
 # Maximum speed value to consider the ego vehicle stopped
 # Units: m/s
 # Value type: Desired
 max_stop_speed: 1.0
 # parameter to enable cooperative behavior
 # Value type: Desired
-enable_cooperative_behavior: true
+enable_cooperative_behavior: false
 # parameter to always accept mobility request
 # Value type: Desired
-always_accept_mobility_request: true
+always_accept_mobility_request: false
 # Acceptable number of timesteps to use the latest known mobility request before switching to yield
 # Value type: Desired
 acceptable_passed_timesteps: 5
 # Intervehicle distance that is considered a collision
 # Unit: m
 # Value type: Desired
-intervehicle_collision_distance: 6.0
+intervehicle_collision_distance: 6.0 #TODO account for obstacle + vehicle length into code
 # Radius to check for potential collision
 # Unit: m
 # Value type: Desired
@@ -69,4 +57,4 @@ enable_adjustable_gap: true
 acceptable_urgency: 5
 # Window size for speed moving average filter
 # Value type: Desired (must be odd)
-speed_moving_average_window_size: 7.0
+speed_moving_average_window_size: 3.0

--- a/yield_plugin/config/parameters.yaml
+++ b/yield_plugin/config/parameters.yaml
@@ -40,7 +40,7 @@ acceptable_passed_timesteps: 5
 # Intervehicle distance that is considered a collision
 # Unit: m
 # Value type: Desired
-intervehicle_collision_distance: 6.0 #TODO account for obstacle + vehicle length into code
+intervehicle_collision_distance: 6.0
 # Radius to check for potential collision
 # Unit: m
 # Value type: Desired

--- a/yield_plugin/include/yield_plugin/yield_config.hpp
+++ b/yield_plugin/include/yield_plugin/yield_config.hpp
@@ -23,49 +23,49 @@
  */
 struct YieldPluginConfig
 {
-  double acceleration_adjustment_factor = 4.0;  // Adjustment factor for safe and comfortable acceleration/deceleration 
-  double on_route_vehicle_collision_horizon = 10.0;        // time horizon for collision detection in s
-  double min_obstacle_speed = 2.0;       // Minimum speed for moving obstacle in m/s
-  double tpmin = 2.0;                     // minimum object avoidance planning time in s
-  double yield_max_deceleration = 3.0;  // max deceleration value in m/s^2
-  double x_gap = 2.0;                       // minimum safety gap in m
+  double acceleration_adjustment_factor = 4.0;  // Adjustment factor for safe and comfortable acceleration/deceleration
+  double on_route_vehicle_collision_horizon_in_s = 10.0;        // time horizon for collision detection in s
+  double min_obstacle_speed_in_ms = 2.0;       // Minimum speed for moving obstacle in m/s
+  double min_obj_avoidance_plan_time_in_s = 2.0;                     // minimum object avoidance planning time in s
+  double yield_max_deceleration_in_ms2 = 3.0;  // max deceleration value in m/s^2
+  double minimum_safety_gap_in_meters = 2.0;                       // minimum safety gap in m
   double vehicle_length = 5.0;              // Host vehicle length in m
   double vehicle_height = 3.0;              // Host vehicle height in m
   double vehicle_width = 2.5;              // Host vehicle width in m
-  double max_stop_speed = 1.0;           //  Maximum speed value to consider the ego vehicle stopped in m/s
+  double max_stop_speed_in_ms = 1.0;           //  Maximum speed value to consider the ego vehicle stopped in m/s
   bool enable_cooperative_behavior = true;       //parameter to enable cooperative behavior
   bool always_accept_mobility_request = true;       //parameter to always accept mobility request
   std::string vehicle_id = "DEFAULT_VEHICLE_ID";         // Vehicle id is the license plate of the vehicle
   int acceptable_passed_timesteps = 10;              // acceptable number of timesteps to use the latest known mobility request before switching to yield
-  double intervehicle_collision_distance = 10.0;    //Intervehicle distance that is considered a collision
-  double safety_collision_time_gap = 2.0;          // Time gap to finish planning a yield earlier than collision time
+  double intervehicle_collision_distance_in_m = 10.0;    //Intervehicle distance that is considered a collision
+  double safety_collision_time_gap_in_s = 2.0;          // Time gap to finish planning a yield earlier than collision time
   bool enable_adjustable_gap = true;          // Flag to enable yield plugin to check for adjustable gap for example digital gap from map
   int acceptable_urgency = 5;                 //Minimum urgency value to consider the mobility request
   double speed_moving_average_window_size = 3.0;  //Window size for speed moving average filter
-  double collision_check_radius = 150.0;  //Radius to check for potential collision
+  double collision_check_radius_in_m = 150.0;  //Radius to check for potential collision
 
   friend std::ostream& operator<<(std::ostream& output, const YieldPluginConfig& c)
   {
     output << "YieldPluginConfig { " << std::endl
           << "acceleration_adjustment_factor: " << c.acceleration_adjustment_factor << std::endl
-          << "on_route_vehicle_collision_horizon: " << c.on_route_vehicle_collision_horizon << std::endl
-          << "min_obstacle_speed: " << c.min_obstacle_speed << std::endl
-          << "yield_max_deceleration: " << c.yield_max_deceleration << std::endl
-          << "x_gap: " << c.x_gap << std::endl
+          << "on_route_vehicle_collision_horizon_in_s: " << c.on_route_vehicle_collision_horizon_in_s << std::endl
+          << "min_obstacle_speed_in_ms: " << c.min_obstacle_speed_in_ms << std::endl
+          << "yield_max_deceleration_in_ms2: " << c.yield_max_deceleration_in_ms2 << std::endl
+          << "minimum_safety_gap_in_meters: " << c.minimum_safety_gap_in_meters << std::endl
           << "vehicle_length: " << c.vehicle_length << std::endl
           << "vehicle_height: " << c.vehicle_height << std::endl
           << "vehicle_width: " << c.vehicle_width << std::endl
-          << "max_stop_speed: " << c.max_stop_speed << std::endl
+          << "max_stop_speed_in_ms: " << c.max_stop_speed_in_ms << std::endl
           << "enable_cooperative_behavior: " << c.enable_cooperative_behavior << std::endl
           << "always_accept_mobility_request: " << c.always_accept_mobility_request << std::endl
           << "vehicle_id: " << c.vehicle_id << std::endl
           << "acceptable_passed_timesteps: " << c.acceptable_passed_timesteps << std::endl
-          << "intervehicle_collision_distance: " << c.intervehicle_collision_distance << std::endl
-          << "safety_collision_time_gap: " << c.safety_collision_time_gap << std::endl
+          << "intervehicle_collision_distance_in_m: " << c.intervehicle_collision_distance_in_m << std::endl
+          << "safety_collision_time_gap_in_s: " << c.safety_collision_time_gap_in_s << std::endl
           << "enable_adjustable_gap: " << c.enable_adjustable_gap << std::endl
           << "acceptable_urgency: " << c.acceptable_urgency << std::endl
           << "speed_moving_average_window_size: " << c.speed_moving_average_window_size << std::endl
-          << "collision_check_radius: " << c.collision_check_radius << std::endl
+          << "collision_check_radius_in_m: " << c.collision_check_radius_in_m << std::endl
           << "}" << std::endl;
     return output;
   }

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -118,10 +118,10 @@ public:
   /**
    * \brief calculates the maximum speed in a set of tajectory points
    * \param trajectory_points trajectory points
-   # \param time in seconds before which to look for max trajectory speed
+   # \param timestamp_to_search_until in seconds before which to look for max trajectory speed
    * \return maximum speed
    */
-  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double earliest_collision_time) const;
+  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double timestamp_to_search_until) const;
 
   /**
    * \brief calculates distance between trajectory points in a plan

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -118,6 +118,7 @@ public:
   /**
    * \brief calculates the maximum speed in a set of tajectory points
    * \param trajectory_points trajectory points
+   # \param time in seconds before which to look for max trajectory speed
    * \return maximum speed
    */
   double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double earliest_collision_time) const;
@@ -174,7 +175,7 @@ public:
    * \param initial_velocity start velocity
    * \param goal_velocity end velocity
    * \param planning_time time duration of the planning
-   * \param original original_max_speed from original_tp accounting for the collision TODO
+   * \param original original_max_speed from original_tp accounting for the collision
    * \return updated JMT trajectory
    */
   carma_planning_msgs::msg::TrajectoryPlan generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos,
@@ -239,9 +240,22 @@ public:
    */
   std::optional<rclcpp::Time> detect_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
 
-
-  // TODO
+  /**
+   * \brief Return the earliest collision object and time of collision pair from the given trajectory and list of external objects with predicted states.
+            Function first filters obstacles based on whether if their any of predicted state will be on the route. Only then, the logic compares trajectory and predicted states.
+   * \param original_tp trajectory of the ego vehicle
+   * \param external_objects list of external objects with predicted states
+   * \return earliest collision object and its collision time if collision detected. std::nullopt if no collision is detected or if route is not available.
+   */
   std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> get_earliest_collision_object_and_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects);
+
+  /**
+   * \brief Given the object velocity in map frame with x,y components, this function returns the projected velocity along the trajectory at given time.
+   * \param object_velocity_in_map_frame trajectory of the ego vehicle
+   * \param original_tp trajectory of the ego vehicle
+   * \param collision_timestamp_in_seconds timestamp in seconds along the trajectory to return the projected velocity
+   * \return velocity_along_trajectory
+   */
   double get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds);
 
 private:

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -177,7 +177,8 @@ public:
    * \param original original_max_speed from original_tp accounting for the collision TODO
    * \return updated JMT trajectory
    */
-  carma_planning_msgs::msg::TrajectoryPlan generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time, double original_max_speed);
+  carma_planning_msgs::msg::TrajectoryPlan generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos,
+    double initial_velocity, double goal_velocity, double planning_time, double original_max_speed);
 
   /**
    * \brief update trajectory for yielding to an incoming cooperative behavior

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -118,10 +118,10 @@ public:
   /**
    * \brief calculates the maximum speed in a set of tajectory points
    * \param trajectory_points trajectory points
-   # \param timestamp_to_search_until in seconds before which to look for max trajectory speed
+   # \param timestamp_in_sec_to_search_until before which to look for max trajectory speed
    * \return maximum speed
    */
-  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double timestamp_to_search_until) const;
+  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double timestamp_in_sec_to_search_until) const;
 
   /**
    * \brief calculates distance between trajectory points in a plan
@@ -232,13 +232,21 @@ public:
   void set_external_objects(const std::vector<carma_perception_msgs::msg::ExternalObject>& object_list);
 
   /**
-   * \brief Return collision time given two trajectories
+   * \brief Return collision time given two trajectories with one being predicted steps
    * \param trajectory1 trajectory of the ego vehicle
-   * \param trajectory2 trajectory of the obstacle
+   * \param trajectory2 trajectory of predicted steps
    * \param collision_radius a distance to check between two trajectory points at a same timestamp that is considered a collision
    * \return time_of_collision if collision detected, otherwise, std::nullopt
    */
-  std::optional<rclcpp::Time> detect_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
+  std::optional<rclcpp::Time> get_collision_time_using_predicted_steps(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
+
+  /**
+   * \brief Return collision time given two trajectories with one being external object with predicted steps
+   * \param trajectory1 trajectory of the ego vehicle
+   * \param trajectory2 trajectory of the obstacle
+   * \return time_of_collision if collision detected, otherwise, std::nullopt
+   */
+  std::optional<rclcpp::Time> get_collision_time_using_external_object(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const carma_perception_msgs::msg::ExternalObject& curr_obstacle);
 
   /**
    * \brief Return the earliest collision object and time of collision pair from the given trajectory and list of external objects with predicted states.

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -53,7 +53,7 @@ using LaneChangeStatusCB = std::function<void(const carma_planning_msgs::msg::La
 
 /**
  * \brief Convenience class for pairing 2d points with speeds
- */ 
+ */
 struct PointSpeedPair
 {
   lanelet::BasicPoint2d point;
@@ -62,19 +62,19 @@ struct PointSpeedPair
 
 /**
  * \brief Class containing primary business logic for the In-Lane Cruising Plugin
- * 
- */ 
+ *
+ */
 class YieldPlugin
 {
 public:
   /**
    * \brief Constructor
-   * 
+   *
    * \param wm Pointer to intialized instance of the carma world model for accessing semantic map data
    * \param config The configuration to be used for this object
    * \param mobility_response_publisher Callback which will publish the mobility response
    * \param lc_status_publisher Callback which will publish the cooperative lane change status
-   */ 
+   */
   YieldPlugin(std::shared_ptr<carma_ros2_utils::CarmaLifecycleNode> nh, carma_wm::WorldModelConstPtr wm, YieldPluginConfig config,
                        MobilityResponseCB mobility_response_publisher,
                        LaneChangeStatusCB lc_status_publisher);
@@ -84,17 +84,17 @@ public:
    * \param srv_header header
    * \param req The service request
    * \param resp The service response
-   * 
-   */ 
+   *
+   */
   void plan_trajectory_callback(
-    carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req, 
+    carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req,
     carma_planning_msgs::srv::PlanTrajectory::Response::SharedPtr resp);
 
   /**
    * \brief trajectory is modified to safely avoid obstacles on the road
    * \param original_tp original trajectory plan without object avoidance
    * \param current_speed_ current speed of the vehicle
-   * \param 
+   * \param
    * \return modified trajectory plan
    */
   carma_planning_msgs::msg::TrajectoryPlan update_traj_for_object(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects, double initial_velocity);
@@ -120,24 +120,24 @@ public:
    * \param trajectory_points trajectory points
    * \return maximum speed
    */
-  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points) const;
+  double max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double earliest_collision_time) const;
 
   /**
    * \brief calculates distance between trajectory points in a plan
-   * \param trajectory_plan input trajectory plan 
+   * \param trajectory_plan input trajectory plan
    * \return vector of relative distances between trajectory points
-   */                     
-  std::vector<double> get_relative_downtracks(const carma_planning_msgs::msg::TrajectoryPlan& trajectory_plan) const;  
+   */
+  std::vector<double> get_relative_downtracks(const carma_planning_msgs::msg::TrajectoryPlan& trajectory_plan) const;
 
   /**
    * \brief callback for mobility request
-   * \param msg mobility request message 
+   * \param msg mobility request message
    */
   void mobilityrequest_cb(const carma_v2x_msgs::msg::MobilityRequest::UniquePtr msg);
 
   /**
    * \brief callback for bsm message
-   * \param msg mobility bsm message 
+   * \param msg mobility bsm message
    */
   void bsm_cb(const carma_v2x_msgs::msg::BSM::UniquePtr msg);
 
@@ -148,11 +148,11 @@ public:
    * \return vector of 2d points in map frame
    */
   std::vector<lanelet::BasicPoint2d> convert_eceftrajectory_to_mappoints(const carma_v2x_msgs::msg::Trajectory& ecef_trajectory) const;
-  
+
   /**
    * \brief convert a point in ecef frame (in cm) into map frame (in meters)
    * \param ecef_point carma point ecef frame in cm
-   * \param map_in_earth translate frame 
+   * \param map_in_earth translate frame
    * \return 2d point in map frame
    */
   lanelet::BasicPoint2d ecef_to_map_point(const carma_v2x_msgs::msg::LocationECEF& ecef_point) const;
@@ -165,7 +165,7 @@ public:
    * \return filled mobility response
    */
   carma_v2x_msgs::msg::MobilityResponse compose_mobility_response(const std::string& resp_recipient_id, const std::string& req_plan_id, bool response) const;
-  
+
   /**
    * \brief generate a Jerk Minimizing Trajectory(JMT) with the provided start and end conditions
    * \param original_tp original trajectory plan
@@ -174,10 +174,11 @@ public:
    * \param initial_velocity start velocity
    * \param goal_velocity end velocity
    * \param planning_time time duration of the planning
-   * \return updated JMT trajectory 
+   * \param original original_max_speed from original_tp accounting for the collision TODO
+   * \return updated JMT trajectory
    */
-  carma_planning_msgs::msg::TrajectoryPlan generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time);
-  
+  carma_planning_msgs::msg::TrajectoryPlan generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time, double original_max_speed);
+
   /**
    * \brief update trajectory for yielding to an incoming cooperative behavior
    * \param original_tp original trajectory plan
@@ -193,14 +194,14 @@ public:
    * \return vector of pairs of 2d intersection points and index of the point in trajectory array
    */
   std::vector<std::pair<int, lanelet::BasicPoint2d>> detect_trajectories_intersection(std::vector<lanelet::BasicPoint2d> self_trajectory, std::vector<lanelet::BasicPoint2d> incoming_trajectory) const;
-  
+
 
   /**
    * \brief set values for member variables related to cooperative behavior
    * \param req_trajectory requested trajectory
    * \param req_speed speed of requested cooperative behavior
    * \param req_planning_time planning time for the requested cooperative behavior
-   * \param req_timestamp the mobility request time stamp 
+   * \param req_timestamp the mobility request time stamp
    */
   void set_incoming_request_info(std::vector <lanelet::BasicPoint2d> req_trajectory, double req_speed, double req_planning_time, double req_timestamp);
 
@@ -219,23 +220,28 @@ public:
   /**
    * \brief Setter for map projection string to define lat/lon -> map conversion
    * \param georeference The proj string defining the projection.
-   */ 
+   */
   void set_georeference_string(const std::string& georeference);
 
   /**
    * \brief Setter for external objects with predictions in the environment
    * \param object_list The object list.
-   */ 
+   */
   void set_external_objects(const std::vector<carma_perception_msgs::msg::ExternalObject>& object_list);
 
   /**
    * \brief Return collision time given two trajectories
    * \param trajectory1 trajectory of the ego vehicle
-   * \param trajectory2 trajectory of the obstacle 
+   * \param trajectory2 trajectory of the obstacle
    * \param collision_radius a distance to check between two trajectory points at a same timestamp that is considered a collision
    * \return time_of_collision if collision detected, otherwise, std::nullopt
-   */ 
+   */
   std::optional<rclcpp::Time> detect_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
+
+
+  // TODO
+  std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> get_earliest_collision_object_and_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects);
+  double get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds);
 
 private:
 
@@ -279,4 +285,4 @@ private:
   }
 
 };
-};  // namespace yield_plugin
+}  // namespace yield_plugin

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -262,6 +262,7 @@ public:
    * \param object_velocity_in_map_frame trajectory of the ego vehicle
    * \param original_tp trajectory of the ego vehicle
    * \param timestamp_in_sec_to_predict timestamp in seconds along the trajectory to return the projected velocity
+   * NOTE: returns the last point's speed if the specified time is past the trajectory's planning time
    * \return get_predicted_velocity_at_time
    */
   double get_predicted_velocity_at_time(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double timestamp_in_sec_to_predict);

--- a/yield_plugin/include/yield_plugin/yield_plugin.hpp
+++ b/yield_plugin/include/yield_plugin/yield_plugin.hpp
@@ -238,7 +238,7 @@ public:
    * \param collision_radius a distance to check between two trajectory points at a same timestamp that is considered a collision
    * \return time_of_collision if collision detected, otherwise, std::nullopt
    */
-  std::optional<rclcpp::Time> get_collision_time_using_predicted_steps(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
+  std::optional<rclcpp::Time> get_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius);
 
   /**
    * \brief Return collision time given two trajectories with one being external object with predicted steps
@@ -246,7 +246,7 @@ public:
    * \param trajectory2 trajectory of the obstacle
    * \return time_of_collision if collision detected, otherwise, std::nullopt
    */
-  std::optional<rclcpp::Time> get_collision_time_using_external_object(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const carma_perception_msgs::msg::ExternalObject& curr_obstacle);
+  std::optional<rclcpp::Time> get_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const carma_perception_msgs::msg::ExternalObject& curr_obstacle);
 
   /**
    * \brief Return the earliest collision object and time of collision pair from the given trajectory and list of external objects with predicted states.
@@ -261,10 +261,10 @@ public:
    * \brief Given the object velocity in map frame with x,y components, this function returns the projected velocity along the trajectory at given time.
    * \param object_velocity_in_map_frame trajectory of the ego vehicle
    * \param original_tp trajectory of the ego vehicle
-   * \param collision_timestamp_in_seconds timestamp in seconds along the trajectory to return the projected velocity
-   * \return velocity_along_trajectory
+   * \param timestamp_in_sec_to_predict timestamp in seconds along the trajectory to return the projected velocity
+   * \return get_predicted_velocity_at_time
    */
-  double get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds);
+  double get_predicted_velocity_at_time(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double timestamp_in_sec_to_predict);
 
 private:
 

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -365,7 +365,6 @@ namespace yield_plugin
     double initial_accel = 0.0;
     double goal_accel = 0.0;
 
-    double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
     RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -264,7 +264,7 @@ namespace yield_plugin
     }
 
     // return original trajectory if no difference in trajectory points a.k.a no collision
-    if (fabs(rclcpp::Time(original_trajectory.trajectory_points.back().target_time).seconds() - rclcpp::Time(yield_trajectory.trajectory_points.front().target_time).seconds()) < 0.01)
+    if (fabs(rclcpp::Time(original_trajectory.trajectory_points.back().target_time).seconds() - rclcpp::Time(yield_trajectory.trajectory_points.back().target_time).seconds()) < 0.01)
     {
       resp->trajectory_plan = original_trajectory;
     }
@@ -543,7 +543,6 @@ namespace yield_plugin
     std::set<int> checked_external_object_ids;
     rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
 
-
     RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
 
     if (wm_->getRoute() == nullptr)
@@ -619,7 +618,6 @@ namespace yield_plugin
 
       if (p1b_t >= collision_timestamp_in_seconds)
       {
-        // TODO GEOMETRY
         auto dx = p1b.x - p1a.x;
         auto dy = p1b.y - p1a.y;
         tf2::Vector3 trajectory_direction(dx, dy, 0);
@@ -638,7 +636,6 @@ namespace yield_plugin
         return return_value;
       }
     }
-    // TODO error
     return 0.0;
   }
 

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -157,7 +157,7 @@ namespace yield_plugin
         carma_v2x_msgs::msg::Trajectory incoming_trajectory = incoming_request.trajectory;
         std::string req_strategy_params = incoming_request.strategy_params;
         clc_urgency_ = incoming_request.urgency;
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
 
         // Parse strategy parameters
         using boost::property_tree::ptree;
@@ -169,9 +169,9 @@ namespace yield_plugin
         int start_lanelet_id = pt.get<int>("sl");
         int end_lanelet_id = pt.get<int>("el");
         double req_traj_speed = static_cast<double>(req_traj_speed_full) + static_cast<double>(req_traj_fractional)/10.0;
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
 
         std::vector<lanelet::BasicPoint2d> req_traj_plan = {};
 
@@ -217,7 +217,7 @@ namespace yield_plugin
     req_trajectory_points_ = req_trajectory;
     req_target_speed_ = req_speed;
     req_target_plan_time_ = req_planning_time;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
     req_timestamp_ = req_timestamp;
   }
 
@@ -262,17 +262,24 @@ namespace yield_plugin
       RCLCPP_DEBUG(nh_->get_logger(),"Yield for object avoidance");
       yield_trajectory = update_traj_for_object(original_trajectory, external_objects_, req->vehicle_state.longitudinal_vel); // Compute the trajectory
     }
-    yield_trajectory.header.frame_id = "map";
-    yield_trajectory.header.stamp = nh_->now();
-    yield_trajectory.trajectory_id = original_trajectory.trajectory_id;
-    yield_trajectory.initial_longitudinal_velocity = original_trajectory.initial_longitudinal_velocity;//copy the original trajectory's desired speed for now.
 
-    resp->trajectory_plan = yield_trajectory;
+    // return original trajectory if no difference in trajectory points a.k.a no collision
+    if (fabs(rclcpp::Time(original_trajectory.trajectory_points.back().target_time).seconds() - rclcpp::Time(yield_trajectory.trajectory_points.front().target_time).seconds()) < 0.01)
+    {
+      resp->trajectory_plan = original_trajectory;
+    }
+    else
+    {
+      yield_trajectory.header.frame_id = "map";
+      yield_trajectory.header.stamp = nh_->now();
+      yield_trajectory.trajectory_id = original_trajectory.trajectory_id;
+      resp->trajectory_plan = yield_trajectory;
+    }
 
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
 
   }
 
@@ -303,14 +310,14 @@ namespace yield_plugin
       double dy = original_tp.trajectory_points[0].y - intersection_point.y();
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       goal_pos = sqrt(dx*dx + dy*dy) - config_.x_gap;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
       double collision_time = req_timestamp_ + (intersection_points[0].first * ecef_traj_timestep_) - config_.safety_collision_time_gap;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
       // calculate distance traveled from beginning of trajectory to collision point
       double dx2 = intersection_point.x() - req_trajectory_points_[0].x();
       double dy2 = intersection_point.y() - req_trajectory_points_[0].y();
@@ -320,13 +327,14 @@ namespace yield_plugin
       goal_velocity = std::min(goal_velocity, incoming_trajectory_speed);
       double min_time = (initial_velocity - goal_velocity)/config_.yield_max_deceleration;
 
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
 
       if (planning_time > min_time)
       {
         cooperative_request_acceptable_ = true;
-        cooperative_trajectory = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, planning_time);
+        double original_max_speed = max_trajectory_speed(original_tp.trajectory_points, rclcpp::Time(original_tp.trajectory_points.back().target_time).seconds());
+        cooperative_trajectory = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, planning_time, original_max_speed);
       }
       else
       {
@@ -346,7 +354,7 @@ namespace yield_plugin
     return cooperative_trajectory;
   }
 
-  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time)
+  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time, double original_max_speed)
   {
     carma_planning_msgs::msg::TrajectoryPlan jmt_trajectory;
     std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint> jmt_trajectory_points;
@@ -356,8 +364,8 @@ namespace yield_plugin
     double initial_accel = 0.0;
     double goal_accel = 0.0;
 
-    double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
+    //double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"original_max_speed: " << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,
                                                                                                 initial_velocity,
@@ -367,64 +375,104 @@ namespace yield_plugin
                                                                                                 initial_time,
                                                                                                 planning_time);
 
-    std::vector<double> original_traj_downtracks = get_relative_downtracks(original_tp);
+    std::vector<double> original_traj_relative_downtracks = get_relative_downtracks(original_tp);
     std::vector<double> calculated_speeds = {};
+    std::vector<double> new_relative_downtracks = {};
+    new_relative_downtracks.push_back(0.0);
     calculated_speeds.push_back(initial_velocity);
-    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++ )
-    {
-      double traj_target_time = i * planning_time / original_tp.trajectory_points.size();
-      double dt_dist = polynomial_calc(values, traj_target_time);
-      double dv = polynomial_calc_d(values, traj_target_time);
+    auto original_planning_time = (rclcpp::Time(original_tp.trajectory_points.back().target_time) - rclcpp::Time(original_tp.trajectory_points.front().target_time)).seconds();
 
-      if (dv >= original_max_speed)
+    double average_time_step = original_planning_time / original_tp.trajectory_points.size(); // arbitrary
+    double new_traj_accumulated_downtrack = 0.0;
+    double original_traj_accumulated_downtrack = original_traj_relative_downtracks.at(1);
+    int new_traj_i = 1;
+    int original_traj_i = 1;
+    while (new_traj_accumulated_downtrack < goal_pos - 0.1 && original_traj_i < original_traj_relative_downtracks.size()) // 0.1 buffer to make it stop
+    {
+      double traj_target_time = new_traj_i * average_time_step;
+      double dist_at_tt = polynomial_calc(values, traj_target_time);
+      double velocity_at_tt = polynomial_calc_d(values, traj_target_time);
+
+      RCLCPP_ERROR_STREAM(nh_->get_logger(), "Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
+      if (velocity_at_tt >= original_max_speed)
       {
-        dv = original_max_speed;
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "higher! speed velocity_at_tt: " << velocity_at_tt);
+        velocity_at_tt = original_max_speed;
       }
-      calculated_speeds.push_back(dv);
+      velocity_at_tt = std::max(velocity_at_tt, 0.0);
+
+      // pick the speeds if it matches with the original downtracks
+      if (dist_at_tt >= original_traj_accumulated_downtrack)
+      {
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Picked Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
+        calculated_speeds.push_back(velocity_at_tt);  // assuming the dist_at_tt is so close to original_traj_accumulated_downtrack; hence this speed matches that of original_traj_relative_downtracks
+        original_traj_accumulated_downtrack += original_traj_relative_downtracks.at(original_traj_i);
+        original_traj_i ++;
+      }
+      new_traj_accumulated_downtrack = dist_at_tt;
+      new_traj_i++;
     }
+
+    // TODO: combine the later speed with the newer speed before filtering?
+
     // moving average filter
     std::vector<double> filtered_speeds = basic_autonomy::smoothing::moving_average_filter(calculated_speeds, config_.speed_moving_average_window_size);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "filtered_speeds size: " << filtered_speeds.size());
 
     double prev_speed = filtered_speeds[0];
-    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++ )
+    // Modify the original trajectory based on the new filtered_speed and downtracks
+    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++)
     {
       carma_planning_msgs::msg::TrajectoryPlanPoint jmt_tpp;
-      double current_speed = filtered_speeds.at(i);
-      double traj_target_time = i * planning_time / original_tp.trajectory_points.size();
+      double current_speed = goal_velocity;
+      if (i < filtered_speeds.size())
+      {
+        current_speed = filtered_speeds.at(i);
+      }
       if (current_speed >= config_.max_stop_speed)
       {
-        double dt = (2 * original_traj_downtracks.at(i)) / (current_speed + prev_speed);
+        double dt = (2 * original_traj_relative_downtracks.at(i)) / (current_speed + prev_speed);
         jmt_tpp = original_tp.trajectory_points.at(i);
-        jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt*1e9);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+        jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt * 1e9);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
       else
       {
-        RCLCPP_DEBUG(nh_->get_logger(),"Target speed is zero");
+        RCLCPP_DEBUG(nh_->get_logger(),"Target speed is zero, applying constant time");
         // if speed is zero, the vehicle will stay in previous location.
-        jmt_tpp = jmt_trajectory_points.back();
-        // MISH: Potential bug where if purepursuit accidentally picks a point that has previous time, then it may speed up. target_time is assumed to increase
-        jmt_tpp.target_time =  rclcpp::Time(std::max((rclcpp::Time(jmt_trajectory_points[0].target_time) + rclcpp::Duration(traj_target_time*1e9)).seconds(), rclcpp::Time(jmt_trajectory_points.back().target_time).seconds()) * 1e9);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
-
+        jmt_tpp = original_tp.trajectory_points.at(i);
+        current_speed = 0;
+        if (prev_speed > 0.01)
+        {
+          double dt = (2 * original_traj_relative_downtracks.at(i)) / (prev_speed);
+          jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt * 1e9);
+        }
+        else
+        {
+          jmt_tpp.target_time = rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(6000 * 1e9); // normally 0.2 sec plan into 100 mins effectively making it stop, but keeping original points
+        }
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
         jmt_trajectory_points.push_back(jmt_tpp);
       }
+
       prev_speed = current_speed;
     }
 
     jmt_trajectory.header = original_tp.header;
     jmt_trajectory.trajectory_id = original_tp.trajectory_id;
     jmt_trajectory.trajectory_points = jmt_trajectory_points;
+    jmt_trajectory.initial_longitudinal_velocity = initial_velocity;
     return jmt_trajectory;
   }
+
 
   std::optional<rclcpp::Time> YieldPlugin::detect_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius)
   {
     // Iterate through each pair of consecutive points in the trajectories
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
 
     // Iterate through the object to check if it's on the route
     bool on_route = false;
@@ -440,7 +488,7 @@ namespace yield_plugin
 
       for (const auto& llt: corresponding_lanelets)
       {
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
 
         if (route_llt_ids_.find(llt.id()) != route_llt_ids_.end())
         {
@@ -473,15 +521,15 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
+        //
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
+        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
 
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
-
-        // Linearly interpolate positions at a common timestamp for both trajectories
+        // Linearly interpolate positions at a common timestamp (p2a_t) for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
         double x1 = p1a.x + dt * (p1b.x - p1a.x);
         double y1 = p1a.y + dt * (p1b.y - p1a.y);
@@ -491,7 +539,7 @@ namespace yield_plugin
         // Calculate the distance between the two interpolated points
         double distance = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
         smallest_dist = std::min(distance, smallest_dist);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
 
         if (i == 0 && j == 0 && distance > config_.collision_check_radius)
         {
@@ -517,7 +565,23 @@ namespace yield_plugin
         }
         else
         {
-          RCLCPP_WARN_STREAM(nh_->get_logger(), "Collision detected at timestamp " << std::to_string(p2a_t) << ", x: " << x1 << ", y: " << y1 << ", within distance: " << distance);
+
+          RCLCPP_WARN_STREAM(nh_->get_logger(), "Collision detected at timestamp " << std::to_string(p2a_t) << ", x: " << x1 << ", y: " << y1 <<
+            ", within actual downtrack distance: " << object_downtrack - vehicle_downtrack <<
+            ", and collision distance: " << distance);
+
+          RCLCPP_ERROR_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL START POINTS ==========");
+          // DEBUG
+          for (const auto& veh_point :  trajectory1.trajectory_points)
+          {
+            RCLCPP_ERROR_STREAM(nh_->get_logger(), "veh_point.x: " << veh_point.x << ", veh_point.y: " << veh_point.y);
+          }
+
+          for (const auto& ped :  trajectory2)
+          {
+            RCLCPP_ERROR_STREAM(nh_->get_logger(), "ped.x: " << ped.predicted_position.position.x << ", ped.y: " << ped.predicted_position.position.y);
+          }
+          RCLCPP_ERROR_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL END POINTS ==========");
           return rclcpp::Time(p2a.header.stamp);
         }
       }
@@ -527,35 +591,19 @@ namespace yield_plugin
     return std::nullopt;
   }
 
-  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::update_traj_for_object(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects, double initial_velocity)
+  std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> YieldPlugin::get_earliest_collision_object_and_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects)
   {
-    if (original_tp.trajectory_points.size() < 2)
-    {
-      RCLCPP_WARN(nh_->get_logger(), "Yield plugin received less than 2 points in update_traj_for_object, returning unchanged...");
-      return original_tp;
-    }
-
-    if (original_tp.trajectory_points.empty())
-    {
-      RCLCPP_ERROR(nh_->get_logger(), "Yield plugin received empty trajectory plan in update_traj_for_object");
-      throw std::invalid_argument("Yield plugin received empty trajectory plan in update_traj_for_object");
-    }
-
-    rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
-    carma_planning_msgs::msg::TrajectoryPlan update_tpp_vector;
-    geometry_msgs::msg::Twist current_velocity;
-    current_velocity.linear.x = initial_velocity;
-
     std::optional<carma_perception_msgs::msg::ExternalObject> earliest_collision_obj = std::nullopt;
     std::set<int> checked_external_object_ids;
+    rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
 
-    std::vector<carma_perception_msgs::msg::PredictedState> new_list;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
+
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
 
     if (wm_->getRoute() == nullptr)
     {
-      RCLCPP_WARN(nh_->get_logger(), "No route available!");
-      return original_tp; //route not available
+      RCLCPP_WARN(nh_->get_logger(), "Yield plugin was not able to analyze collision since route is not available! Please check if route is set");
+      return std::nullopt;
     }
 
     // save route Ids for faster access
@@ -566,21 +614,25 @@ namespace yield_plugin
 
     double earliest_collision_obj_time = std::numeric_limits<double>::max();
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
 
     for (const auto& curr_obstacle : external_objects)
     {
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time.seconds()));
+      RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time.seconds()));
 
       // do not process outdated objects
       if (rclcpp::Time(curr_obstacle.predictions.back().header.stamp) > plan_start_time)
       {
+        std::vector<carma_perception_msgs::msg::PredictedState> new_list;
         carma_perception_msgs::msg::PredictedState curr_state;
         // artificially include current position as one of the predicted states
         curr_state.header.stamp = curr_obstacle.header.stamp;
         curr_state.predicted_position.position.x = curr_obstacle.pose.pose.position.x;
         curr_state.predicted_position.position.y = curr_obstacle.pose.pose.position.y;
+        // NOTE: predicted_velocity is not used for collision calculation, but timestamps
         curr_state.predicted_velocity.linear.x = curr_obstacle.velocity.twist.linear.x;
+        curr_state.predicted_velocity.linear.y = curr_obstacle.velocity.twist.linear.y;
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << static_cast<int>(curr_obstacle.object_type) << ", speed: " << curr_obstacle.velocity.twist.linear.x);
         new_list.push_back(curr_state);
         new_list.insert(new_list.end(), curr_obstacle.predictions.cbegin(), curr_obstacle.predictions.cend());
 
@@ -600,92 +652,156 @@ namespace yield_plugin
       }
     }
 
-    lanelet::BasicPoint2d point(original_tp.trajectory_points[0].x,original_tp.trajectory_points[0].y);
-    double vehicle_downtrack = wm_->routeTrackPos(point).downtrack;
+    if (earliest_collision_obj == std::nullopt)
+      return std::nullopt;
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"earliest object x: " << earliest_collision_obj.value().velocity.twist.linear.x << ", y: " << earliest_collision_obj.value().velocity.twist.linear.y);
+
+    return std::make_pair(earliest_collision_obj.value(), earliest_collision_obj_time);
+  }
+
+  double YieldPlugin::get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds)
+  {
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds) <<
+      ", original_tp.trajectory_points.back().target_time: " << std::to_string(rclcpp::Time(original_tp.trajectory_points.back().target_time).seconds()));
+
+    for (size_t i = 0; i < original_tp.trajectory_points.size() - 1; ++i)
+    {
+      auto p1a = original_tp.trajectory_points.at(i);
+      auto p1b = original_tp.trajectory_points.at(i + 1);
+      double p1b_t = rclcpp::Time(p1b.target_time).seconds();
+
+      if (p1b_t >= collision_timestamp_in_seconds)
+      {
+        // TODO GEOMETRY
+        auto dx = p1b.x - p1a.x;
+        auto dy = p1b.y - p1a.y;
+        tf2::Vector3 trajectory_direction(dx, dy, 0);
+        if (trajectory_direction.length() < 0.001) //EPSILON
+        {
+          return 0.0;
+        }
+        tf2::Vector3 object_direction(object_velocity_in_map_frame.linear.x, object_velocity_in_map_frame.linear.y, 0);
+
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds)
+          << ", p1b_t: " << std::to_string(p1b_t)
+          << ", dx: " << dx << ", dy: " << dy << ", "
+          << ", object_velocity_in_map_frame.x: " << object_velocity_in_map_frame.linear.x
+          << ", object_velocity_in_map_frame.y: " << object_velocity_in_map_frame.linear.y);
+        auto return_value = static_cast<double>(tf2::tf2Dot(object_direction, trajectory_direction)) / trajectory_direction.length();
+        return return_value;
+      }
+    }
+    // TODO error
+    return 0.0;
+  }
+
+  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::update_traj_for_object(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects, double initial_velocity)
+  {
+    if (original_tp.trajectory_points.size() < 2)
+    {
+      RCLCPP_WARN(nh_->get_logger(), "Yield plugin received less than 2 points in update_traj_for_object, returning unchanged...");
+      return original_tp;
+    }
+
+    if (original_tp.trajectory_points.empty())
+    {
+      RCLCPP_ERROR(nh_->get_logger(), "Yield plugin received empty trajectory plan in update_traj_for_object");
+      throw std::invalid_argument("Yield plugin received empty trajectory plan in update_traj_for_object");
+    }
+
+    rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
+    carma_planning_msgs::msg::TrajectoryPlan update_tpp_vector;
+
+    // GET EARLIEST COLLISION OBJECT TODO
+    std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> earliest_collision_obj_pair = get_earliest_collision_object_and_time(original_tp, external_objects);
+
+    if (!earliest_collision_obj_pair.has_value())
+    {
+      RCLCPP_DEBUG(nh_->get_logger(),"No collision detection, so trajectory not modified.");
+      return original_tp;
+    }
+
+    carma_perception_msgs::msg::ExternalObject earliest_collision_obj = earliest_collision_obj_pair.value().first;
+    double earliest_collision_time = earliest_collision_obj_pair.value().second;
 
     // Issue (https://github.com/usdot-fhwa-stol/carma-platform/issues/2155): If the yield_plugin can detect if the roadway object is moving along the route,
     // it is able to plan yielding much earlier and smoother using on_route_vehicle_collision_horizon.
 
-    if(earliest_collision_obj.has_value())
-    {
-      RCLCPP_WARN_STREAM(nh_->get_logger(),"Collision Detected!");
+    lanelet::BasicPoint2d point(original_tp.trajectory_points[0].x,original_tp.trajectory_points[0].y);
+    double vehicle_downtrack = wm_->routeTrackPos(point).downtrack;
 
-      lanelet::BasicPoint2d point_o(earliest_collision_obj.value().pose.pose.position.x, earliest_collision_obj.value().pose.pose.position.y);
-      double object_downtrack = wm_->routeTrackPos(point_o).downtrack;
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
 
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
+    RCLCPP_WARN_STREAM(nh_->get_logger(),"Collision Detected!");
 
-      double dist_to_object = object_downtrack - vehicle_downtrack;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"dist_to_object: " << dist_to_object);
+    lanelet::BasicPoint2d point_o(earliest_collision_obj.pose.pose.position.x, earliest_collision_obj.pose.pose.position.y);
+    double object_downtrack = wm_->routeTrackPos(point_o).downtrack;
 
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object speed: " << earliest_collision_obj.value().velocity.twist.linear.x);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
 
-      // Distance from the original trajectory point to the lead vehicle/object
-      double dist_x = earliest_collision_obj.value().pose.pose.position.x - original_tp.trajectory_points[0].x;
-      double dist_y = earliest_collision_obj.value().pose.pose.position.y - original_tp.trajectory_points[0].y;
-      double x_lead = sqrt(dist_x*dist_x + dist_y*dist_y);
+    double x_lead = std::max(0.0, object_downtrack - vehicle_downtrack);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"x_lead: " << x_lead);
 
-      // roadway object position
-      double gap_time = (x_lead - config_.x_gap)/initial_velocity;
+    double goal_velocity = get_object_velocity_along_trajectory(earliest_collision_obj.velocity.twist, original_tp, earliest_collision_time);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
 
-      double goal_velocity = earliest_collision_obj.value().velocity.twist.linear.x;
-      // determine the safety inter-vehicle gap based on speed
-      double safety_gap = std::max(goal_velocity * gap_time, config_.x_gap);
-      if (config_.enable_adjustable_gap)
-      {
-        // check if a digital_gap is available
-        double digital_gap = check_traj_for_digital_min_gap(original_tp);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
-        // if a digital gap is available, it is replaced as safety gap
-        safety_gap = std::max(safety_gap, digital_gap);
-      }
-      // safety gap is implemented
-      double goal_pos = x_lead - safety_gap;
+    // roadway object position
+    double gap_time = std::max(0.0, x_lead - config_.x_gap)/initial_velocity;
 
-      if (goal_velocity <= config_.min_obstacle_speed){
-        RCLCPP_WARN(nh_->get_logger(),"The obstacle is not moving, goal velocity is set to 0");
-        goal_velocity = 0.0;
-      }
-
-      double initial_time = 0;
-      double initial_pos = 0.0; //relative initial position (first trajectory point)
-
-      double initial_accel = 0;
-      double goal_accel = 0;
-
-      double delta_v_max = fabs(earliest_collision_obj.value().velocity.twist.linear.x - max_trajectory_speed(original_tp.trajectory_points));
-      // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
-      double t_ref = (rclcpp::Time(original_tp.trajectory_points[original_tp.trajectory_points.size() - 1].target_time).seconds() - plan_start_time.seconds());
-      // time required for comfortable deceleration
-      double t_ph = config_.acceleration_adjustment_factor * delta_v_max / config_.yield_max_deceleration;
-
-      // planning time for object avoidance
-      double tp = 0;
-
-      if(t_ph > config_.tpmin && t_ref > t_ph)
-      {
-        tp = t_ph;
-      }
-      else if(t_ph < config_.tpmin)
-      {
-        tp = config_.tpmin;
-      }
-      else
-      {
-        tp = t_ref;
-      }
-
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
-
-      update_tpp_vector = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp);
-
-      return update_tpp_vector;
+    if (goal_velocity <= config_.min_obstacle_speed){
+      RCLCPP_WARN_STREAM(nh_->get_logger(),"The obstacle is not moving, goal velocity is set to 0 from: " << goal_velocity);
+      goal_velocity = 0.0;
     }
 
-    RCLCPP_DEBUG(nh_->get_logger(),"No collision detection, so trajectory not modified.");
-    return original_tp;
+    // determine the safety inter-vehicle gap based on speed
+    double safety_gap = std::max(goal_velocity * gap_time, config_.x_gap);
+    if (!std::isnormal(safety_gap))
+    {
+      RCLCPP_WARN_STREAM(rclcpp::get_logger("yield_plugin"),"Detected non-normal (nan, inf, etc.) safety_gap. Making it desired safety gap configured at config_.x_gap: " << config_.x_gap);
+      safety_gap = config_.x_gap;
+    }
+    if (config_.enable_adjustable_gap)
+    {
+      // check if a digital_gap is available
+      double digital_gap = check_traj_for_digital_min_gap(original_tp);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      // if a digital gap is available, it is replaced as safety gap
+      safety_gap = std::max(safety_gap, digital_gap);
+    }
+    // safety gap is implemented
+    double goal_pos = std::max(0.0, x_lead - safety_gap);
+    double initial_pos = 0.0; //relative initial position (first trajectory point)
+    double original_max_speed = max_trajectory_speed(original_tp.trajectory_points, earliest_collision_time);
+    double delta_v_max = fabs(goal_velocity - original_max_speed);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
+
+    // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
+    double t_ref = (rclcpp::Time(original_tp.trajectory_points[original_tp.trajectory_points.size() - 1].target_time).seconds() - plan_start_time.seconds());
+    // time required for comfortable deceleration
+    double t_ph = config_.acceleration_adjustment_factor * delta_v_max / config_.yield_max_deceleration;
+
+    // planning time for object avoidance
+    double tp = 0;
+
+    if(t_ph > config_.tpmin && t_ref > t_ph)
+    {
+      tp = t_ph;
+    }
+    else if(t_ph < config_.tpmin)
+    {
+      tp = config_.tpmin;
+    }
+    else
+    {
+      tp = t_ref;
+    }
+
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
+
+    update_tpp_vector = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp, original_max_speed);
+
+    return update_tpp_vector;
   }
 
 
@@ -726,7 +842,7 @@ namespace yield_plugin
     return result;
   }
 
-  double YieldPlugin::max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points) const
+  double YieldPlugin::max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double earliest_collision_time) const
   {
     double max_speed = 0;
     for(size_t i = 0; i < trajectory_points.size() - 2; i++ )
@@ -740,6 +856,11 @@ namespace yield_plugin
       {
         max_speed = v;
       }
+      if (rclcpp::Time(trajectory_points.at(i + 1).target_time).seconds() >= earliest_collision_time)
+      {
+        break;
+      }
+
     }
     return max_speed;
   }
@@ -762,7 +883,7 @@ namespace yield_plugin
       if (!digital_min_gap.empty())
       {
         double digital_gap = digital_min_gap[0]->getMinimumGap(); // Provided gap is in meters
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
         desired_gap = std::max(desired_gap, digital_gap);
       }
     }

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -157,7 +157,7 @@ namespace yield_plugin
         carma_v2x_msgs::msg::Trajectory incoming_trajectory = incoming_request.trajectory;
         std::string req_strategy_params = incoming_request.strategy_params;
         clc_urgency_ = incoming_request.urgency;
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
 
         // Parse strategy parameters
         using boost::property_tree::ptree;
@@ -169,9 +169,9 @@ namespace yield_plugin
         int start_lanelet_id = pt.get<int>("sl");
         int end_lanelet_id = pt.get<int>("el");
         double req_traj_speed = static_cast<double>(req_traj_speed_full) + static_cast<double>(req_traj_fractional)/10.0;
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
 
         std::vector<lanelet::BasicPoint2d> req_traj_plan = {};
 
@@ -217,7 +217,7 @@ namespace yield_plugin
     req_trajectory_points_ = req_trajectory;
     req_target_speed_ = req_speed;
     req_target_plan_time_ = req_planning_time;
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
     req_timestamp_ = req_timestamp;
   }
 
@@ -279,7 +279,7 @@ namespace yield_plugin
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
 
   }
 
@@ -310,14 +310,14 @@ namespace yield_plugin
       double dy = original_tp.trajectory_points[0].y - intersection_point.y();
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       goal_pos = sqrt(dx*dx + dy*dy) - config_.x_gap;
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
       double collision_time = req_timestamp_ + (intersection_points[0].first * ecef_traj_timestep_) - config_.safety_collision_time_gap;
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
       // calculate distance traveled from beginning of trajectory to collision point
       double dx2 = intersection_point.x() - req_trajectory_points_[0].x();
       double dy2 = intersection_point.y() - req_trajectory_points_[0].y();
@@ -327,8 +327,8 @@ namespace yield_plugin
       goal_velocity = std::min(goal_velocity, incoming_trajectory_speed);
       double min_time = (initial_velocity - goal_velocity)/config_.yield_max_deceleration;
 
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
 
       if (planning_time > min_time)
       {
@@ -365,7 +365,7 @@ namespace yield_plugin
     double goal_accel = 0.0;
 
     //double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"original_max_speed: " << original_max_speed);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed: " << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,
                                                                                                 initial_velocity,
@@ -393,10 +393,10 @@ namespace yield_plugin
       double dist_at_tt = polynomial_calc(values, traj_target_time);
       double velocity_at_tt = polynomial_calc_d(values, traj_target_time);
 
-      RCLCPP_ERROR_STREAM(nh_->get_logger(), "Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
       if (velocity_at_tt >= original_max_speed)
       {
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "higher! speed velocity_at_tt: " << velocity_at_tt);
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "higher! speed velocity_at_tt: " << velocity_at_tt);
         velocity_at_tt = original_max_speed;
       }
       velocity_at_tt = std::max(velocity_at_tt, 0.0);
@@ -404,7 +404,7 @@ namespace yield_plugin
       // pick the speeds if it matches with the original downtracks
       if (dist_at_tt >= original_traj_accumulated_downtrack)
       {
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Picked Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Picked Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
         calculated_speeds.push_back(velocity_at_tt);  // assuming the dist_at_tt is so close to original_traj_accumulated_downtrack; hence this speed matches that of original_traj_relative_downtracks
         original_traj_accumulated_downtrack += original_traj_relative_downtracks.at(original_traj_i);
         original_traj_i ++;
@@ -417,7 +417,7 @@ namespace yield_plugin
 
     // moving average filter
     std::vector<double> filtered_speeds = basic_autonomy::smoothing::moving_average_filter(calculated_speeds, config_.speed_moving_average_window_size);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "filtered_speeds size: " << filtered_speeds.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "filtered_speeds size: " << filtered_speeds.size());
 
     double prev_speed = filtered_speeds[0];
     // Modify the original trajectory based on the new filtered_speed and downtracks
@@ -434,7 +434,7 @@ namespace yield_plugin
         double dt = (2 * original_traj_relative_downtracks.at(i)) / (current_speed + prev_speed);
         jmt_tpp = original_tp.trajectory_points.at(i);
         jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt * 1e9);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
@@ -453,7 +453,7 @@ namespace yield_plugin
         {
           jmt_tpp.target_time = rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(6000 * 1e9); // normally 0.2 sec plan into 100 mins effectively making it stop, but keeping original points
         }
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
         jmt_trajectory_points.push_back(jmt_tpp);
       }
 
@@ -472,7 +472,7 @@ namespace yield_plugin
   {
     // Iterate through each pair of consecutive points in the trajectories
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
 
     // Iterate through the object to check if it's on the route
     bool on_route = false;
@@ -488,7 +488,7 @@ namespace yield_plugin
 
       for (const auto& llt: corresponding_lanelets)
       {
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
 
         if (route_llt_ids_.find(llt.id()) != route_llt_ids_.end())
         {
@@ -521,13 +521,13 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
         //
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
-        //RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
+        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
 
         // Linearly interpolate positions at a common timestamp (p2a_t) for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
@@ -539,7 +539,7 @@ namespace yield_plugin
         // Calculate the distance between the two interpolated points
         double distance = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
         smallest_dist = std::min(distance, smallest_dist);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
 
         if (i == 0 && j == 0 && distance > config_.collision_check_radius)
         {
@@ -570,18 +570,18 @@ namespace yield_plugin
             ", within actual downtrack distance: " << object_downtrack - vehicle_downtrack <<
             ", and collision distance: " << distance);
 
-          RCLCPP_ERROR_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL START POINTS ==========");
+          RCLCPP_DEBUG_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL START POINTS ==========");
           // DEBUG
           for (const auto& veh_point :  trajectory1.trajectory_points)
           {
-            RCLCPP_ERROR_STREAM(nh_->get_logger(), "veh_point.x: " << veh_point.x << ", veh_point.y: " << veh_point.y);
+            RCLCPP_DEBUG_STREAM(nh_->get_logger(), "veh_point.x: " << veh_point.x << ", veh_point.y: " << veh_point.y);
           }
 
           for (const auto& ped :  trajectory2)
           {
-            RCLCPP_ERROR_STREAM(nh_->get_logger(), "ped.x: " << ped.predicted_position.position.x << ", ped.y: " << ped.predicted_position.position.y);
+            RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ped.x: " << ped.predicted_position.position.x << ", ped.y: " << ped.predicted_position.position.y);
           }
-          RCLCPP_ERROR_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL END POINTS ==========");
+          RCLCPP_DEBUG_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL END POINTS ==========");
           return rclcpp::Time(p2a.header.stamp);
         }
       }
@@ -598,7 +598,7 @@ namespace yield_plugin
     rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
 
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
 
     if (wm_->getRoute() == nullptr)
     {
@@ -614,11 +614,11 @@ namespace yield_plugin
 
     double earliest_collision_obj_time = std::numeric_limits<double>::max();
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
 
     for (const auto& curr_obstacle : external_objects)
     {
-      RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time.seconds()));
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time.seconds()));
 
       // do not process outdated objects
       if (rclcpp::Time(curr_obstacle.predictions.back().header.stamp) > plan_start_time)
@@ -632,7 +632,7 @@ namespace yield_plugin
         // NOTE: predicted_velocity is not used for collision calculation, but timestamps
         curr_state.predicted_velocity.linear.x = curr_obstacle.velocity.twist.linear.x;
         curr_state.predicted_velocity.linear.y = curr_obstacle.velocity.twist.linear.y;
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << static_cast<int>(curr_obstacle.object_type) << ", speed: " << curr_obstacle.velocity.twist.linear.x);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << static_cast<int>(curr_obstacle.object_type) << ", speed: " << curr_obstacle.velocity.twist.linear.x);
         new_list.push_back(curr_state);
         new_list.insert(new_list.end(), curr_obstacle.predictions.cbegin(), curr_obstacle.predictions.cend());
 
@@ -655,14 +655,14 @@ namespace yield_plugin
     if (earliest_collision_obj == std::nullopt)
       return std::nullopt;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"earliest object x: " << earliest_collision_obj.value().velocity.twist.linear.x << ", y: " << earliest_collision_obj.value().velocity.twist.linear.y);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"earliest object x: " << earliest_collision_obj.value().velocity.twist.linear.x << ", y: " << earliest_collision_obj.value().velocity.twist.linear.y);
 
     return std::make_pair(earliest_collision_obj.value(), earliest_collision_obj_time);
   }
 
   double YieldPlugin::get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds)
   {
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds) <<
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds) <<
       ", original_tp.trajectory_points.back().target_time: " << std::to_string(rclcpp::Time(original_tp.trajectory_points.back().target_time).seconds()));
 
     for (size_t i = 0; i < original_tp.trajectory_points.size() - 1; ++i)
@@ -683,7 +683,7 @@ namespace yield_plugin
         }
         tf2::Vector3 object_direction(object_velocity_in_map_frame.linear.x, object_velocity_in_map_frame.linear.y, 0);
 
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds)
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds)
           << ", p1b_t: " << std::to_string(p1b_t)
           << ", dx: " << dx << ", dy: " << dy << ", "
           << ", object_velocity_in_map_frame.x: " << object_velocity_in_map_frame.linear.x
@@ -731,20 +731,20 @@ namespace yield_plugin
     lanelet::BasicPoint2d point(original_tp.trajectory_points[0].x,original_tp.trajectory_points[0].y);
     double vehicle_downtrack = wm_->routeTrackPos(point).downtrack;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
 
     RCLCPP_WARN_STREAM(nh_->get_logger(),"Collision Detected!");
 
     lanelet::BasicPoint2d point_o(earliest_collision_obj.pose.pose.position.x, earliest_collision_obj.pose.pose.position.y);
     double object_downtrack = wm_->routeTrackPos(point_o).downtrack;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
 
     double x_lead = std::max(0.0, object_downtrack - vehicle_downtrack);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"x_lead: " << x_lead);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"x_lead: " << x_lead);
 
     double goal_velocity = get_object_velocity_along_trajectory(earliest_collision_obj.velocity.twist, original_tp, earliest_collision_time);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
 
     // roadway object position
     double gap_time = std::max(0.0, x_lead - config_.x_gap)/initial_velocity;
@@ -765,7 +765,7 @@ namespace yield_plugin
     {
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       // if a digital gap is available, it is replaced as safety gap
       safety_gap = std::max(safety_gap, digital_gap);
     }
@@ -774,7 +774,7 @@ namespace yield_plugin
     double initial_pos = 0.0; //relative initial position (first trajectory point)
     double original_max_speed = max_trajectory_speed(original_tp.trajectory_points, earliest_collision_time);
     double delta_v_max = fabs(goal_velocity - original_max_speed);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
 
     // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
     double t_ref = (rclcpp::Time(original_tp.trajectory_points[original_tp.trajectory_points.size() - 1].target_time).seconds() - plan_start_time.seconds());
@@ -797,7 +797,7 @@ namespace yield_plugin
       tp = t_ref;
     }
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
 
     update_tpp_vector = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp, original_max_speed);
 
@@ -883,7 +883,7 @@ namespace yield_plugin
       if (!digital_min_gap.empty())
       {
         double digital_gap = digital_min_gap[0]->getMinimumGap(); // Provided gap is in meters
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
         desired_gap = std::max(desired_gap, digital_gap);
       }
     }

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -656,12 +656,12 @@ namespace yield_plugin
     rclcpp::Time plan_start_time = original_tp.trajectory_points[0].target_time;
     carma_planning_msgs::msg::TrajectoryPlan update_tpp_vector;
 
-    // GET EARLIEST COLLISION OBJECT TODO
+    // Get earliest collision object
     std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> earliest_collision_obj_pair = get_earliest_collision_object_and_time(original_tp, external_objects);
 
-    if (!earliest_collision_obj_pair.has_value())
+    if (!earliest_collision_obj_pair)
     {
-      RCLCPP_DEBUG(nh_->get_logger(),"No collision detection, so trajectory not modified.");
+      RCLCPP_DEBUG(nh_->get_logger(),"No collision detected, so trajectory not modified.");
       return original_tp;
     }
 

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -481,15 +481,15 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
-        //
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
 
-        // Linearly interpolate positions at a common timestamp (p2a_t) for both trajectories
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
+
+        // Linearly interpolate positions at a common timestamp for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
         double x1 = p1a.x + dt * (p1b.x - p1a.x);
         double y1 = p1a.y + dt * (p1b.y - p1a.y);
@@ -525,23 +525,9 @@ namespace yield_plugin
         }
         else
         {
-
           RCLCPP_WARN_STREAM(nh_->get_logger(), "Collision detected at timestamp " << std::to_string(p2a_t) << ", x: " << x1 << ", y: " << y1 <<
             ", within actual downtrack distance: " << object_downtrack - vehicle_downtrack <<
             ", and collision distance: " << distance);
-
-          RCLCPP_DEBUG_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL START POINTS ==========");
-          // DEBUG
-          for (const auto& veh_point :  trajectory1.trajectory_points)
-          {
-            RCLCPP_DEBUG_STREAM(nh_->get_logger(), "veh_point.x: " << veh_point.x << ", veh_point.y: " << veh_point.y);
-          }
-
-          for (const auto& ped :  trajectory2)
-          {
-            RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ped.x: " << ped.predicted_position.position.x << ", ped.y: " << ped.predicted_position.position.y);
-          }
-          RCLCPP_DEBUG_STREAM(nh_->get_logger(), "======= COLLISION ORIGINAL END POINTS ==========");
           return rclcpp::Time(p2a.header.stamp);
         }
       }

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -354,7 +354,8 @@ namespace yield_plugin
     return cooperative_trajectory;
   }
 
-  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos, double initial_velocity, double goal_velocity, double planning_time, double original_max_speed)
+  carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::generate_JMT_trajectory(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double initial_pos, double goal_pos,
+    double initial_velocity, double goal_velocity, double planning_time, double original_max_speed)
   {
     carma_planning_msgs::msg::TrajectoryPlan jmt_trajectory;
     std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint> jmt_trajectory_points;
@@ -364,8 +365,8 @@ namespace yield_plugin
     double initial_accel = 0.0;
     double goal_accel = 0.0;
 
-    //double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed: " << original_max_speed);
+    double original_max_speed = max_trajectory_speed(original_tp.trajectory_points);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,
                                                                                                 initial_velocity,
@@ -375,98 +376,58 @@ namespace yield_plugin
                                                                                                 initial_time,
                                                                                                 planning_time);
 
-    std::vector<double> original_traj_relative_downtracks = get_relative_downtracks(original_tp);
+    std::vector<double> original_traj_downtracks = get_relative_downtracks(original_tp);
     std::vector<double> calculated_speeds = {};
-    std::vector<double> new_relative_downtracks = {};
-    new_relative_downtracks.push_back(0.0);
     calculated_speeds.push_back(initial_velocity);
-    auto original_planning_time = (rclcpp::Time(original_tp.trajectory_points.back().target_time) - rclcpp::Time(original_tp.trajectory_points.front().target_time)).seconds();
-
-    double average_time_step = original_planning_time / original_tp.trajectory_points.size(); // arbitrary
-    double new_traj_accumulated_downtrack = 0.0;
-    double original_traj_accumulated_downtrack = original_traj_relative_downtracks.at(1);
-    int new_traj_i = 1;
-    int original_traj_i = 1;
-    while (new_traj_accumulated_downtrack < goal_pos - 0.1 && original_traj_i < original_traj_relative_downtracks.size()) // 0.1 buffer to make it stop
+    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++ )
     {
-      double traj_target_time = new_traj_i * average_time_step;
-      double dist_at_tt = polynomial_calc(values, traj_target_time);
-      double velocity_at_tt = polynomial_calc_d(values, traj_target_time);
+      double traj_target_time = i * planning_time / original_tp.trajectory_points.size();
+      double dt_dist = polynomial_calc(values, traj_target_time);
+      double dv = polynomial_calc_d(values, traj_target_time);
 
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
-      if (velocity_at_tt >= original_max_speed)
+      if (dv >= original_max_speed)
       {
-        //RCLCPP_DEBUG_STREAM(nh_->get_logger(), "higher! speed velocity_at_tt: " << velocity_at_tt);
-        velocity_at_tt = original_max_speed;
+        dv = original_max_speed;
       }
-      velocity_at_tt = std::max(velocity_at_tt, 0.0);
-
-      // pick the speeds if it matches with the original downtracks
-      if (dist_at_tt >= original_traj_accumulated_downtrack)
-      {
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Picked Calculated speed velocity_at_tt: " << velocity_at_tt << ", dist_at_tt: "<< dist_at_tt << ", traj_target_time: " << traj_target_time);
-        calculated_speeds.push_back(velocity_at_tt);  // assuming the dist_at_tt is so close to original_traj_accumulated_downtrack; hence this speed matches that of original_traj_relative_downtracks
-        original_traj_accumulated_downtrack += original_traj_relative_downtracks.at(original_traj_i);
-        original_traj_i ++;
-      }
-      new_traj_accumulated_downtrack = dist_at_tt;
-      new_traj_i++;
+      calculated_speeds.push_back(dv);
     }
-
-    // TODO: combine the later speed with the newer speed before filtering?
-
     // moving average filter
     std::vector<double> filtered_speeds = basic_autonomy::smoothing::moving_average_filter(calculated_speeds, config_.speed_moving_average_window_size);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "filtered_speeds size: " << filtered_speeds.size());
 
     double prev_speed = filtered_speeds[0];
-    // Modify the original trajectory based on the new filtered_speed and downtracks
-    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++)
+    for(size_t i = 1; i < original_tp.trajectory_points.size(); i++ )
     {
       carma_planning_msgs::msg::TrajectoryPlanPoint jmt_tpp;
-      double current_speed = goal_velocity;
-      if (i < filtered_speeds.size())
-      {
-        current_speed = filtered_speeds.at(i);
-      }
+      double current_speed = filtered_speeds.at(i);
+      double traj_target_time = i * planning_time / original_tp.trajectory_points.size();
       if (current_speed >= config_.max_stop_speed)
       {
-        double dt = (2 * original_traj_relative_downtracks.at(i)) / (current_speed + prev_speed);
+        double dt = (2 * original_traj_downtracks.at(i)) / (current_speed + prev_speed);
         jmt_tpp = original_tp.trajectory_points.at(i);
-        jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt * 1e9);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
+        jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt*1e9);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
       else
       {
-        RCLCPP_DEBUG(nh_->get_logger(),"Target speed is zero, applying constant time");
+        RCLCPP_DEBUG(nh_->get_logger(),"Target speed is zero");
         // if speed is zero, the vehicle will stay in previous location.
-        jmt_tpp = original_tp.trajectory_points.at(i);
-        current_speed = 0;
-        if (prev_speed > 0.01)
-        {
-          double dt = (2 * original_traj_relative_downtracks.at(i)) / (prev_speed);
-          jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt * 1e9);
-        }
-        else
-        {
-          jmt_tpp.target_time = rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(6000 * 1e9); // normally 0.2 sec plan into 100 mins effectively making it stop, but keeping original points
-        }
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()) << ", prev_speed: " << prev_speed << ", current_speed: " << current_speed);
+        jmt_tpp = jmt_trajectory_points.back();
+        // MISH: Potential bug where if purepursuit accidentally picks a point that has previous time, then it may speed up. target_time is assumed to increase
+        jmt_tpp.target_time =  rclcpp::Time(std::max((rclcpp::Time(jmt_trajectory_points[0].target_time) + rclcpp::Duration(traj_target_time*1e9)).seconds(), rclcpp::Time(jmt_trajectory_points.back().target_time).seconds()) * 1e9);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+
         jmt_trajectory_points.push_back(jmt_tpp);
       }
-
       prev_speed = current_speed;
     }
 
     jmt_trajectory.header = original_tp.header;
     jmt_trajectory.trajectory_id = original_tp.trajectory_id;
     jmt_trajectory.trajectory_points = jmt_trajectory_points;
-    jmt_trajectory.initial_longitudinal_velocity = initial_velocity;
     return jmt_trajectory;
   }
-
 
   std::optional<rclcpp::Time> YieldPlugin::detect_collision_time(const carma_planning_msgs::msg::TrajectoryPlan& trajectory1, const std::vector<carma_perception_msgs::msg::PredictedState>& trajectory2, double collision_radius)
   {

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -157,7 +157,7 @@ namespace yield_plugin
         carma_v2x_msgs::msg::Trajectory incoming_trajectory = incoming_request.trajectory;
         std::string req_strategy_params = incoming_request.strategy_params;
         clc_urgency_ = incoming_request.urgency;
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
 
         // Parse strategy parameters
         using boost::property_tree::ptree;
@@ -169,9 +169,9 @@ namespace yield_plugin
         int start_lanelet_id = pt.get<int>("sl");
         int end_lanelet_id = pt.get<int>("el");
         double req_traj_speed = static_cast<double>(req_traj_speed_full) + static_cast<double>(req_traj_fractional)/10.0;
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
 
         std::vector<lanelet::BasicPoint2d> req_traj_plan = {};
 
@@ -217,7 +217,7 @@ namespace yield_plugin
     req_trajectory_points_ = req_trajectory;
     req_target_speed_ = req_speed;
     req_target_plan_time_ = req_planning_time;
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
     req_timestamp_ = req_timestamp;
   }
 
@@ -290,7 +290,7 @@ namespace yield_plugin
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
 
   }
 
@@ -321,14 +321,14 @@ namespace yield_plugin
       double dy = original_tp.trajectory_points[0].y - intersection_point.y();
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       goal_pos = sqrt(dx*dx + dy*dy) - config_.minimum_safety_gap_in_meters;
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
       double collision_time = req_timestamp_ + (intersection_points[0].first * ecef_traj_timestep_) - config_.safety_collision_time_gap_in_s;
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
       // calculate distance traveled from beginning of trajectory to collision point
       double dx2 = intersection_point.x() - req_trajectory_points_[0].x();
       double dy2 = intersection_point.y() - req_trajectory_points_[0].y();
@@ -338,8 +338,8 @@ namespace yield_plugin
       goal_velocity = std::min(goal_velocity, incoming_trajectory_speed);
       double min_time = (initial_velocity - goal_velocity)/config_.yield_max_deceleration_in_ms2;
 
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
 
       if (planning_time > min_time)
       {
@@ -376,7 +376,7 @@ namespace yield_plugin
     double initial_accel = 0.0;
     double goal_accel = 0.0;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,
                                                                                                 initial_velocity,
@@ -415,7 +415,7 @@ namespace yield_plugin
         double dt = (2 * original_traj_downtracks.at(i)) / (current_speed + prev_speed);
         jmt_tpp = original_tp.trajectory_points.at(i);
         jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt*1e9);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
@@ -426,7 +426,7 @@ namespace yield_plugin
         jmt_tpp = jmt_trajectory_points.back();
         // MISH: Potential bug where if purepursuit accidentally picks a point that has previous time, then it may speed up. target_time is assumed to increase
         jmt_tpp.target_time =  rclcpp::Time(std::max((rclcpp::Time(jmt_trajectory_points[0].target_time) + rclcpp::Duration(traj_target_time*1e9)).seconds(), rclcpp::Time(jmt_trajectory_points.back().target_time).seconds()) * 1e9);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
@@ -444,7 +444,7 @@ namespace yield_plugin
 
     // Iterate through each pair of consecutive points in the trajectories
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
 
     // Iterate through the object to check if it's on the route
     bool on_route = false;
@@ -460,7 +460,7 @@ namespace yield_plugin
 
       for (const auto& llt: corresponding_lanelets)
       {
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
 
         if (route_llt_ids_.find(llt.id()) != route_llt_ids_.end())
         {
@@ -493,13 +493,13 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
 
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
 
         // Linearly interpolate positions at a common timestamp for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
@@ -511,7 +511,7 @@ namespace yield_plugin
         // Calculate the distance between the two interpolated points
         double distance = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
         smallest_dist = std::min(distance, smallest_dist);
-        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
 
         if (i == 0 && j == 0 && distance > config_.collision_check_radius_in_m)
         {
@@ -553,7 +553,7 @@ namespace yield_plugin
   {
     auto plan_start_time = get_trajectory_start_time(original_tp);
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time));
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time));
 
     // do not process outdated objects
     if (rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds() <= plan_start_time)
@@ -570,7 +570,7 @@ namespace yield_plugin
     // NOTE: predicted_velocity is not used for collision calculation, but timestamps
     curr_state.predicted_velocity.linear.x = curr_obstacle.velocity.twist.linear.x;
     curr_state.predicted_velocity.linear.y = curr_obstacle.velocity.twist.linear.y;
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << curr_obstacle.object_type << ", speed: " << curr_obstacle.velocity.twist.linear.x);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << curr_obstacle.object_type << ", speed: " << curr_obstacle.velocity.twist.linear.x);
     new_list.push_back(curr_state);
     new_list.insert(new_list.end(), curr_obstacle.predictions.cbegin(), curr_obstacle.predictions.cend());
 
@@ -579,7 +579,7 @@ namespace yield_plugin
 
   std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> YieldPlugin::get_earliest_collision_object_and_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects)
   {
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
 
     if (!wm_->getRoute())
     {
@@ -593,7 +593,7 @@ namespace yield_plugin
       route_llt_ids_.insert(llt.id());
     }
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
 
     std::map<std::uint32_t, rclcpp::Time> collision_times;
     for (const auto & object : external_objects) {
@@ -612,7 +612,7 @@ namespace yield_plugin
       std::cbegin(external_objects), std::cend(external_objects),
       [&earliest_colliding_object_id](const auto & object) { return object.id == earliest_colliding_object_id; })};
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"earliest object x: " << earliest_colliding_object->velocity.twist.linear.x
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"earliest object x: " << earliest_colliding_object->velocity.twist.linear.x
         << ", y: " << earliest_colliding_object->velocity.twist.linear.y);
     return std::make_pair(*earliest_colliding_object, collision_times.at(earliest_colliding_object_id).seconds());
 
@@ -620,7 +620,7 @@ namespace yield_plugin
 
   double YieldPlugin::get_predicted_velocity_at_time(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double timestamp_in_sec_to_predict)
   {
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "timestamp_in_sec_to_predict: " << std::to_string(timestamp_in_sec_to_predict) <<
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "timestamp_in_sec_to_predict: " << std::to_string(timestamp_in_sec_to_predict) <<
       ", trajectory_end_time: " << std::to_string(get_trajectory_end_time(original_tp)));
 
     double point_b_time = 0.0;
@@ -644,7 +644,7 @@ namespace yield_plugin
     auto dy = point_b.y - point_a.y;
     const tf2::Vector3 trajectory_direction(dx, dy, 0);
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(), "timestamp_in_sec_to_predict: " << std::to_string(timestamp_in_sec_to_predict)
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "timestamp_in_sec_to_predict: " << std::to_string(timestamp_in_sec_to_predict)
       << ", point_b_time: " << std::to_string(point_b_time)
       << ", dx: " << dx << ", dy: " << dy << ", "
       << ", object_velocity_in_map_frame.x: " << object_velocity_in_map_frame.linear.x
@@ -686,21 +686,21 @@ namespace yield_plugin
     const lanelet::BasicPoint2d vehicle_point(original_tp.trajectory_points[0].x,original_tp.trajectory_points[0].y);
     const double vehicle_downtrack = wm_->routeTrackPos(vehicle_point).downtrack;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
 
     RCLCPP_WARN_STREAM(nh_->get_logger(),"Collision Detected!");
 
     const lanelet::BasicPoint2d object_point(earliest_collision_obj.pose.pose.position.x, earliest_collision_obj.pose.pose.position.y);
     const double object_downtrack = wm_->routeTrackPos(object_point).downtrack;
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
 
     const double object_downtrack_lead = std::max(0.0, object_downtrack - vehicle_downtrack);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack_lead: " << object_downtrack_lead);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack_lead: " << object_downtrack_lead);
 
     // The vehicle's goal velocity of the yielding behavior is to match the velocity of the object along the trajectory.
     double goal_velocity = get_predicted_velocity_at_time(earliest_collision_obj.velocity.twist, original_tp, earliest_collision_time_in_seconds);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
 
     // roadway object position
     const double gap_time_until_min_gap_distance = std::max(0.0, object_downtrack_lead - config_.minimum_safety_gap_in_meters)/initial_velocity;
@@ -722,7 +722,7 @@ namespace yield_plugin
       // externally_commanded_safety_gap is desired distance gap commanded from external sources
       // such as different plugin, map, or infrastructure depending on the use case
       double externally_commanded_safety_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),"externally_commanded_safety_gap: " << externally_commanded_safety_gap);
+      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"externally_commanded_safety_gap: " << externally_commanded_safety_gap);
       // if a digital gap is available, it is replaced as safety gap
       safety_gap = std::max(safety_gap, externally_commanded_safety_gap);
     }
@@ -731,7 +731,7 @@ namespace yield_plugin
     const double initial_pos = 0.0; //relative initial position (first trajectory point)
     const double original_max_speed = max_trajectory_speed(original_tp.trajectory_points, earliest_collision_time_in_seconds);
     const double delta_v_max = fabs(goal_velocity - original_max_speed);
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
 
     // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
     const auto plan_start_time = get_trajectory_start_time(original_tp);
@@ -756,7 +756,7 @@ namespace yield_plugin
       planning_time_in_s = max_allowed_trajectory_duration_in_s;
     }
 
-    RCLCPP_ERROR_STREAM(nh_->get_logger(),"Object avoidance planning time: " << planning_time_in_s);
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Object avoidance planning time: " << planning_time_in_s);
 
     return generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, planning_time_in_s, original_max_speed);;
   }
@@ -840,7 +840,7 @@ namespace yield_plugin
       if (!digital_min_gap.empty())
       {
         double digital_gap = digital_min_gap[0]->getMinimumGap(); // Provided gap is in meters
-        RCLCPP_ERROR_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
+        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
         desired_gap = std::max(desired_gap, digital_gap);
       }
     }

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -157,7 +157,7 @@ namespace yield_plugin
         carma_v2x_msgs::msg::Trajectory incoming_trajectory = incoming_request.trajectory;
         std::string req_strategy_params = incoming_request.strategy_params;
         clc_urgency_ = incoming_request.urgency;
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"received urgency: " << clc_urgency_);
 
         // Parse strategy parameters
         using boost::property_tree::ptree;
@@ -169,9 +169,9 @@ namespace yield_plugin
         int start_lanelet_id = pt.get<int>("sl");
         int end_lanelet_id = pt.get<int>("el");
         double req_traj_speed = static_cast<double>(req_traj_speed_full) + static_cast<double>(req_traj_fractional)/10.0;
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_traj_speed" << req_traj_speed);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"start_lanelet_id" << start_lanelet_id);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"end_lanelet_id" << end_lanelet_id);
 
         std::vector<lanelet::BasicPoint2d> req_traj_plan = {};
 
@@ -217,7 +217,7 @@ namespace yield_plugin
     req_trajectory_points_ = req_trajectory;
     req_target_speed_ = req_speed;
     req_target_plan_time_ = req_planning_time;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"req_target_plan_time_" << req_target_plan_time_);
     req_timestamp_ = req_timestamp;
   }
 
@@ -290,7 +290,7 @@ namespace yield_plugin
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
 
   }
 
@@ -321,14 +321,14 @@ namespace yield_plugin
       double dy = original_tp.trajectory_points[0].y - intersection_point.y();
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       goal_pos = sqrt(dx*dx + dy*dy) - config_.minimum_safety_gap_in_meters;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Goal position (goal_pos): " << goal_pos);
       double collision_time = req_timestamp_ + (intersection_points[0].first * ecef_traj_timestep_) - config_.safety_collision_time_gap_in_s;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"req time stamp: " << req_timestamp_);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Collision time: " << collision_time);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"intersection num: " << intersection_points[0].first);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"Planning time: " << planning_time);
       // calculate distance traveled from beginning of trajectory to collision point
       double dx2 = intersection_point.x() - req_trajectory_points_[0].x();
       double dy2 = intersection_point.y() - req_trajectory_points_[0].y();
@@ -338,8 +338,8 @@ namespace yield_plugin
       goal_velocity = std::min(goal_velocity, incoming_trajectory_speed);
       double min_time = (initial_velocity - goal_velocity)/config_.yield_max_deceleration_in_ms2;
 
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"goal_velocity: " << goal_velocity);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"incoming_trajectory_speed: " << incoming_trajectory_speed);
 
       if (planning_time > min_time)
       {
@@ -376,7 +376,7 @@ namespace yield_plugin
     double initial_accel = 0.0;
     double goal_accel = 0.0;
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"original_max_speed" << original_max_speed);
     std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
                                                                                                 goal_pos,
                                                                                                 initial_velocity,
@@ -415,7 +415,7 @@ namespace yield_plugin
         double dt = (2 * original_traj_downtracks.at(i)) / (current_speed + prev_speed);
         jmt_tpp = original_tp.trajectory_points.at(i);
         jmt_tpp.target_time =  rclcpp::Time(jmt_trajectory_points.back().target_time) + rclcpp::Duration(dt*1e9);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "non-empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
@@ -426,7 +426,7 @@ namespace yield_plugin
         jmt_tpp = jmt_trajectory_points.back();
         // MISH: Potential bug where if purepursuit accidentally picks a point that has previous time, then it may speed up. target_time is assumed to increase
         jmt_tpp.target_time =  rclcpp::Time(std::max((rclcpp::Time(jmt_trajectory_points[0].target_time) + rclcpp::Duration(traj_target_time*1e9)).seconds(), rclcpp::Time(jmt_trajectory_points.back().target_time).seconds()) * 1e9);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "empty x: " << jmt_tpp.x << ", y:" << jmt_tpp.y << ", t:" << std::to_string(rclcpp::Time(jmt_tpp.target_time).seconds()));
 
         jmt_trajectory_points.push_back(jmt_tpp);
       }
@@ -444,7 +444,7 @@ namespace yield_plugin
 
     // Iterate through each pair of consecutive points in the trajectories
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Starting a new collision detection, trajectory size: " << trajectory1.trajectory_points.size() << ". prediction size: " << trajectory2.size());
 
     // Iterate through the object to check if it's on the route
     bool on_route = false;
@@ -460,7 +460,7 @@ namespace yield_plugin
 
       for (const auto& llt: corresponding_lanelets)
       {
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Checking llt: " << llt.id());
 
         if (route_llt_ids_.find(llt.id()) != route_llt_ids_.end())
         {
@@ -493,13 +493,13 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p1b.x: " << p1b.x << ", p1b.y: " << p1b.y);
 
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2a.x: " << p2a.predicted_position.position.x << ", p2a.y: " << p2a.predicted_position.position.y);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "p2b.x: " << p2b.predicted_position.position.x << ", p2b.y: " << p2b.predicted_position.position.y);
 
         // Linearly interpolate positions at a common timestamp for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
@@ -511,7 +511,7 @@ namespace yield_plugin
         // Calculate the distance between the two interpolated points
         double distance = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
         smallest_dist = std::min(distance, smallest_dist);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt << ", x1: " << x1 << ", y1: " <<y1 <<  ", x2: " << x2 << ", y2: " << y2 << ", p2a_t:" << std::to_string(p2a_t));
 
         if (i == 0 && j == 0 && distance > config_.collision_check_radius_in_m)
         {
@@ -553,7 +553,7 @@ namespace yield_plugin
   {
     auto plan_start_time = get_trajectory_start_time(original_tp);
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time));
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object's back time: " << std::to_string(rclcpp::Time(curr_obstacle.predictions.back().header.stamp).seconds()) << ", plan_start_time: " << std::to_string(plan_start_time));
     auto collision_time = std::nullopt;
 
     // do not process outdated objects
@@ -571,7 +571,7 @@ namespace yield_plugin
     // NOTE: predicted_velocity is not used for collision calculation, but timestamps
     curr_state.predicted_velocity.linear.x = curr_obstacle.velocity.twist.linear.x;
     curr_state.predicted_velocity.linear.y = curr_obstacle.velocity.twist.linear.y;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << static_cast<int>(curr_obstacle.object_type) << ", speed: " << curr_obstacle.velocity.twist.linear.x);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "Object: " << curr_obstacle.id <<", type: " << static_cast<int>(curr_obstacle.object_type) << ", speed: " << curr_obstacle.velocity.twist.linear.x);
     new_list.push_back(curr_state);
     new_list.insert(new_list.end(), curr_obstacle.predictions.cbegin(), curr_obstacle.predictions.cend());
 
@@ -580,7 +580,7 @@ namespace yield_plugin
 
   std::optional<std::pair<carma_perception_msgs::msg::ExternalObject, double>> YieldPlugin::get_earliest_collision_object_and_time(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, const std::vector<carma_perception_msgs::msg::ExternalObject>& external_objects)
   {
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "ExternalObjects size: " << external_objects.size());
 
     if (wm_->getRoute() == nullptr)
     {
@@ -594,29 +594,33 @@ namespace yield_plugin
       route_llt_ids_.insert(llt.id());
     }
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"External Object List (external_objects) size: " << external_objects.size());
+
+    std::vector<std::optional<rclcpp::Time>> collision_times = {};
+    for (const auto& obj : external_objects)
+    {
+      collision_times.push_back(get_collision_time_using_external_object(original_tp, obj));
+    }
 
     // Custom comparator
-    auto compare_collision_times = [&](const carma_perception_msgs::msg::ExternalObject& obj1, const carma_perception_msgs::msg::ExternalObject& obj2) {
-    auto collision_time1 = get_collision_time_using_external_object(original_tp, obj1);
-    auto collision_time2 = get_collision_time_using_external_object(original_tp, obj2);
+    auto compare_collision_times = [&](const std::optional<rclcpp::Time>& collision_time1, const std::optional<rclcpp::Time>& collision_time2) {
+      // Handle std::nullopt (no collision) cases
+      if (!collision_time1 || !collision_time2) return false;
 
-    // Handle std::nullopt (no collision) cases
-    if (!collision_time1.has_value()) return false;
-    if (!collision_time2.has_value()) return true;
-
-    return collision_time1.value().seconds() < collision_time2.value().seconds();
+      return collision_time1.value().seconds() < collision_time2.value().seconds();
     };
 
     // Find the external object with the earliest collision time using std::min_element
-    auto it = std::min_element(external_objects.begin(), external_objects.end(), compare_collision_times);
+    auto earliest_collision_time_it = std::min_element(collision_times.begin(), collision_times.end(), compare_collision_times);
 
-    if (it != external_objects.end()) {
-        auto earliest_collision_time = get_collision_time_using_external_object(original_tp, *it);
-        if (earliest_collision_time.has_value()) {
-          RCLCPP_DEBUG_STREAM(nh_->get_logger(),"earliest object x: " << it->velocity.twist.linear.x << ", y: " << it->velocity.twist.linear.y);
-          return std::make_pair(*it, earliest_collision_time.value().seconds());
-        }
+    if (earliest_collision_time_it != collision_times.end()) {
+      size_t earliest_collision_object_idx = earliest_collision_time_it - collision_times.begin();
+
+      if (*earliest_collision_time_it) {
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"earliest object x: " << external_objects.at(earliest_collision_object_idx).velocity.twist.linear.x
+          << ", y: " << external_objects.at(earliest_collision_object_idx).velocity.twist.linear.y);
+        return std::make_pair(external_objects.at(earliest_collision_object_idx), earliest_collision_time_it->value().seconds());
+      }
     }
 
     return std::nullopt;
@@ -624,7 +628,7 @@ namespace yield_plugin
 
   double YieldPlugin::get_object_velocity_along_trajectory(const geometry_msgs::msg::Twist& object_velocity_in_map_frame, const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double collision_timestamp_in_seconds)
   {
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds) <<
+    RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds) <<
       ", trajectory_end_time: " << std::to_string(get_trajectory_end_time(original_tp)));
 
     for (size_t i = 0; i < original_tp.trajectory_points.size() - 1; ++i)
@@ -644,7 +648,7 @@ namespace yield_plugin
         }
         tf2::Vector3 object_direction(object_velocity_in_map_frame.linear.x, object_velocity_in_map_frame.linear.y, 0);
 
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds)
+        RCLCPP_ERROR_STREAM(nh_->get_logger(), "collision_timestamp_in_seconds: " << std::to_string(collision_timestamp_in_seconds)
           << ", p1b_t: " << std::to_string(p1b_t)
           << ", dx: " << dx << ", dy: " << dy << ", "
           << ", object_velocity_in_map_frame.x: " << object_velocity_in_map_frame.linear.x
@@ -690,21 +694,21 @@ namespace yield_plugin
     lanelet::BasicPoint2d point(original_tp.trajectory_points[0].x,original_tp.trajectory_points[0].y);
     double vehicle_downtrack = wm_->routeTrackPos(point).downtrack;
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"vehicle_downtrack: " << vehicle_downtrack);
 
     RCLCPP_WARN_STREAM(nh_->get_logger(),"Collision Detected!");
 
     lanelet::BasicPoint2d object_point(earliest_collision_obj.pose.pose.position.x, earliest_collision_obj.pose.pose.position.y);
     double object_downtrack = wm_->routeTrackPos(object_point).downtrack;
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack: " << object_downtrack);
 
     double object_downtrack_lead = std::max(0.0, object_downtrack - vehicle_downtrack);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object_downtrack_lead: " << object_downtrack_lead);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object_downtrack_lead: " << object_downtrack_lead);
 
     // The vehicle's goal velocity of the yielding behavior is to match the velocity of the object along the trajectory.
     double goal_velocity = get_object_velocity_along_trajectory(earliest_collision_obj.velocity.twist, original_tp, earliest_collision_time_in_seconds);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"object's speed along trajectory at collision: " << goal_velocity);
 
     // roadway object position
     double gap_time = std::max(0.0, object_downtrack_lead - config_.minimum_safety_gap_in_meters)/initial_velocity;
@@ -725,7 +729,7 @@ namespace yield_plugin
     {
       // check if a digital_gap is available
       double digital_gap = check_traj_for_digital_min_gap(original_tp);
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),"digital_gap: " << digital_gap);
       // if a digital gap is available, it is replaced as safety gap
       safety_gap = std::max(safety_gap, digital_gap);
     }
@@ -734,7 +738,7 @@ namespace yield_plugin
     double initial_pos = 0.0; //relative initial position (first trajectory point)
     double original_max_speed = max_trajectory_speed(original_tp.trajectory_points, earliest_collision_time_in_seconds);
     double delta_v_max = fabs(goal_velocity - original_max_speed);
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
 
     // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
     auto plan_start_time = get_trajectory_start_time(original_tp);
@@ -758,7 +762,7 @@ namespace yield_plugin
       tp = max_allowed_trajectory_duration;
     }
 
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
+    RCLCPP_ERROR_STREAM(nh_->get_logger(),"Object avoidance planning time: " << tp);
 
     update_tpp_vector = generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp, original_max_speed);
 
@@ -844,7 +848,7 @@ namespace yield_plugin
       if (!digital_min_gap.empty())
       {
         double digital_gap = digital_min_gap[0]->getMinimumGap(); // Provided gap is in meters
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
+        RCLCPP_ERROR_STREAM(nh_->get_logger(),"Digital Gap found with value: " << digital_gap);
         desired_gap = std::max(desired_gap, digital_gap);
       }
     }

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -785,7 +785,7 @@ namespace yield_plugin
     return result;
   }
 
-  double YieldPlugin::max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double earliest_collision_time) const
+  double YieldPlugin::max_trajectory_speed(const std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint>& trajectory_points, double timestamp_to_search_until) const
   {
     double max_speed = 0;
     for(size_t i = 0; i < trajectory_points.size() - 2; i++ )
@@ -799,7 +799,7 @@ namespace yield_plugin
       {
         max_speed = v;
       }
-      if (rclcpp::Time(trajectory_points.at(i + 1).target_time).seconds() >= earliest_collision_time)
+      if (rclcpp::Time(trajectory_points.at(i + 1).target_time).seconds() >= timestamp_to_search_until)
       {
         break;
       }

--- a/yield_plugin/src/yield_plugin_node.cpp
+++ b/yield_plugin/src/yield_plugin_node.cpp
@@ -22,7 +22,7 @@ namespace yield_plugin
 
   YieldPluginNode::YieldPluginNode(const rclcpp::NodeOptions &options)
       : carma_guidance_plugins::TacticalPlugin(options),
-        version_id_("v1.0"), 
+        version_id_("v1.0"),
         config_(YieldPluginConfig())
   {
     // Declare parameters
@@ -46,7 +46,7 @@ namespace yield_plugin
     config_.vehicle_height = declare_parameter<double>("vehicle_height", config_.vehicle_height);
     config_.vehicle_width = declare_parameter<double>("vehicle_width", config_.vehicle_width);
     config_.vehicle_id = declare_parameter<std::string>("vehicle_id", config_.vehicle_id);
-     
+
   }
 
   carma_ros2_utils::CallbackReturn YieldPluginNode::on_configure_plugin()
@@ -68,7 +68,7 @@ namespace yield_plugin
     get_parameter<double>("safety_collision_time_gap", config_.safety_collision_time_gap);
     get_parameter<bool>("enable_adjustable_gap", config_.enable_adjustable_gap);
     get_parameter<int>("acceptable_urgency", config_.acceptable_urgency);
-    get_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size);
+    get_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size); //TODO not double
     get_parameter<double>("tpmin", config_.tpmin);
     get_parameter<double>("vehicle_length", config_.vehicle_length);
     get_parameter<double>("vehicle_height", config_.vehicle_height);
@@ -88,13 +88,13 @@ namespace yield_plugin
     // Subscriber
     mob_request_sub_ = create_subscription<carma_v2x_msgs::msg::MobilityRequest>("incoming_mobility_request", 10, std::bind(&YieldPlugin::mobilityrequest_cb,worker_.get(),std_ph::_1));
     bsm_sub_ = create_subscription<carma_v2x_msgs::msg::BSM>("bsm_outbound", 1, std::bind(&YieldPlugin::bsm_cb,worker_.get(),std_ph::_1));
-    georeference_sub_ = create_subscription<std_msgs::msg::String>("georeference", 10, 
+    georeference_sub_ = create_subscription<std_msgs::msg::String>("georeference", 10,
                                                                   [this](const std_msgs::msg::String::SharedPtr msg) {
                                                                     worker_->set_georeference_string(msg->data);
                                                                   });
-                                                                  
+
     // Return success if everything initialized successfully
-    external_objects_sub_ = create_subscription<carma_perception_msgs::msg::ExternalObjectList>("external_object_predictions", 20, 
+    external_objects_sub_ = create_subscription<carma_perception_msgs::msg::ExternalObjectList>("external_object_predictions", 20,
                                                                                                 [this](const carma_perception_msgs::msg::ExternalObjectList::SharedPtr msg) {
                                                                                                   worker_->set_external_objects(msg->objects);
                                                                                                 });
@@ -103,8 +103,8 @@ namespace yield_plugin
   }
 
     void YieldPluginNode::plan_trajectory_callback(
-    std::shared_ptr<rmw_request_id_t> srv_header, 
-    carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req, 
+    std::shared_ptr<rmw_request_id_t> srv_header,
+    carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req,
     carma_planning_msgs::srv::PlanTrajectory::Response::SharedPtr resp)
   {
     worker_->plan_trajectory_callback(req, resp);

--- a/yield_plugin/src/yield_plugin_node.cpp
+++ b/yield_plugin/src/yield_plugin_node.cpp
@@ -68,7 +68,7 @@ namespace yield_plugin
     get_parameter<double>("safety_collision_time_gap", config_.safety_collision_time_gap);
     get_parameter<bool>("enable_adjustable_gap", config_.enable_adjustable_gap);
     get_parameter<int>("acceptable_urgency", config_.acceptable_urgency);
-    get_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size); //TODO not double
+    get_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size);
     get_parameter<double>("tpmin", config_.tpmin);
     get_parameter<double>("vehicle_length", config_.vehicle_length);
     get_parameter<double>("vehicle_height", config_.vehicle_height);

--- a/yield_plugin/src/yield_plugin_node.cpp
+++ b/yield_plugin/src/yield_plugin_node.cpp
@@ -27,18 +27,18 @@ namespace yield_plugin
   {
     // Declare parameters
     config_.acceleration_adjustment_factor = declare_parameter<double>("acceleration_adjustment_factor", config_.acceleration_adjustment_factor);
-    config_.min_obstacle_speed = declare_parameter<double>("min_obstacle_speed", config_.min_obstacle_speed);
-    config_.on_route_vehicle_collision_horizon = declare_parameter<double>("on_route_vehicle_collision_horizon", config_.on_route_vehicle_collision_horizon);
-    config_.collision_check_radius = declare_parameter<double>("collision_check_radius", config_.collision_check_radius);
-    config_.yield_max_deceleration = declare_parameter<double>("yield_max_deceleration", config_.yield_max_deceleration);
-    config_.tpmin = declare_parameter<double>("tpmin", config_.tpmin);
-    config_.x_gap = declare_parameter<double>("x_gap", config_.x_gap);
-    config_.max_stop_speed= declare_parameter<double>("max_stop_speed", config_.max_stop_speed);
+    config_.min_obstacle_speed_in_ms = declare_parameter<double>("min_obstacle_speed_in_ms", config_.min_obstacle_speed_in_ms);
+    config_.on_route_vehicle_collision_horizon_in_s = declare_parameter<double>("on_route_vehicle_collision_horizon_in_s", config_.on_route_vehicle_collision_horizon_in_s);
+    config_.collision_check_radius_in_m = declare_parameter<double>("collision_check_radius_in_m", config_.collision_check_radius_in_m);
+    config_.yield_max_deceleration_in_ms2 = declare_parameter<double>("yield_max_deceleration_in_ms2", config_.yield_max_deceleration_in_ms2);
+    config_.min_obj_avoidance_plan_time_in_s = declare_parameter<double>("min_obj_avoidance_plan_time_in_s", config_.min_obj_avoidance_plan_time_in_s);
+    config_.minimum_safety_gap_in_meters = declare_parameter<double>("minimum_safety_gap_in_meters", config_.minimum_safety_gap_in_meters);
+    config_.max_stop_speed_in_ms= declare_parameter<double>("max_stop_speed_in_ms", config_.max_stop_speed_in_ms);
     config_.enable_cooperative_behavior = declare_parameter< bool>("enable_cooperative_behavior", config_.enable_cooperative_behavior);
     config_.always_accept_mobility_request = declare_parameter< bool>("always_accept_mobility_request", config_.always_accept_mobility_request);
     config_.acceptable_passed_timesteps = declare_parameter<int>("acceptable_passed_timesteps", config_.acceptable_passed_timesteps);
-    config_.intervehicle_collision_distance = declare_parameter<double>("intervehicle_collision_distance", config_.intervehicle_collision_distance);
-    config_.safety_collision_time_gap = declare_parameter<double>("safety_collision_time_gap", config_.safety_collision_time_gap);
+    config_.intervehicle_collision_distance_in_m = declare_parameter<double>("intervehicle_collision_distance_in_m", config_.intervehicle_collision_distance_in_m);
+    config_.safety_collision_time_gap_in_s = declare_parameter<double>("safety_collision_time_gap_in_s", config_.safety_collision_time_gap_in_s);
     config_.enable_adjustable_gap = declare_parameter<bool>("enable_adjustable_gap", config_.enable_adjustable_gap);
     config_.acceptable_urgency = declare_parameter<int>("acceptable_urgency", config_.acceptable_urgency);
     config_.speed_moving_average_window_size = declare_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size);
@@ -54,22 +54,22 @@ namespace yield_plugin
     config_ = YieldPluginConfig();
 
     get_parameter<double>("acceleration_adjustment_factor", config_.acceleration_adjustment_factor);
-    get_parameter<double>("min_obstacle_speed", config_.min_obstacle_speed);
-    get_parameter<double>("on_route_vehicle_collision_horizon", config_.on_route_vehicle_collision_horizon);
-    get_parameter<double>("collision_check_radius", config_.collision_check_radius);
-    get_parameter<double>("yield_max_deceleration", config_.yield_max_deceleration);
-    get_parameter<double>("x_gap", config_.x_gap);
-    get_parameter<double>("max_stop_speed", config_.max_stop_speed);
+    get_parameter<double>("min_obstacle_speed_in_ms", config_.min_obstacle_speed_in_ms);
+    get_parameter<double>("on_route_vehicle_collision_horizon_in_s", config_.on_route_vehicle_collision_horizon_in_s);
+    get_parameter<double>("collision_check_radius_in_m", config_.collision_check_radius_in_m);
+    get_parameter<double>("yield_max_deceleration_in_ms2", config_.yield_max_deceleration_in_ms2);
+    get_parameter<double>("minimum_safety_gap_in_meters", config_.minimum_safety_gap_in_meters);
+    get_parameter<double>("max_stop_speed_in_ms", config_.max_stop_speed_in_ms);
     get_parameter<bool>("enable_cooperative_behavior", config_.enable_cooperative_behavior);
     get_parameter<bool>("always_accept_mobility_request", config_.always_accept_mobility_request);
     get_parameter<int>("acceptable_passed_timesteps", config_.acceptable_passed_timesteps);
-    get_parameter<double>("intervehicle_collision_distance", config_.intervehicle_collision_distance);
+    get_parameter<double>("intervehicle_collision_distance_in_m", config_.intervehicle_collision_distance_in_m);
 
-    get_parameter<double>("safety_collision_time_gap", config_.safety_collision_time_gap);
+    get_parameter<double>("safety_collision_time_gap_in_s", config_.safety_collision_time_gap_in_s);
     get_parameter<bool>("enable_adjustable_gap", config_.enable_adjustable_gap);
     get_parameter<int>("acceptable_urgency", config_.acceptable_urgency);
     get_parameter<double>("speed_moving_average_window_size", config_.speed_moving_average_window_size);
-    get_parameter<double>("tpmin", config_.tpmin);
+    get_parameter<double>("min_obj_avoidance_plan_time_in_s", config_.min_obj_avoidance_plan_time_in_s);
     get_parameter<double>("vehicle_length", config_.vehicle_length);
     get_parameter<double>("vehicle_height", config_.vehicle_height);
     get_parameter<double>("vehicle_width", config_.vehicle_width);

--- a/yield_plugin/test/test_cooperative_yield.cpp
+++ b/yield_plugin/test/test_cooperative_yield.cpp
@@ -66,7 +66,7 @@ TEST(YieldPluginTest, test_detect_trajectories_intersection)
   p3.y() = 3;
   v1 = {p1, p2, p3};
 
-  
+
   lanelet::BasicPoint2d p4;
   p4.x() = 2.5;
   p4.y() = 0;
@@ -85,7 +85,7 @@ TEST(YieldPluginTest, test_detect_trajectories_intersection)
 TEST(YieldPluginTest, test_update_clc_trajectory)
 {
   YieldPluginConfig config;
-  config.safety_collision_time_gap = 0.1;
+  config.safety_collision_time_gap_in_s = 0.1;
   std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto nh = std::make_shared<yield_plugin::YieldPluginNode>(rclcpp::NodeOptions());
   auto map = carma_wm::test::buildGuidanceTestMap(100.0, 100.0);
@@ -93,7 +93,7 @@ TEST(YieldPluginTest, test_update_clc_trajectory)
 
   carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1203 }, wm);
   YieldPlugin plugin(nh,wm, config,[&](auto msg) {}, [&](auto msg) {});
-        
+
     lanelet::BasicPoint2d p1(10, 40);
     lanelet::BasicPoint2d p2(20, 40);
     lanelet::BasicPoint2d p3(30, 40);
@@ -126,7 +126,7 @@ TEST(YieldPluginTest, test_update_clc_trajectory)
     trajectory_point_3.x = 20.0;
     trajectory_point_3.y = 30.0;
     trajectory_point_3.target_time = rclcpp::Time(2*1e9);
-    
+
     trajectory_point_4.x = 20.0;
     trajectory_point_4.y = 40.0;
     trajectory_point_4.target_time = rclcpp::Time(3*1e9);
@@ -142,7 +142,7 @@ TEST(YieldPluginTest, test_update_clc_trajectory)
     trajectory_point_7.x = 20.0;
     trajectory_point_7.y = 70.0;
     trajectory_point_7.target_time = rclcpp::Time(6*1e9);
-    
+
     original_tp.trajectory_points = {trajectory_point_1, trajectory_point_2, trajectory_point_3, trajectory_point_4, trajectory_point_5, trajectory_point_6, trajectory_point_7};
 
     double current_speed = 10;
@@ -186,7 +186,7 @@ TEST(YieldPluginTest, test_traj_cb)
     trajectory_point_3.x = 20.0;
     trajectory_point_3.y = -20.0;
     trajectory_point_3.target_time = rclcpp::Time(2,0);
-    
+
     trajectory_point_4.x = 20.0;
     trajectory_point_4.y = -10.0;
     trajectory_point_4.target_time = rclcpp::Time(3,0);
@@ -202,7 +202,7 @@ TEST(YieldPluginTest, test_traj_cb)
     trajectory_point_7.x = 20.0;
     trajectory_point_7.y = 20.0;
     trajectory_point_7.target_time = rclcpp::Time(60,0);
-    
+
     original_tp.trajectory_points = {trajectory_point_1, trajectory_point_2, trajectory_point_3, trajectory_point_4, trajectory_point_5, trajectory_point_6, trajectory_point_7};
 
     std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request> req = std::make_shared<carma_planning_msgs::srv::PlanTrajectory::Request>();

--- a/yield_plugin/test/test_yield.cpp
+++ b/yield_plugin/test/test_yield.cpp
@@ -319,7 +319,7 @@ TEST(YieldPluginTest, get_collision_time)
   carma_perception_msgs::msg::ExternalObjectList rwol;
   carma_planning_msgs::msg::TrajectoryPlan tp;
 
-  EXPECT_THROW(plugin.update_traj_for_object(tp, {}, 0.0), std::invalid_argument);
+  EXPECT_EQ(plugin.update_traj_for_object(tp, {}, 0.0), tp); //should return unchanged if received invalid trajectory
 
   carma_planning_msgs::msg::TrajectoryPlanPoint trajectory_point_1;
   carma_planning_msgs::msg::TrajectoryPlanPoint trajectory_point_2;

--- a/yield_plugin/test/test_yield.cpp
+++ b/yield_plugin/test/test_yield.cpp
@@ -309,7 +309,7 @@ TEST(YieldPluginTest, detect_collision_time)
   config.vehicle_length = 4;
   config.vehicle_width = 2;
   config.vehicle_height = 1;
-  config.collision_check_radius = 90;
+  config.collision_check_radius_in_m = 90;
 
   // std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto nh = std::make_shared<yield_plugin::YieldPluginNode>(rclcpp::NodeOptions());

--- a/yield_plugin/test/test_yield.cpp
+++ b/yield_plugin/test/test_yield.cpp
@@ -56,7 +56,7 @@ TEST(YieldPluginTest, test_polynomial_calc)
   coeff.push_back(2.0);
   coeff.push_back(2.0);
   coeff.push_back(2.0);
-  coeff.push_back(2.0);    
+  coeff.push_back(2.0);
   coeff.push_back(2.0);
 
   double result = plugin.polynomial_calc(coeff, 0);
@@ -64,7 +64,7 @@ TEST(YieldPluginTest, test_polynomial_calc)
 
   result = plugin.polynomial_calc(coeff, 1);
   EXPECT_EQ(12, result);
-  
+
   result = plugin.polynomial_calc(coeff, 2);
   EXPECT_EQ(126, result);
 
@@ -85,7 +85,7 @@ TEST(YieldPluginTest, test_polynomial_calc_derivative)
   coeff.push_back(2.0);
   coeff.push_back(2.0);
   coeff.push_back(2.0);
-  coeff.push_back(2.0);    
+  coeff.push_back(2.0);
   coeff.push_back(2.0);
 
   double result = plugin.polynomial_calc_d(coeff, 0);
@@ -93,7 +93,7 @@ TEST(YieldPluginTest, test_polynomial_calc_derivative)
 
   result = plugin.polynomial_calc_d(coeff, 1);
   EXPECT_EQ(30, result);
-  
+
   result = plugin.polynomial_calc_d(coeff, 2);
   EXPECT_EQ(258, result);
 
@@ -163,7 +163,7 @@ TEST(YieldPluginTest, MaxTrajectorySpeed)
   point_7.lane_id = "1";
   trajectory_points.push_back(point_7);
 
-  double result = plugin.max_trajectory_speed(trajectory_points);
+  double result = plugin.max_trajectory_speed(trajectory_points, rclcpp::Time(point_7.target_time).seconds());
   EXPECT_EQ(5, result);
 
 }
@@ -172,15 +172,15 @@ TEST(YieldPluginTest, test_update_traj)
 {
   std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto map = carma_wm::test::buildGuidanceTestMap(100,100);
-  
+
   wm->setMap(map);
   carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1203 }, wm);
-  
+
   YieldPluginConfig config;
   config.vehicle_length = 4;
   config.vehicle_width = 2;
   config.vehicle_height = 1;
-  
+
   // std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto nh = std::make_shared<yield_plugin::YieldPluginNode>(rclcpp::NodeOptions());
 
@@ -188,7 +188,7 @@ TEST(YieldPluginTest, test_update_traj)
 
   carma_perception_msgs::msg::ExternalObjectList rwol;
   carma_planning_msgs::msg::TrajectoryPlan tp;
-  
+
   rclcpp::Time startTime(1.0);
 
   carma_planning_msgs::msg::TrajectoryPlanPoint trajectory_point_1;
@@ -301,21 +301,21 @@ TEST(YieldPluginTest, detect_collision_time)
 {
   std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto map = carma_wm::test::buildGuidanceTestMap(100,100);
-  
+
   wm->setMap(map);
   carma_wm::test::setRouteByIds({ 1200, 1201, 1202, 1203 }, wm);
-  
+
   YieldPluginConfig config;
   config.vehicle_length = 4;
   config.vehicle_width = 2;
   config.vehicle_height = 1;
   config.collision_check_radius = 90;
-  
+
   // std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto nh = std::make_shared<yield_plugin::YieldPluginNode>(rclcpp::NodeOptions());
 
   YieldPlugin plugin(nh,wm, config,[](const auto& msg) {}, [](const auto& msg) {});
-  
+
   carma_perception_msgs::msg::ExternalObjectList rwol;
   carma_planning_msgs::msg::TrajectoryPlan tp;
 
@@ -363,7 +363,7 @@ TEST(YieldPluginTest, detect_collision_time)
 
   // Set route but also test no throw
   EXPECT_NO_THROW(plugin.update_traj_for_object(tp, {}, 0.0));
- 
+
   // ON ROUTE, BUT NO COLLISION DUE TO BEING AHEAD
 
   tf2::Quaternion tf_orientation;
@@ -536,7 +536,7 @@ TEST(YieldPluginTest, test_update_traj2)
   trajectory_point_3.x = 10.0;
   trajectory_point_3.y = 1.0;
   trajectory_point_3.target_time = rclcpp::Time(2,0);
-  
+
   trajectory_point_4.x = 15.0;
   trajectory_point_4.y = 1.0;
   trajectory_point_4.target_time = rclcpp::Time(3,0);
@@ -552,7 +552,7 @@ TEST(YieldPluginTest, test_update_traj2)
   trajectory_point_7.x = 30.0;
   trajectory_point_7.y = 1.0;
   trajectory_point_7.target_time = rclcpp::Time(6,0);
-   
+
   original_tp.trajectory_points = {trajectory_point_1, trajectory_point_2, trajectory_point_3, trajectory_point_4, trajectory_point_5, trajectory_point_6, trajectory_point_7};
 
 
@@ -565,13 +565,13 @@ TEST(YieldPluginTest, test_update_traj2)
   double initial_time = 0.0;
   double tp = 5;
 
-  std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos, 
-                                                                                              goal_pos, 
-                                                                                              current_speed_, 
-                                                                                              goal_velocity, 
+  std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
+                                                                                              goal_pos,
+                                                                                              current_speed_,
+                                                                                              goal_velocity,
                                                                                               initial_accel,
-                                                                                              goal_accel, 
-                                                                                              initial_time, 
+                                                                                              goal_accel,
+                                                                                              initial_time,
                                                                                               tp);
 
   std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint> new_trajectory_points;
@@ -584,7 +584,7 @@ TEST(YieldPluginTest, test_update_traj2)
 
 
   for(size_t i = 1; i < original_tp.trajectory_points.size() ; i++ )
-  {            
+  {
       double traj_target_time = i * tp / original_tp.trajectory_points.size();
       double dt_dist = plugin.polynomial_calc(values, traj_target_time);
       distance_travelled.push_back(dt_dist);
@@ -597,7 +597,7 @@ TEST(YieldPluginTest, test_update_traj2)
       new_trajectory_points.push_back(new_tpp);
   }
 
-  // speeds are decreasing 
+  // speeds are decreasing
   EXPECT_EQ(6, new_speeds.size());
   EXPECT_TRUE(new_speeds[5] <= new_speeds[4]);
   EXPECT_TRUE(new_speeds[3] <= new_speeds[1]);
@@ -638,7 +638,7 @@ TEST(YieldPluginTest, test_update_traj_stop)
   trajectory_point_3.x = 10.0;
   trajectory_point_3.y = 1.0;
   trajectory_point_3.target_time = rclcpp::Time(2,0);
-  
+
   trajectory_point_4.x = 15.0;
   trajectory_point_4.y = 1.0;
   trajectory_point_4.target_time = rclcpp::Time(3,0);
@@ -654,7 +654,7 @@ TEST(YieldPluginTest, test_update_traj_stop)
   trajectory_point_7.x = 30.0;
   trajectory_point_7.y = 1.0;
   trajectory_point_7.target_time = rclcpp::Time(6,0);
-   
+
   original_tp.trajectory_points = {trajectory_point_1, trajectory_point_2, trajectory_point_3, trajectory_point_4, trajectory_point_5, trajectory_point_6, trajectory_point_7};
 
 
@@ -670,13 +670,13 @@ TEST(YieldPluginTest, test_update_traj_stop)
   double initial_time = 0.0;
   double tp = 5;
 
-  std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos, 
-                                                                                              goal_pos, 
-                                                                                              current_speed_, 
-                                                                                              goal_velocity, 
+  std::vector<double> values = quintic_coefficient_calculator::quintic_coefficient_calculator(initial_pos,
+                                                                                              goal_pos,
+                                                                                              current_speed_,
+                                                                                              goal_velocity,
                                                                                               initial_accel,
-                                                                                              goal_accel, 
-                                                                                              initial_time, 
+                                                                                              goal_accel,
+                                                                                              initial_time,
                                                                                               tp);
 
   std::vector<carma_planning_msgs::msg::TrajectoryPlanPoint> new_trajectory_points;
@@ -686,12 +686,12 @@ TEST(YieldPluginTest, test_update_traj_stop)
   std::vector<double> new_speeds;
   std::vector<double> distance_travelled;
   for(size_t i = 1; i < original_tp.trajectory_points.size() ; i++ )
-  {            
+  {
       double traj_target_time = i * tp / original_tp.trajectory_points.size();
       double dt_dist = plugin.polynomial_calc(values, traj_target_time);
       double dv = plugin.polynomial_calc_d(values, traj_target_time);
       carma_planning_msgs::msg::TrajectoryPlanPoint new_tpp;
-      
+
       if (dv >= 1.0)
         {
           RCLCPP_WARN(rclcpp::get_logger("yield_plugin"),"target speed is positive");
@@ -713,7 +713,7 @@ TEST(YieldPluginTest, test_update_traj_stop)
       new_speeds.push_back(dv);
   }
 
-  
+
   EXPECT_EQ(original_tp.trajectory_points.size(), new_trajectory_points.size());
   // Trajectory point location same as previous point
   EXPECT_EQ(new_trajectory_points[5].x, new_trajectory_points[4].x);
@@ -750,7 +750,7 @@ TEST(YieldPluginTest, jmt_traj)
   trajectory_point_3.x = 10.0;
   trajectory_point_3.y = 1.0;
   trajectory_point_3.target_time = rclcpp::Time(2,0);
-  
+
   trajectory_point_4.x = 15.0;
   trajectory_point_4.y = 1.0;
   trajectory_point_4.target_time = rclcpp::Time(3,0);
@@ -766,7 +766,7 @@ TEST(YieldPluginTest, jmt_traj)
   trajectory_point_7.x = 30.0;
   trajectory_point_7.y = 1.0;
   trajectory_point_7.target_time = rclcpp::Time(6,0);
-   
+
   original_tp.trajectory_points = {trajectory_point_1, trajectory_point_2, trajectory_point_3, trajectory_point_4, trajectory_point_5, trajectory_point_6, trajectory_point_7};
 
 
@@ -781,7 +781,7 @@ TEST(YieldPluginTest, jmt_traj)
   double initial_time = 0.0;
   double tp = 5;
 
-  carma_planning_msgs::msg::TrajectoryPlan jmt_traj = plugin.generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp);
+  carma_planning_msgs::msg::TrajectoryPlan jmt_traj = plugin.generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, tp, rclcpp::Time(original_tp.trajectory_points.back().target_time).seconds());
 
   EXPECT_EQ(jmt_traj.trajectory_points.size(), original_tp.trajectory_points.size());
   EXPECT_LE(rclcpp::Time(jmt_traj.trajectory_points[2].target_time), rclcpp::Time(original_tp.trajectory_points[2].target_time));
@@ -829,7 +829,7 @@ TEST(YieldPluginTest, min_digital_gap)
   trajectory_point_3.x = 2.0;
   trajectory_point_3.y = 1.0;
   trajectory_point_3.target_time = rclcpp::Time(2,0);
-  
+
   trajectory_point_4.x = 2.5;
   trajectory_point_4.y = 1.0;
   trajectory_point_4.target_time = rclcpp::Time(3,0);
@@ -839,5 +839,5 @@ TEST(YieldPluginTest, min_digital_gap)
   double gap = plugin.check_traj_for_digital_min_gap(original_tp);
 
   EXPECT_EQ(gap, min_gap);
-    
+
 }

--- a/yield_plugin/test/test_yield.cpp
+++ b/yield_plugin/test/test_yield.cpp
@@ -297,7 +297,7 @@ TEST(YieldPluginTest, test_update_traj)
   EXPECT_EQ(7, tp.trajectory_points.size());
 }
 
-TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
+TEST(YieldPluginTest, get_collision_time)
 {
   std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto map = carma_wm::test::buildGuidanceTestMap(100,100);
@@ -421,7 +421,7 @@ TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
   rwo_1.predictions = {ps_1,ps_2,ps_3};
   rwo_1.velocity.twist.linear.x = 10.0;
 
-  std::optional<rclcpp::Time> collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
+  std::optional<rclcpp::Time> collision_time = plugin.get_collision_time(tp, rwo_1.predictions, 6);
 
   ASSERT_TRUE(collision_time == std::nullopt);
 
@@ -448,7 +448,7 @@ TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
   rwo_1.predictions = {ps_1,ps_2,ps_3};
   //
 
-  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time != std::nullopt);
   ASSERT_TRUE(collision_time.value() == rclcpp::Time(2, 0, collision_time.value().get_clock_type()));
 
@@ -467,7 +467,7 @@ TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 
   // STATES ARE ON THE ROUTE, BUT TOO FAR AWAY
@@ -485,7 +485,7 @@ TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 
   // STATES ARE ON THE ROUTE, BUT ALREADY PASSED
@@ -503,7 +503,7 @@ TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 }
 

--- a/yield_plugin/test/test_yield.cpp
+++ b/yield_plugin/test/test_yield.cpp
@@ -297,7 +297,7 @@ TEST(YieldPluginTest, test_update_traj)
   EXPECT_EQ(7, tp.trajectory_points.size());
 }
 
-TEST(YieldPluginTest, detect_collision_time)
+TEST(YieldPluginTest, get_collision_time_using_predicted_steps)
 {
   std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
   auto map = carma_wm::test::buildGuidanceTestMap(100,100);
@@ -421,7 +421,7 @@ TEST(YieldPluginTest, detect_collision_time)
   rwo_1.predictions = {ps_1,ps_2,ps_3};
   rwo_1.velocity.twist.linear.x = 10.0;
 
-  std::optional<rclcpp::Time> collision_time = plugin.detect_collision_time(tp, rwo_1.predictions, 6);
+  std::optional<rclcpp::Time> collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
 
   ASSERT_TRUE(collision_time == std::nullopt);
 
@@ -448,7 +448,7 @@ TEST(YieldPluginTest, detect_collision_time)
   rwo_1.predictions = {ps_1,ps_2,ps_3};
   //
 
-  collision_time = plugin.detect_collision_time(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time != std::nullopt);
   ASSERT_TRUE(collision_time.value() == rclcpp::Time(2, 0, collision_time.value().get_clock_type()));
 
@@ -467,7 +467,7 @@ TEST(YieldPluginTest, detect_collision_time)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.detect_collision_time(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 
   // STATES ARE ON THE ROUTE, BUT TOO FAR AWAY
@@ -485,7 +485,7 @@ TEST(YieldPluginTest, detect_collision_time)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.detect_collision_time(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 
   // STATES ARE ON THE ROUTE, BUT ALREADY PASSED
@@ -503,7 +503,7 @@ TEST(YieldPluginTest, detect_collision_time)
 
   rwo_1.predictions = {ps_1,ps_2};
 
-  collision_time = plugin.detect_collision_time(tp, rwo_1.predictions, 6);
+  collision_time = plugin.get_collision_time_using_predicted_steps(tp, rwo_1.predictions, 6);
   ASSERT_TRUE(collision_time == std::nullopt);
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR is first of the two PR needed to get yield_plugin to a state where TRB videos were recorded.
On a high level, this only includes refactor changes and some guards against bad values such as nan and no large algorithmic changes. Specifically:
- Refactor: `update_traj_for_object` (which is the main function that updates trajectory to yield for detected object) was too large. So divided its portion out to a function called `get_earliest_collision_object_and_time` which handles large portion of collision detection. 
- Parameter changes: Renamed many parameters for clarification. Deleted parameters that should be set from carma-config (vehicle_length, vehicle_height and vehicle_width). And some more tuning of the default parameters. 
- max_trajectory_speed: This function gets the max speed along the ego vehicle's trajectory. Without going into too much detail, JMT algorithm (jerk minimizing trajectory) is dependent on it. However, the max_trajectory_speed should return max speed from only the portion of the trajectory that is being modified. For example, if the vehicle detected a collision while turning in an intersection, its relevant max speed for JMT is from the curvature up until the collision rather than its post-collision speed, post-curvature speed that could be much higher. 
- `get_predicted_velocity_at_time` this function is added because in order to use the JMT trajectory, both ego vehicle's velocity and the obstacles velocity must be in the same direction. Therefore if pedestrian has 1.33 m/s along only x direction and vehicle has 5m/s along only y direction, the effective speed of the pedestrian along the trajectory at collision is 0 m/s. This needed to be accounted. NOTE: At the time of writing this function, external_objects's x,y speeds are in map frame, not in its direction of travel as conventionally done. So the logic to calculate that speed assumes the inputs in said frame.
- minor guards against negative time or dist and nan values that may arise from dividing by zero etc.   
<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2153
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-126
CDAR-126
<!-- e.g. CAR-123 -->

## Motivation and Context
integration testing vehicle controls and yield plugin under vru use case 1
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
part of full integration test on cdasim pc 1 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
