### PR TITLE
fix sdsm not publishing

### DIFF
--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -25,6 +25,8 @@
 #include <j3224_v2x_msgs/msg/detected_object_data.hpp>
 #include <j3224_v2x_msgs/msg/measurement_time_offset.hpp>
 #include <j3224_v2x_msgs/msg/object_type.hpp>
+#include <j2735_v2x_msgs/msg/positional_accuracy.hpp>
+#include <j3224_v2x_msgs/msg/equipment_type.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -566,6 +568,13 @@ auto to_sdsm_msg(
 
     detected_object_list.detected_object_data.push_back(sdsm_detected_object);
   }
+
+  std::vector<uint8_t> id = {0x00, 0x00, 0x00, 0x01};
+  sdsm.source_id.id = id;
+  sdsm.equipment_type.equipment_type = j3224_v2x_msgs::msg::EquipmentType::OBU;
+  sdsm.ref_pos_xy_conf.semi_major = j2735_v2x_msgs::msg::PositionalAccuracy::ACCURACY_UNAVAILABLE;
+  sdsm.ref_pos_xy_conf.semi_minor = j2735_v2x_msgs::msg::PositionalAccuracy::ACCURACY_UNAVAILABLE;
+  sdsm.ref_pos_xy_conf.orientation = j2735_v2x_msgs::msg::PositionalAccuracy::ACCURACY_ORIENTATION_UNAVAILABLE;
   sdsm.objects = detected_object_list;
 
   return sdsm;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Encoder is not able to encode SDSM due to missing fields.
It publishes now.
## Related GitHub Issue
N/A
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-831
<!-- e.g. CAR-123 -->

## Motivation and Context
vru verification prep
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
sim pc 1 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
