### PR TITLE
Add georeference subscription

### DIFF
--- a/carma_cooperative_perception/docs/sdsm_to_detection_list_node.md
+++ b/carma_cooperative_perception/docs/sdsm_to_detection_list_node.md
@@ -8,9 +8,10 @@ offsets, to the same local UTM zone’s coordinate frame.
 
 ## Subscriptions
 
-| Topic          | Message Type                                  | Description    |
-| -------------- | --------------------------------------------- | -------------- |
-| `~/input/sdsm` | `carma_v2x_msgs/SensorDataSharingMessage.msg` | Incoming SDSMs |
+| Topic                  | Message Type                                  | Description                            |
+| ---------------------- | --------------------------------------------- | -------------------------------------- |
+| `~/input/sdsm`         | `carma_v2x_msgs/SensorDataSharingMessage.msg` | Incoming SDSMs                         |
+| `~/input/georeference` | `std_msgs/String.msg`                         | CARMA's map georeference (PROJ string) |
 
 ## Publishers
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -15,6 +15,8 @@
 #ifndef CARMA_COOPERATIVE_PERCEPTION__SDSM_TO_DETECTION_LIST_COMPONENT_HPP_
 #define CARMA_COOPERATIVE_PERCEPTION__SDSM_TO_DETECTION_LIST_COMPONENT_HPP_
 
+#include <string>
+
 #include <carma_cooperative_perception_interfaces/msg/detection_list.hpp>
 #include <carma_ros2_utils/carma_lifecycle_node.hpp>
 #include <carma_v2x_msgs/msg/sensor_data_sharing_message.hpp>

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -19,6 +19,7 @@
 #include <carma_ros2_utils/carma_lifecycle_node.hpp>
 #include <carma_v2x_msgs/msg/sensor_data_sharing_message.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include "carma_cooperative_perception/msg_conversion.hpp"
 
@@ -35,7 +36,10 @@ public:
   : CarmaLifecycleNode{options},
     publisher_{create_publisher<output_msg_type>("output/detections", 1)},
     subscription_{create_subscription<input_msg_type>(
-      "input/sdsm", 1, [this](input_msg_shared_pointer msg_ptr) { sdsm_msg_callback(*msg_ptr); })}
+      "input/sdsm", 1, [this](input_msg_shared_pointer msg_ptr) { sdsm_msg_callback(*msg_ptr); })},
+    georeference_subscription_{create_subscription<std_msgs::msg::String>(
+      "input/georeference", 1,
+      [this](std_msgs::msg::String::SharedPtr msg_ptr) { georeference_ = msg_ptr->data; })}
   {
   }
 
@@ -47,6 +51,9 @@ public:
 private:
   rclcpp::Publisher<output_msg_type>::SharedPtr publisher_;
   rclcpp::Subscription<input_msg_type>::SharedPtr subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr georeference_subscription_;
+
+  std::string georeference_{""};
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/package.xml
+++ b/carma_cooperative_perception/package.xml
@@ -25,6 +25,9 @@ limitations under the License.
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_extension</depend>
+
   <build_depend>ament_cmake_auto</build_depend>
   <build_depend>carma_cmake_common</build_depend>
   <build_depend>carma_cooperative_perception_interfaces</build_depend>
@@ -34,10 +37,9 @@ limitations under the License.
   <build_depend>j3224_v2x_msgs</build_depend>
   <build_depend>carma_v2x_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
-  <depend>lanelet2_core</depend>
-  <depend>lanelet2_extension</depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>multiple_object_tracking</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# PR Details
## Description

This PR adds a georeference subscription to the SDSM conversion node. As part of a bigger-picture refactoring, we want the SDSM objects' coordinates to get projected into CARMA's map frame. Currently, they are projected into CARMA's current UTM zone frame.

## Related GitHub Issue

Closes #2281 

## Related Jira Key

Progresses [CDAR-728](https://usdot-carma.atlassian.net/browse/CDAR-728)

## Motivation and Context

## How Has This Been Tested?

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-728]: https://usdot-carma.atlassian.net/browse/CDAR-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ