### PR TITLE
Add DetectionList message visualization

### DIFF
--- a/carma_cooperative_perception/CMakeLists.txt
+++ b/carma_cooperative_perception/CMakeLists.txt
@@ -65,6 +65,7 @@ ament_auto_add_library(carma_cooperative_perception SHARED
   src/utm_zone.cpp
   src/multiple_object_tracker_component.cpp
   src/host_vehicle_filter_component.cpp
+  src/detection_list_viz_component.cpp
 )
 
 target_link_libraries(carma_cooperative_perception
@@ -101,6 +102,10 @@ ament_auto_add_executable(external_object_list_to_sdsm_node
 
 ament_auto_add_executable(host_vehicle_filter_node
   src/host_vehicle_filter_node.cpp
+)
+
+ament_auto_add_executable(detection_list_viz_node
+  src/detection_list_viz_node.cpp
 )
 
 # boost::posix_time definition for using nanoseconds

--- a/carma_cooperative_perception/include/carma_cooperative_perception/detection_list_viz_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/detection_list_viz_component.hpp
@@ -1,0 +1,37 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CARMA_COOPERATIVE_PERCEPTION__DETECTION_LIST_VIZ_COMPONENT_HPP_
+#define CARMA_COOPERATIVE_PERCEPTION__DETECTION_LIST_VIZ_COMPONENT_HPP_
+
+#include <carma_cooperative_perception_interfaces/msg/detection_list.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace carma_cooperative_perception
+{
+class DetectionListVizNode : public rclcpp::Node
+{
+public:
+  explicit DetectionListVizNode(const rclcpp::NodeOptions & options);
+
+private:
+  rclcpp::Subscription<carma_cooperative_perception_interfaces::msg::DetectionList>::SharedPtr
+    detection_list_sub_{nullptr};
+
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_{nullptr};
+};
+}  // namespace carma_cooperative_perception
+
+#endif  // CARMA_COOPERATIVE_PERCEPTION__DETECTION_LIST_VIZ_COMPONENT_HPP_

--- a/carma_cooperative_perception/package.xml
+++ b/carma_cooperative_perception/package.xml
@@ -40,6 +40,7 @@ limitations under the License.
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>multiple_object_tracking</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/carma_cooperative_perception/src/detection_list_viz_component.cpp
+++ b/carma_cooperative_perception/src/detection_list_viz_component.cpp
@@ -1,0 +1,56 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "carma_cooperative_perception/detection_list_viz_component.hpp"
+
+#include <rclcpp_components/register_node_macro.hpp>
+
+namespace carma_cooperative_perception
+{
+
+DetectionListVizNode::DetectionListVizNode(const rclcpp::NodeOptions & options)
+: Node("detection_list_viz_node", options)
+{
+  detection_list_sub_ =
+    create_subscription<carma_cooperative_perception_interfaces::msg::DetectionList>(
+      "input/detections_lists", 1,
+      [this](carma_cooperative_perception_interfaces::msg::DetectionList::ConstSharedPtr msg_ptr) {
+        visualization_msgs::msg::MarkerArray markers;
+
+        for (const auto detection : msg_ptr->detections) {
+          visualization_msgs::msg::Marker marker;
+
+          marker.header = detection.header;
+          marker.ns = detection.id;
+          marker.type = marker.CUBE;
+          marker.action = marker.MODIFY;  // equivalent to ADD if marker does not exist
+          marker.pose = detection.pose.pose;
+          marker.scale.x = 2.0;
+          marker.scale.y = 2.0;
+          marker.scale.z = 2.0;
+        }
+
+        marker_pub_->publish(markers);
+      });
+
+  marker_pub_ = create_publisher<visualization_msgs::msg::MarkerArray>("output/markers", 1);
+}
+
+}  // namespace carma_cooperative_perception
+
+// This is not our macro, so we should not worry about linting it.
+// clang-tidy added support for ignoring system macros in release 14.0.0 (see the release notes
+// here: https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html), but
+// ament_clang_tidy for ROS 2 Foxy specifically looks for clang-tidy-6.0.
+RCLCPP_COMPONENTS_REGISTER_NODE(carma_cooperative_perception::DetectionListVizNode)  // NOLINT

--- a/carma_cooperative_perception/src/detection_list_viz_node.cpp
+++ b/carma_cooperative_perception/src/detection_list_viz_node.cpp
@@ -1,0 +1,31 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <carma_cooperative_perception/detection_list_viz_component.hpp>
+
+#include <memory>
+
+auto main(int argc, char * argv[]) -> int
+{
+  rclcpp::init(argc, argv);
+
+  rclcpp::spin(
+    std::make_shared<carma_cooperative_perception::DetectionListVizNode>(rclcpp::NodeOptions{}));
+
+  rclcpp::shutdown();
+
+  return 0;
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds a new node to convert `DetectionList.msg` messages to `MarkerArray.msg` messages that can be used in RViz or Foxglove Studio to visualize detections. This will help with troubleshooting cooperative perception pipeline issues.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-758](https://usdot-carma.atlassian.net/browse/CDAR-758)

## Motivation and Context

Helps with troubleshooting cooperative perception stack issues.

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-758]: https://usdot-carma.atlassian.net/browse/CDAR-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ