### PR TITLE
[cooperative perception] Compensate for CDASim time lag

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/sdsm_to_detection_list_component.hpp
@@ -59,7 +59,7 @@ public:
         // When in simulation, ROS time is CARLA time, but SDSMs use CDASim time
         const auto time_delta{now() - cdasim_time_.value()};
 
-        for (auto detection : detection_list_msg.detections) {
+        for (auto & detection : detection_list_msg.detections) {
           detection.header.stamp = rclcpp::Time(detection.header.stamp) + time_delta;
         }
       }

--- a/carma_cooperative_perception/package.xml
+++ b/carma_cooperative_perception/package.xml
@@ -41,6 +41,7 @@ limitations under the License.
   <build_depend>multiple_object_tracking</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# PR Details
## Description

CARLA and CDASim have two different epochs, and CARLA time (CARLA's game time) leads CDASim time (MOSAIC's current time) by a considerable amount. The incoming SDSMs use CDASim time, which throws off the temporal alignment tracking steps. 

The SDSM to detection conversion node now listens the the CDASim's clock topic and records the time difference between it and CARLA's clock. The SDSMs' timestamps are now updated to their equivalent CARLA time values when being converted into detection lists.

> [!NOTE]
> This is not the ideal fix, but it is necessary because we currently don't have a way to compensate for the time differences internally with CDASim. That is for future work.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-757](https://usdot-carma.atlassian.net/browse/CDAR-757)

## Motivation and Context

This was causing performance issues.

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
