### PR TITLE
Prepend BSM ID to detections

### DIFF
--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -244,7 +244,21 @@ auto to_detection_list_msg(
 
     detection.header.stamp = to_time_msg(detection_time);
 
-    detection.id = std::to_string(common_data.detected_id.object_id);
+    static constexpr auto to_string = [](const std::vector<std::uint8_t> bsm_id) {
+      std::string bsm_string;
+
+      std::array<char, 2> buffer;
+      for (const auto & element : bsm_id) {
+        std::to_chars(std::begin(buffer), std::end(buffer), element, 16);
+        bsm_string.push_back(std::toupper(std::get<0>(buffer)));
+        bsm_string.push_back(std::toupper(std::get<1>(buffer)));
+      }
+
+      return bsm_string;
+    };
+
+    detection.id =
+      to_string(sdsm.source_id.id) + "-" + std::to_string(common_data.detected_id.object_id);
 
     const auto pos_offset{PositionOffsetXYZ::from_msg(common_data.pos)};
     detection.pose.pose.position = to_position_msg(MapCoordinate{

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -244,17 +244,19 @@ auto to_detection_list_msg(
 
     detection.header.stamp = to_time_msg(detection_time);
 
-    static constexpr auto to_string = [](const std::vector<std::uint8_t> bsm_id) {
-      std::string bsm_string;
+    // TemporaryID and octet string terms come from the SAE J2735 message definitions
+    static constexpr auto to_string = [](const std::vector<std::uint8_t> & temporary_id) {
+      std::string str;
+      str.reserve(2 * std::size(temporary_id));  // Two hex characters per octet string
 
       std::array<char, 2> buffer;
-      for (const auto & element : bsm_id) {
-        std::to_chars(std::begin(buffer), std::end(buffer), element, 16);
-        bsm_string.push_back(std::toupper(std::get<0>(buffer)));
-        bsm_string.push_back(std::toupper(std::get<1>(buffer)));
+      for (const auto & octet_string : temporary_id) {
+        std::to_chars(std::begin(buffer), std::end(buffer), octet_string, 16);
+        str.push_back(std::toupper(std::get<0>(buffer)));
+        str.push_back(std::toupper(std::get<1>(buffer)));
       }
 
-      return bsm_string;
+      return str;
     };
 
     detection.id =

--- a/carma_cooperative_perception/test/test_msg_conversion.cpp
+++ b/carma_cooperative_perception/test/test_msg_conversion.cpp
@@ -58,6 +58,7 @@ TEST(ToTimeMsg, NulloptSeconds)
 TEST(ToDetectionMsg, Simple)
 {
   carma_v2x_msgs::msg::SensorDataSharingMessage sdsm_msg;
+  sdsm_msg.source_id.id = {0xBA, 0xDD, 0xCA, 0xFE};
   sdsm_msg.sdsm_time_stamp.second.millisecond = 1000;
   sdsm_msg.sdsm_time_stamp.presence_vector |= sdsm_msg.sdsm_time_stamp.SECOND;
   sdsm_msg.ref_pos.longitude = -90.703125;  // degrees
@@ -66,7 +67,7 @@ TEST(ToDetectionMsg, Simple)
   sdsm_msg.ref_pos.elevation = 300.0;  // m
 
   carma_v2x_msgs::msg::DetectedObjectData object_data;
-  object_data.detected_object_common_data.detected_id.object_id = 0xBEEF;
+  object_data.detected_object_common_data.detected_id.object_id = 1;
   object_data.detected_object_common_data.measurement_time.measurement_time_offset = -0.1;  // s
 
   object_data.detected_object_common_data.heading.heading = 34;  // true heading; degrees
@@ -118,7 +119,7 @@ TEST(ToDetectionMsg, Simple)
   EXPECT_DOUBLE_EQ(detection.accel.accel.linear.y, 1.0);
   EXPECT_NEAR(detection.accel.accel.linear.z, 2.4 * 9.80665, 1e-4);
 
-  EXPECT_EQ(detection.id, std::to_string(0xBEEF));
+  EXPECT_EQ(detection.id, "BADDCAFE-1");
   EXPECT_EQ(detection.motion_model, detection.MOTION_MODEL_CTRV);
 }
 


### PR DESCRIPTION
# PR Details
## Description

This PR changes the way detection IDs are generated from incoming SDSMs. Previously, the detection IDs were simply the object IDs from the SDSM's contained objects. Now the detection IDs will have the SDSM's originator source ID prepended to it. This will detection IDs unique across all detections.

## Related GitHub Issue

Closes #2286

## Related Jira Key

Progresses [CDAR-538](https://usdot-carma.atlassian.net/browse/CDAR-538)

## Motivation and Context

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] All new and existing tests passed.


[CDAR-538]: https://usdot-carma.atlassian.net/browse/CDAR-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ