### PR TITLE
[cooperative perception] Change UUID when creating tracks

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/multiple_object_tracker_component.hpp
@@ -80,6 +80,7 @@ private:
     multiple_object_tracking::RemovalThreshold{0U}};
   units::time::nanosecond_t execution_period_{1 / units::frequency::hertz_t{2.0}};
   OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_{nullptr};
+  std::size_t lifetime_generated_track_count_{0U};
 };
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -582,6 +582,8 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     for (const auto & cluster : clusters) {
       const auto detection{std::cbegin(cluster.get_detections())->second};
       const auto uuid_str{mot::get_uuid(detection).value()};
+      // CARLA uses three-digit actor identifiers. We want to UUID scheme to be
+      // <track_number>-<carla_actor_id> for easier visual analysis by users.
       const mot::Uuid new_uuid{
         std::to_string(lifetime_generated_track_count_++) +
         uuid_str.substr(std::size(uuid_str) - 4, 4)};
@@ -665,6 +667,8 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
   for (const auto & cluster : clusters) {
     const auto detection{std::cbegin(cluster.get_detections())->second};
     const auto uuid_str{mot::get_uuid(detection).value()};
+    // CARLA uses three-digit actor identifiers. We want to UUID scheme to be
+    // <track_number>-<carla_actor_id> for easier visual analysis by users.
     const mot::Uuid new_uuid{
       std::to_string(lifetime_generated_track_count_++) +
       uuid_str.substr(std::size(uuid_str) - 4, 4)};

--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 #include <multiple_object_tracking/clustering.hpp>
 #include <multiple_object_tracking/ctra_model.hpp>
 #include <multiple_object_tracking/ctrv_model.hpp>
@@ -31,7 +32,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <limits>
 
 namespace carma_cooperative_perception
 {
@@ -560,8 +560,12 @@ struct MetricSe2
 auto MultipleObjectTrackerNode::execute_pipeline() -> void
 {
   static constexpr mot::Visitor make_track_visitor{
-    [](const mot::CtrvDetection & d) { return Track{mot::make_track<mot::CtrvTrack>(d)}; },
-    [](const mot::CtraDetection & d) { return Track{mot::make_track<mot::CtraTrack>(d)}; },
+    [](const mot::CtrvDetection & d, const mot::Uuid & u) {
+      return Track{mot::make_track<mot::CtrvTrack>(d, u)};
+    },
+    [](const mot::CtraDetection & d, const mot::Uuid & u) {
+      return Track{mot::make_track<mot::CtraTrack>(d, u)};
+    },
     [](const auto &) {
       // Currently on support CTRV and CTRA
       throw std::runtime_error("cannot make track from given detection");
@@ -577,7 +581,12 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
     const auto clusters{mot::cluster_detections(detections_, 0.75)};
     for (const auto & cluster : clusters) {
       const auto detection{std::cbegin(cluster.get_detections())->second};
-      track_manager_.add_tentative_track(std::visit(make_track_visitor, detection));
+      const auto uuid_str{mot::get_uuid(detection).value()};
+      const mot::Uuid new_uuid{
+        std::to_string(lifetime_generated_track_count_++) +
+        uuid_str.substr(std::size(uuid_str) - 4, 4)};
+      track_manager_.add_tentative_track(
+        std::visit(make_track_visitor, detection, std::variant<mot::Uuid>(new_uuid)));
     }
 
     track_list_pub_->publish(carma_cooperative_perception_interfaces::msg::TrackList{});
@@ -655,7 +664,12 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
   const auto clusters{mot::cluster_detections(unassociated_detections, 0.75, MetricSe2{})};
   for (const auto & cluster : clusters) {
     const auto detection{std::cbegin(cluster.get_detections())->second};
-    track_manager_.add_tentative_track(std::visit(make_track_visitor, detection));
+    const auto uuid_str{mot::get_uuid(detection).value()};
+    const mot::Uuid new_uuid{
+      std::to_string(lifetime_generated_track_count_++) +
+      uuid_str.substr(std::size(uuid_str) - 4, 4)};
+    track_manager_.add_tentative_track(
+      std::visit(make_track_visitor, detection, std::variant<mot::Uuid>(new_uuid)));
   }
 
   carma_cooperative_perception_interfaces::msg::TrackList track_list;


### PR DESCRIPTION
# PR Details
## Description

This PR changes how UUIDs are generated for tracks. Previously, the multiple object tracking node would reuse the UUID from a detection when converting it to a track. This made the track identifiers misleading because tracks' states are fused from several sources, not only detections with the same identifier. It also caused issues downstream when converting the UUID to an integer due to data size limits.

The node now maintains a monotonically increasing count of lifetime-generated tracks. It uses this number when creating new tracks.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-792](https://usdot-carma.atlassian.net/browse/CDAR-792)

## Motivation and Context

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-792]: https://usdot-carma.atlassian.net/browse/CDAR-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ