### PR TITLE
[cooperative perception] Fix segmentation fault when there is no georeference

### DIFF
--- a/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
+++ b/carma_cooperative_perception/src/external_object_list_to_sdsm_component.cpp
@@ -118,6 +118,15 @@ auto ExternalObjectListToSdsmNode::handle_on_shutdown(
 auto ExternalObjectListToSdsmNode::publish_as_sdsm(const external_objects_msg_type & msg) const
   -> void
 {
+  if (!map_projector_) {
+    // Set to DEBUG level because this node may start up before any georeference publisher. In that
+    // scenario, temporarily not having a georeference (and therefore, no projector) is expected.
+    RCLCPP_DEBUG(
+      this->get_logger(), "Could not convert external object list to SDSM: unknown georeference");
+
+    return;
+  }
+
   try {
     const auto sdsm_output{to_sdsm_msg(msg, current_pose_, map_projector_)};
 


### PR DESCRIPTION
# PR Details
## Description

This PR fixes a segmentation fault in the `ExternalObjectListToSdsmNode` that was caused by an unchecked pointer dereference for `map_projector_`.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-826](https://usdot-carma.atlassian.net/browse/CDAR-826)

## Motivation and Context

## How Has This Been Tested?

Manually in integration testing

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-826]: https://usdot-carma.atlassian.net/browse/CDAR-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ