### PR TITLE
[cooperative perception] Add covariance calculations to SDSM conversions

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -49,10 +49,8 @@ public:
   {
     try {
       publisher_->publish(to_detection_list_msg(msg, georeference_));
-    } catch (const std::bad_optional_access &) {
-      RCLCPP_ERROR(
-        get_logger(),
-        "Not converting SDSM to detection list: missing at least one required optional-field");
+    } catch (const std::runtime_error & e) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Not converting SDSM to detection list: " << e.what());
     }
   }
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -50,7 +50,7 @@ public:
     try {
       publisher_->publish(to_detection_list_msg(msg, georeference_));
     } catch (const std::runtime_error & e) {
-      RCLCPP_ERROR_STREAM(get_logger(), "Not converting SDSM to detection list: " << e.what());
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to convert SDSM to detection list: " << e.what());
     }
   }
 

--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -47,7 +47,13 @@ public:
 
   auto sdsm_msg_callback(const input_msg_type & msg) const -> void
   {
-    publisher_->publish(to_detection_list_msg(msg, georeference_));
+    try {
+      publisher_->publish(to_detection_list_msg(msg, georeference_));
+    } catch (const std::bad_optional_access &) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Not converting SDSM to detection list: missing at least one required optional-field");
+    }
   }
 
 private:

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -270,12 +270,21 @@ auto to_detection_list_msg(
       ref_pos_map.elevation + pos_offset.offset_z.value_or(units::length::meter_t{0.0})});
 
     // Pose covariance is x, y, z, roll, pitch, yaw
-    detection.pose.covariance.at(0) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.pos).value(), 2);
-    detection.pose.covariance.at(1) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.pos).value(), 2);
-    detection.pose.covariance.at(2) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.elevation).value(), 2);
+    try {
+      detection.pose.covariance.at(0) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.pos).value(), 2);
+      detection.pose.covariance.at(7) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.pos).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing position confidence");
+    }
+
+    try {
+      detection.pose.covariance.at(14) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.elevation).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing elevation confidence");
+    }
 
     const auto true_heading{units::angle::degree_t{Heading::from_msg(common_data.heading).heading}};
 
@@ -291,9 +300,13 @@ auto to_detection_list_msg(
     quat_tf.setRPY(0, 0, remove_units(units::angle::radian_t{enu_yaw}));
     detection.pose.pose.orientation = tf2::toMsg(quat_tf);
 
-    // Pose covariance is x, y, z, roll, pitch, yaw
-    detection.pose.covariance.at(5) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.heading_conf).value(), 2);
+    try {
+      // Pose covariance is x, y, z, roll, pitch, yaw
+      detection.pose.covariance.at(35) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.heading_conf).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing heading confidence");
+    }
 
     const auto speed{Speed::from_msg(common_data.speed)};
     detection.twist.twist.linear.x =
@@ -303,32 +316,31 @@ auto to_detection_list_msg(
     detection.twist.twist.linear.z =
       remove_units(units::velocity::meters_per_second_t{speed_z.speed});
 
-    // Twist covariance is x, y, z, roll, pitch, yaw
-    detection.twist.covariance.at(0) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.speed_confidence).value(), 2);
-    detection.twist.covariance.at(2) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.speed_confidence_z).value(), 2);
+    try {
+      // Twist covariance is x, y, z, roll, pitch, yaw
+      detection.twist.covariance.at(0) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.speed_confidence).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing speed confidence");
+    }
+
+    try {
+      detection.twist.covariance.at(14) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.speed_confidence_z).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing z-speed confidence");
+    }
 
     const auto accel_set{AccelerationSet4Way::from_msg(common_data.accel_4_way)};
-    detection.accel.accel.linear.x =
-      remove_units(units::acceleration::meters_per_second_squared_t{accel_set.longitudinal});
-    detection.accel.accel.linear.y =
-      remove_units(units::acceleration::meters_per_second_squared_t{accel_set.lateral});
-    detection.accel.accel.linear.z =
-      remove_units(units::acceleration::meters_per_second_squared_t{accel_set.vert});
-
-    detection.accel.covariance.at(0) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.acc_cfd_x).value(), 2);
-    detection.accel.covariance.at(1) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.acc_cfd_y).value(), 2);
-    detection.accel.covariance.at(2) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.acc_cfd_z).value(), 2);
-
     detection.twist.twist.angular.z =
       remove_units(units::angular_velocity::degrees_per_second_t{accel_set.yaw_rate});
 
-    detection.twist.covariance.at(5) =
-      0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.acc_cfd_yaw).value(), 2);
+    try {
+      detection.twist.covariance.at(35) =
+        0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.acc_cfd_yaw).value(), 2);
+    } catch (const std::bad_optional_access &) {
+      throw std::runtime_error("missing yaw-rate confidence");
+    }
 
     switch (common_data.obj_type.object_type) {
       case common_data.obj_type.ANIMAL:

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -269,7 +269,7 @@ auto to_detection_list_msg(
       ref_pos_map.easting + pos_offset.offset_x, ref_pos_map.northing + pos_offset.offset_y,
       ref_pos_map.elevation + pos_offset.offset_z.value_or(units::length::meter_t{0.0})});
 
-    // Pose covariance is x, y, z, roll, pitch, yaw
+    // Pose covariance is flattened 6x6 matrix with rows/columns of x, y, z, roll, pitch, yaw
     try {
       detection.pose.covariance.at(0) =
         0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.pos_confidence.pos).value(), 2);
@@ -301,7 +301,7 @@ auto to_detection_list_msg(
     detection.pose.pose.orientation = tf2::toMsg(quat_tf);
 
     try {
-      // Pose covariance is x, y, z, roll, pitch, yaw
+      // Pose covariance is flattened 6x6 matrix with rows/columns of x, y, z, roll, pitch, yaw
       detection.pose.covariance.at(35) =
         0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.heading_conf).value(), 2);
     } catch (const std::bad_optional_access &) {
@@ -317,7 +317,7 @@ auto to_detection_list_msg(
       remove_units(units::velocity::meters_per_second_t{speed_z.speed});
 
     try {
-      // Twist covariance is x, y, z, roll, pitch, yaw
+      // Twist covariance is flattened 6x6 matrix with rows/columns of x, y, z, roll, pitch, yaw
       detection.twist.covariance.at(0) =
         0.5 * std::pow(j2735_v2x_msgs::to_double(common_data.speed_confidence).value(), 2);
     } catch (const std::bad_optional_access &) {


### PR DESCRIPTION
# PR Details
## Description

This SDSM to detected object list conversion did not generate the covariance matrix values from confidence intervals, making the resulting detection list pretty much useless.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-729](https://usdot-carma.atlassian.net/browse/CDAR-729)

## Motivation and Context

SDSM to detection list conversion is necessary to receive detected object information from nearby actors.

## How Has This Been Tested?

Manually in integration testing.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-729]: https://usdot-carma.atlassian.net/browse/CDAR-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ