### PR TITLE
Cdar 766 georeference remap

### DIFF
--- a/carma/launch/environment.launch.py
+++ b/carma/launch/environment.launch.py
@@ -483,6 +483,7 @@ def generate_launch_description():
                     {'--log-level' : GetLogLevel('cp_sdsm_to_detection_list_node', env_log_levels) },
                 ],
                 remappings=[
+                    ("input/georeference", [ EnvironmentVariable('CARMA_LOCZ_NS', default_value=''), "/map_param_loader/georeference" ] )
                     ("input/sdsm", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_sdsm" ] ),
                     ("input/cdasim_clock", "/sim_clock"),
                     ("output/detections", "full_detection_list"),

--- a/carma/launch/environment.launch.py
+++ b/carma/launch/environment.launch.py
@@ -483,7 +483,7 @@ def generate_launch_description():
                     {'--log-level' : GetLogLevel('cp_sdsm_to_detection_list_node', env_log_levels) },
                 ],
                 remappings=[
-                    ("input/georeference", [ EnvironmentVariable('CARMA_LOCZ_NS', default_value=''), "/map_param_loader/georeference" ] )
+                    ("input/georeference", [ EnvironmentVariable('CARMA_LOCZ_NS', default_value=''), "/map_param_loader/georeference" ] ),
                     ("input/sdsm", [ EnvironmentVariable('CARMA_MSG_NS', default_value=''), "/incoming_sdsm" ] ),
                     ("input/cdasim_clock", "/sim_clock"),
                     ("output/detections", "full_detection_list"),


### PR DESCRIPTION
# PR Details
## Description

This PR adds a topic remap for the SDSM to detection list node in the environment launch file.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-766](https://usdot-carma.atlassian.net/browse/CDAR-766)

## Motivation and Context

The missing remap was preventing the node from receiving georeference updates.

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-766]: https://usdot-carma.atlassian.net/browse/CDAR-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ