### PR TITLE
[cooperative perception] Fix distance calculation for host vehicle filter

### DIFF
--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -167,6 +167,12 @@ auto HostVehicleFilterNode::attempt_filter_and_republish(
     return;
   }
 
+  if (
+    detection.semantic_class != detection.SEMANTIC_CLASS_UNKNOWN &&
+    detection.semantic_class != detection.SEMANTIC_CLASS_SMALL_VEHICLE) {
+    return false;
+  }
+
   const auto is_within_distance = [this](const auto & detection) {
     return euclidean_distance_squared(host_vehicle_pose_.value().pose, detection.pose.pose) <=
            this->squared_distance_threshold_meters_;
@@ -184,10 +190,7 @@ auto euclidean_distance_squared(
   const geometry_msgs::msg::Pose & a, const geometry_msgs::msg::Pose & b) -> double
 {
   return std::pow(a.position.x - b.position.x, 2) + std::pow(a.position.y - b.position.y, 2) +
-         std::pow(a.position.z - b.position.z, 2) + std::pow(a.orientation.x - b.orientation.x, 2) +
-         std::pow(a.orientation.y - b.orientation.y, 2) +
-         std::pow(a.orientation.z - b.orientation.z, 2) +
-         std::pow(a.orientation.w - b.orientation.w, 2);
+         std::pow(a.position.z - b.position.z, 2);
 }
 
 }  // namespace carma_cooperative_perception

--- a/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
+++ b/carma_cooperative_perception/src/host_vehicle_filter_component.cpp
@@ -167,13 +167,13 @@ auto HostVehicleFilterNode::attempt_filter_and_republish(
     return;
   }
 
-  if (
-    detection.semantic_class != detection.SEMANTIC_CLASS_UNKNOWN &&
-    detection.semantic_class != detection.SEMANTIC_CLASS_SMALL_VEHICLE) {
-    return false;
-  }
-
   const auto is_within_distance = [this](const auto & detection) {
+    if (
+      detection.semantic_class != detection.SEMANTIC_CLASS_UNKNOWN &&
+      detection.semantic_class != detection.SEMANTIC_CLASS_SMALL_VEHICLE) {
+      return false;
+    }
+
     return euclidean_distance_squared(host_vehicle_pose_.value().pose, detection.pose.pose) <=
            this->squared_distance_threshold_meters_;
   };


### PR DESCRIPTION
# PR Details
## Description

This PR fixes an implementation issue with the host vehicle filter's distance calculation. The `euclidean_distance_squared()` function included angular distance as part of the calculation, which is different from Euclidean distance. This caused filter issues do to noisy rotations.

This PR also makes a small improvement to the `is_within_distance` lambda by adding a semantic class check. If a detection's semantic class is known to not be a vehicle, the lambda will return false because the object cannot be the host vehicle.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-805](https://usdot-carma.atlassian.net/browse/CDAR-805)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
