### PR TITLE
fix disengage

### DIFF
--- a/carma_guidance_plugins/include/carma_guidance_plugins/control_plugin.hpp
+++ b/carma_guidance_plugins/include/carma_guidance_plugins/control_plugin.hpp
@@ -21,19 +21,19 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <autoware_msgs/msg/control_command_stamped.hpp>
-
+#include <carma_planning_msgs/msg/guidance_state.hpp>
 #include "carma_guidance_plugins/plugin_base_node.hpp"
 
 namespace carma_guidance_plugins
 {
 
   /**
-   * \brief ControlPlugin base class which can be extended by user provided plugins which wish to implement the Control Plugin ROS API. 
-   * 
-   * A control plugin is responsible for generating high frequency vehicle speed and steering commands to execute the currently planned trajectory. 
-   * This plugin provides default subscribers to track the pose, velocity, and current trajectory in the system. 
-   * Extending classes must implement the generate_command() method to use that data and or additional data to plan commands at a 30Hz frequency. 
-   * 
+   * \brief ControlPlugin base class which can be extended by user provided plugins which wish to implement the Control Plugin ROS API.
+   *
+   * A control plugin is responsible for generating high frequency vehicle speed and steering commands to execute the currently planned trajectory.
+   * This plugin provides default subscribers to track the pose, velocity, and current trajectory in the system.
+   * Extending classes must implement the generate_command() method to use that data and or additional data to plan commands at a 30Hz frequency.
+   *
    */
   class ControlPlugin : public PluginBaseNode
   {
@@ -43,6 +43,7 @@ namespace carma_guidance_plugins
     carma_ros2_utils::SubPtr<geometry_msgs::msg::PoseStamped> current_pose_sub_;
     carma_ros2_utils::SubPtr<geometry_msgs::msg::TwistStamped> current_velocity_sub_;
     carma_ros2_utils::SubPtr<carma_planning_msgs::msg::TrajectoryPlan> trajectory_plan_sub_;
+    carma_ros2_utils::SubPtr<carma_planning_msgs::msg::GuidanceState> guidance_state_sub_;
 
     // Publishers
     carma_ros2_utils::PubPtr<autoware_msgs::msg::ControlCommandStamped> vehicle_cmd_pub_;
@@ -54,7 +55,7 @@ namespace carma_guidance_plugins
     void current_pose_callback(geometry_msgs::msg::PoseStamped::UniquePtr msg);
     void current_twist_callback(geometry_msgs::msg::TwistStamped::UniquePtr msg);
     void current_trajectory_callback(carma_planning_msgs::msg::TrajectoryPlan::UniquePtr msg);
-
+    void guidance_state_callback(carma_planning_msgs::msg::GuidanceState::UniquePtr plan);
 
   protected:
 
@@ -71,7 +72,7 @@ namespace carma_guidance_plugins
 
   public:
     /**
-     * \brief ControlPlugin constructor 
+     * \brief ControlPlugin constructor
      */
     explicit ControlPlugin(const rclcpp::NodeOptions &);
 
@@ -79,13 +80,13 @@ namespace carma_guidance_plugins
     virtual ~ControlPlugin() = default;
 
     /**
-     * \brief Extending class provided method which should generate a command message 
+     * \brief Extending class provided method which should generate a command message
      *        which will be published to the required topic by the base class
-     * 
+     *
      * NOTE:  Implementer can determine if trajectory has changed based on current_trajectory_->trajectory_id
-     * 
+     *
      * \return The command message to publish
-     */ 
+     */
     virtual autoware_msgs::msg::ControlCommandStamped generate_command() = 0;
 
     ////
@@ -97,12 +98,12 @@ namespace carma_guidance_plugins
 
     // Final
     uint8_t get_type() override final;
-
+    bool guidance_engaged_ = false;
     carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &) override final;
     carma_ros2_utils::CallbackReturn handle_on_activate(const rclcpp_lifecycle::State &) override final;
     carma_ros2_utils::CallbackReturn handle_on_deactivate(const rclcpp_lifecycle::State &) override final;
     carma_ros2_utils::CallbackReturn handle_on_cleanup(const rclcpp_lifecycle::State &) override final;
-    carma_ros2_utils::CallbackReturn handle_on_shutdown(const rclcpp_lifecycle::State &) override final; 
+    carma_ros2_utils::CallbackReturn handle_on_shutdown(const rclcpp_lifecycle::State &) override final;
     carma_ros2_utils::CallbackReturn handle_on_error(const rclcpp_lifecycle::State &, const std::string &exception_string) override final;
   };
 

--- a/carma_guidance_plugins/include/carma_guidance_plugins/control_plugin.hpp
+++ b/carma_guidance_plugins/include/carma_guidance_plugins/control_plugin.hpp
@@ -55,7 +55,7 @@ namespace carma_guidance_plugins
     void current_pose_callback(geometry_msgs::msg::PoseStamped::UniquePtr msg);
     void current_twist_callback(geometry_msgs::msg::TwistStamped::UniquePtr msg);
     void current_trajectory_callback(carma_planning_msgs::msg::TrajectoryPlan::UniquePtr msg);
-    void guidance_state_callback(carma_planning_msgs::msg::GuidanceState::UniquePtr plan);
+    void guidance_state_callback(carma_planning_msgs::msg::GuidanceState::UniquePtr msg);
 
   protected:
 

--- a/carma_guidance_plugins/src/control_plugin.cpp
+++ b/carma_guidance_plugins/src/control_plugin.cpp
@@ -65,7 +65,7 @@ namespace carma_guidance_plugins
     current_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>("current_pose", 1,
       std::bind(&ControlPlugin::current_pose_callback, this, std_ph::_1));
 
-    guidance_state_sub_ = create_subscription<carma_planning_msgs::msg::GuidanceState>("/guidance/guidance_state", 5,
+    guidance_state_sub_ = create_subscription<carma_planning_msgs::msg::GuidanceState>("/guidance/state", 5,
       std::bind(&ControlPlugin::guidance_state_callback, this, std_ph::_1));
 
     current_velocity_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>("vehicle/twist", 1,

--- a/carma_guidance_plugins/src/control_plugin.cpp
+++ b/carma_guidance_plugins/src/control_plugin.cpp
@@ -82,7 +82,7 @@ namespace carma_guidance_plugins
         [this]() {
           if (this->get_activation_status()) // Only trigger when activated
           {
-            if (guidance_engaged_)
+            if (!guidance_engaged_)
             {
               current_trajectory_ = boost::none;
             }

--- a/carma_guidance_plugins/src/control_plugin.cpp
+++ b/carma_guidance_plugins/src/control_plugin.cpp
@@ -65,8 +65,8 @@ namespace carma_guidance_plugins
     current_pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>("current_pose", 1,
       std::bind(&ControlPlugin::current_pose_callback, this, std_ph::_1));
 
-    guidance_state_sub_ = create_subscription<carma_planning_msgs::msg::GuidanceState>("guidance_state", 5,
-      std::bind(&ControlPlugin::guidanceStateCallback, this, std_ph::_1));
+    guidance_state_sub_ = create_subscription<carma_planning_msgs::msg::GuidanceState>("/guidance/guidance_state", 5,
+      std::bind(&ControlPlugin::guidance_state_callback, this, std_ph::_1));
 
     current_velocity_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>("vehicle/twist", 1,
       std::bind(&ControlPlugin::current_twist_callback, this, std_ph::_1));
@@ -84,7 +84,7 @@ namespace carma_guidance_plugins
           {
             if (guidance_engaged_)
             {
-              current_trajectory_ = std::nullopt;
+              current_trajectory_ = boost::none;
             }
             this->vehicle_cmd_pub_->publish(this->generate_command());
           }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The platform might disengage prematurely when platform is close to finishing the route and stopping. Control plugins currently continuously publish commands despite being disengaged using the last trajectory available. This PR lets the control plugins reset the trajectory if the guidance is disengaged. 
We may not have detected the behavior previously in real life because the vehicle either successfully commanded 0 before disengaging by chance, or since real life vehicles change the gear to park when disengaged. 
<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2280
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
TODO
<!-- e.g. CAR-123 -->

## Motivation and Context
full integration testing cdar vru use case 1
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
simulation pc 1 with cdasim
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
