### PR TITLE
[cooperative perception] Tighten pruning distance

### DIFF
--- a/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
+++ b/carma_cooperative_perception/src/multiple_object_tracker_component.cpp
@@ -608,7 +608,7 @@ auto MultipleObjectTrackerNode::execute_pipeline() -> void
 
   // This pruning distance is an arbitrarily-chosen heuristic. It is working well for our
   // current purposes, but there's no reason it couldn't be restricted or loosened.
-  mot::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 5.0; });
+  mot::prune_track_and_detection_scores_if(scores, [](const auto & score) { return score > 1.0; });
 
   const auto associations{
     mot::associate_detections_to_tracks(scores, mot::gnn_association_visitor)};


### PR DESCRIPTION
# PR Details
## Description

This PR tightens the pruning distance threshold. Any scores (detection--track distance) that are more than 1 meter from a track will be pruned. This makes it easier on the association step since there are fewer possibilities to consider.

## Related GitHub Issue

## Related Jira Key

## Motivation and Context

## How Has This Been Tested?

Manually in integration testing.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
