### PR TITLE
Fix unintended size_t wrap-around behavior in basic_autonomy package

### DIFF
--- a/basic_autonomy/src/helper_functions.cpp
+++ b/basic_autonomy/src/helper_functions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 LEIDOS.
+ * Copyright (C) 2021-2024 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,6 +14,7 @@
  * the License.
  */
 
+#include <algorithm>
 #include <basic_autonomy/helper_functions.hpp>
 
 
@@ -65,18 +66,21 @@ namespace waypoint_generation
     int get_nearest_index_by_downtrack(const std::vector<lanelet::BasicPoint2d>& points, const carma_wm::WorldModelConstPtr& wm, double target_downtrack)
     {
         size_t best_index = points.size() - 1;
-        for(size_t i = 0;i < points.size(); i++){
-            double downtrack = wm->routeTrackPos(points[i]).downtrack;
-            if(downtrack > target_downtrack){
-                //If value is negative, best index should be index 0
-                best_index = std::max((size_t)0, i - 1);
 
-                RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "get_nearest_index_by_downtrack>> Found best_idx: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y() << ", downtrack: "<< downtrack);
-                break;
-            }
+        // Find first point with a downtrack greater than target_downtrack
+        const auto itr = std::find_if(std::cbegin(points), std::cend(points), 
+            [&](const auto & point) { return wm->routeTrackPos(point).downtrack > target_downtrack; });
+
+        // Set best_index to the last point with a downtrack less than target_downtrack without going below index 0
+        if(itr != points.begin()){
+            best_index = std::distance(points.begin(), itr) - 1;
         }
-        RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "get_nearest_index_by_downtrack>> Found best_idx: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y());
+        else{
+            best_index = 0;
+        }
 
+        RCLCPP_DEBUG_STREAM(rclcpp::get_logger(BASIC_AUTONOMY_LOGGER), "get_nearest_index_by_downtrack>> Found best_index: " << best_index<<", points[i].x(): " << points[best_index].x() << ", points[i].y(): " << points[best_index].y());
+        
         return static_cast<int>(best_index);
     }
 

--- a/basic_autonomy/test/test_waypoint_generation.cpp
+++ b/basic_autonomy/test/test_waypoint_generation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 LEIDOS.
+ * Copyright (C) 2019-2024 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -113,7 +113,7 @@ namespace basic_autonomy
 
     }
 
-     TEST(BasicAutonomyTest, constrain_to_time_boundary)
+    TEST(BasicAutonomyTest, constrain_to_time_boundary)
     {
 
         std::vector<waypoint_generation::PointSpeedPair> points;
@@ -201,7 +201,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
-TEST(BasicAutonomyTest, get_nearest_basic_point_index)
+    TEST(BasicAutonomyTest, get_nearest_basic_point_index)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
 
@@ -231,6 +231,43 @@ TEST(BasicAutonomyTest, get_nearest_basic_point_index)
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
+    TEST(BasicAutonomyTest, get_nearest_index_by_downtrack)
+    {
+        // Create CARMA World Model with custom Guidance Test Map
+        std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
+        auto map = carma_wm::test::buildGuidanceTestMap(5.0, 10.0); // Lanelet width 5.0 meters; Lanelet length 10.0 meters
+        wm->setMap(map);
+        carma_wm::test::setRouteByIds({1200, 1201, 1202, 1203}, wm);
+
+        // Create vector of points with y-values corresponding to their respective downtracks on the set route
+        std::vector<lanelet::BasicPoint2d> points;
+
+        lanelet::BasicPoint2d point = lanelet::BasicPoint2d(2.5, 5.0);
+        points.push_back(point);
+        point = lanelet::BasicPoint2d(2.5, 10.0);
+        points.push_back(point);
+        point = lanelet::BasicPoint2d(2.5, 15.0);
+        points.push_back(point);
+        point = lanelet::BasicPoint2d(2.5, 20.0);
+        points.push_back(point);
+
+        // Test with downtrack before points index 0
+        double target_downtrack = 4.0;
+        ASSERT_EQ(0, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
+
+        // Test with downtrack after points index 1
+        target_downtrack = 11.0;
+        ASSERT_EQ(1, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
+
+        // Test with downtrack after points index 2
+        target_downtrack = 17.0;
+        ASSERT_EQ(2, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
+
+        // Test with downtrack after points index 3
+        target_downtrack = 22.0;
+        ASSERT_EQ(3, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
+    }
+    
     TEST(BasicAutonomyTest, split_point_speed_pairs)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes unintended size_t wrap-around behavior in the `basic_autonomy` package's `get_nearest_index_by_downtrack()` function. This function receives [1] a vector of points within increasing downtracks and [2] a target downtrack, and it finds the index of the point with the greatest downtrack that is less than the target downtrack (returning index 0 if no points have a downtrack less than the target downtrack). 

Prior to this fix, the line (slightly altered here) `size_t best_index = std::max((size_t)0, i - 1);` led to unintended behavior if `i` was set to 0, since size_t(-1) results in a very large positive number.

NOTE: Two unit tests currently fail in the `basic_autonomy` package. These will be worked on as part of a separate effort.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
#2329 

## Related Jira Key

<!-- e.g. CAR-123 -->
CF-785

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes the above linked GitHub issue. This is a safety improvement to the system and also improves ride comfort.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test was created for the `get_nearest_index_by_downtrack()` function (no unit tests existed previously for this function) to test its results for several cases, including the case that failed in the original implementation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
