### PR TITLE
Update SDSM to detection conversion

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/geodetic.hpp
@@ -36,6 +36,13 @@ struct Wgs84Coordinate
   units::length::meter_t elevation; /** With respect to the reference ellipsoid. */
 };
 
+struct MapCoordinate
+{
+  units::length::meter_t easting;
+  units::length::meter_t northing;
+  units::length::meter_t elevation;
+};
+
 /**
  * @brief Represents a position using UTM coordinates
 */
@@ -161,6 +168,9 @@ inline constexpr auto operator-(const UtmDisplacement & displacement, UtmCoordin
 */
 auto calculate_utm_zone(const Wgs84Coordinate & coordinate) -> UtmZone;
 
+auto project_to_carma_map(const Wgs84Coordinate & coordinate, std::string_view proj_string)
+  -> MapCoordinate;
+
 /**
  * @brief Projects a Wgs84Coordinate to its corresponding UTM zone
  *
@@ -182,6 +192,9 @@ auto project_to_utm(const Wgs84Coordinate & coordinate) -> UtmCoordinate;
  * @return Grid convergence angle
 */
 auto calculate_grid_convergence(const Wgs84Coordinate & position, const UtmZone & zone)
+  -> units::angle::degree_t;
+
+auto calculate_grid_convergence(const Wgs84Coordinate & position, std::string_view georeference)
   -> units::angle::degree_t;
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/msg_conversion.hpp
@@ -37,6 +37,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace carma_cooperative_perception
 {
@@ -67,7 +68,8 @@ auto transform_pose_from_map_to_wgs84(
   const std::shared_ptr<lanelet::projection::LocalFrameProjector> & map_projection)
   -> carma_v2x_msgs::msg::Position3D;
 
-auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm)
+auto to_detection_list_msg(
+  const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm, std::string_view georeference)
   -> carma_cooperative_perception_interfaces::msg::DetectionList;
 
 struct MotionModelMapping

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -47,7 +47,7 @@ public:
 
   auto sdsm_msg_callback(const input_msg_type & msg) const -> void
   {
-    publisher_->publish(to_detection_list_msg(msg));
+    publisher_->publish(to_detection_list_msg(msg, georeference_));
   }
 
 private:

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <cmath>
 #include <limits>
+#include <string>
 #include <utility>
 
 #include <proj.h>
@@ -140,6 +141,17 @@ auto to_position_msg(const UtmCoordinate & position_utm) -> geometry_msgs::msg::
   return msg;
 }
 
+auto to_position_msg(const MapCoordinate & position_map) -> geometry_msgs::msg::Point
+{
+  geometry_msgs::msg::Point msg;
+
+  msg.x = remove_units(position_map.easting);
+  msg.y = remove_units(position_map.northing);
+  msg.z = remove_units(position_map.elevation);
+
+  return msg;
+}
+
 auto heading_to_enu_yaw(const units::angle::degree_t & heading) -> units::angle::degree_t
 {
   return units::angle::degree_t{std::fmod(-(remove_units(heading) - 90.0) + 360.0, 360.0)};
@@ -209,7 +221,8 @@ auto transform_pose_from_map_to_wgs84(
   return ref_pos;
 }
 
-auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm)
+auto to_detection_list_msg(
+  const carma_v2x_msgs::msg::SensorDataSharingMessage & sdsm, std::string_view georeference)
   -> carma_cooperative_perception_interfaces::msg::DetectionList
 {
   carma_cooperative_perception_interfaces::msg::DetectionList detection_list;
@@ -217,13 +230,13 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
   const auto ref_pos_3d{Position3D::from_msg(sdsm.ref_pos)};
   const Wgs84Coordinate ref_pos_wgs84{
     ref_pos_3d.latitude, ref_pos_3d.longitude, ref_pos_3d.elevation.value()};
-  const auto ref_pos_utm{project_to_utm(ref_pos_wgs84)};
+  const auto ref_pos_map{project_to_carma_map(ref_pos_wgs84, georeference)};
 
   for (const auto & object_data : sdsm.objects.detected_object_data) {
     const auto common_data{object_data.detected_object_common_data};
 
     carma_cooperative_perception_interfaces::msg::Detection detection;
-    detection.header.frame_id = to_string(ref_pos_utm.utm_zone);
+    detection.header.frame_id = "map";
 
     const auto detection_time{calc_detection_time_stamp(
       DDateTime::from_msg(sdsm.sdsm_time_stamp),
@@ -234,17 +247,16 @@ auto to_detection_list_msg(const carma_v2x_msgs::msg::SensorDataSharingMessage &
     detection.id = std::to_string(common_data.detected_id.object_id);
 
     const auto pos_offset{PositionOffsetXYZ::from_msg(common_data.pos)};
-    const auto utm_displacement{
-      UtmDisplacement{pos_offset.offset_x, pos_offset.offset_y, pos_offset.offset_z.value()}};
-
-    const auto detection_pos_utm{ref_pos_utm + utm_displacement};
-    detection.pose.pose.position = to_position_msg(detection_pos_utm);
+    detection.pose.pose.position = to_position_msg(MapCoordinate{
+      ref_pos_map.easting + pos_offset.offset_x, ref_pos_map.northing + pos_offset.offset_y,
+      ref_pos_map.elevation + pos_offset.offset_z.value_or(units::length::meter_t{0.0})});
 
     const auto true_heading{units::angle::degree_t{Heading::from_msg(common_data.heading).heading}};
 
     // Note: This should really use the detection's WGS-84 position, so the
     // convergence will be off slightly. TODO
-    const auto grid_convergence{calculate_grid_convergence(ref_pos_wgs84, ref_pos_utm.utm_zone)};
+    const units::angle::degree_t grid_convergence{
+      calculate_grid_convergence(ref_pos_wgs84, georeference)};
 
     const auto grid_heading{true_heading - grid_convergence};
     const auto enu_yaw{heading_to_enu_yaw(grid_heading)};
@@ -436,7 +448,7 @@ auto to_external_object_msg(const carma_cooperative_perception_interfaces::msg::
     case track.SEMANTIC_CLASS_UNKNOWN:
     default:
       external_object.object_type = external_object.UNKNOWN;
-  };
+  }
 
   return external_object;
 }

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <limits>
 
 namespace carma_cooperative_perception
 {

--- a/carma_cooperative_perception/test/test_msg_conversion.cpp
+++ b/carma_cooperative_perception/test/test_msg_conversion.cpp
@@ -89,15 +89,17 @@ TEST(ToDetectionMsg, Simple)
   object_data.detected_object_common_data.accel_4_way.yaw_rate = 5.0;      // degrees/s
 
   sdsm_msg.objects.detected_object_data.push_back(object_data);
+  constexpr std::string_view georeference{"+proj=utm +zone=15 +datum=WGS84 +units=m +no_defs"};
 
-  const auto detection_list{carma_cooperative_perception::to_detection_list_msg(sdsm_msg)};
+  const auto detection_list{
+    carma_cooperative_perception::to_detection_list_msg(sdsm_msg, georeference)};
   ASSERT_EQ(std::size(detection_list.detections), 1U);
 
   const auto detection{detection_list.detections.at(0)};
 
   EXPECT_EQ(detection.header.stamp.sec, 0);
   EXPECT_NEAR(detection.header.stamp.nanosec, 900'000'000U, 2);  // +/- 2 ns is probably good enough
-  EXPECT_EQ(detection.header.frame_id, "15N");
+  EXPECT_EQ(detection.header.frame_id, "map");
 
   EXPECT_NEAR(detection.pose.pose.position.x, 715068.54 + 100.0, 1e-2);   // m (ref pos + offset)
   EXPECT_NEAR(detection.pose.pose.position.y, 3631576.38 + 100.0, 1e-2);  // m (ref pos + offset)


### PR DESCRIPTION
# PR Details
## Description

This PR updates the SDSM conversion node to project coordinates to CARMA's map frame instead of CARMA's current UTM zone's frame. We were originally using the UTM zone frame, but none of CARMA's components use this approach, they all use the georeference origin provided by the currently-loaded map.

## Related GitHub Issue

Closes #2283 

## Related Jira Key

Progresses [CDAR-538](https://usdot-carma.atlassian.net/browse/CDAR-538)

## Motivation and Context

## How Has This Been Tested?

Integration testing

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-538]: https://usdot-carma.atlassian.net/browse/CDAR-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ