### PR TITLE
Fix DDateTime to ROS message conversion for longer durations

### DIFF
--- a/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
+++ b/carma_cooperative_perception/include/carma_cooperative_perception/j2735_types.hpp
@@ -35,13 +35,13 @@ namespace carma_cooperative_perception
 {
 struct DDateTime
 {
-  std::optional<units::time::year_t> year;
-  std::optional<Month> month;
-  std::optional<units::time::day_t> day;
-  std::optional<units::time::hour_t> hour;
-  std::optional<units::time::minute_t> minute;
-  std::optional<units::time::second_t> second;
-  std::optional<units::time::minute_t> time_zone_offset;
+  std::optional<units::time::year_t> year{std::nullopt};
+  std::optional<Month> month{std::nullopt};
+  std::optional<units::time::day_t> day{std::nullopt};
+  std::optional<units::time::hour_t> hour{std::nullopt};
+  std::optional<units::time::minute_t> minute{std::nullopt};
+  std::optional<units::time::second_t> second{std::nullopt};
+  std::optional<units::time::minute_t> time_zone_offset{std::nullopt};
 
   [[nodiscard]] static auto from_msg(const j2735_v2x_msgs::msg::DDateTime & msg) -> DDateTime;
 };

--- a/carma_cooperative_perception/src/msg_conversion.cpp
+++ b/carma_cooperative_perception/src/msg_conversion.cpp
@@ -58,8 +58,11 @@ namespace carma_cooperative_perception
 auto to_time_msg(const DDateTime & d_date_time) -> builtin_interfaces::msg::Time
 {
   double seconds;
-  const auto fractional_secs{
-    std::modf(remove_units(d_date_time.second.value_or(units::time::second_t{0.0})), &seconds)};
+  const auto fractional_secs{std::modf(
+    remove_units(units::time::second_t{d_date_time.hour.value_or(units::time::second_t{0.0})}) +
+      remove_units(units::time::second_t{d_date_time.minute.value_or(units::time::second_t{0.0})}) +
+      remove_units(units::time::second_t{d_date_time.second.value_or(units::time::second_t{0.0})}),
+    &seconds)};
 
   builtin_interfaces::msg::Time msg;
   msg.sec = static_cast<std::int32_t>(seconds);

--- a/carma_cooperative_perception/test/test_msg_conversion.cpp
+++ b/carma_cooperative_perception/test/test_msg_conversion.cpp
@@ -55,6 +55,51 @@ TEST(ToTimeMsg, NulloptSeconds)
   EXPECT_DOUBLE_EQ(actual_msg.nanosec, expected_msg.nanosec);
 }
 
+TEST(ToTimeMsg, GeneralConversions)
+{
+  carma_cooperative_perception::DDateTime d_date_time;
+
+  d_date_time.hour = units::time::hour_t{0};
+  d_date_time.minute = units::time::minute_t{0};
+  d_date_time.second = units::time::second_t{1};
+  auto actual_msg{carma_cooperative_perception::to_time_msg(d_date_time)};
+
+  EXPECT_DOUBLE_EQ(actual_msg.sec, 1);
+  EXPECT_DOUBLE_EQ(actual_msg.nanosec, 0);
+
+  d_date_time.hour = units::time::hour_t{0};
+  d_date_time.minute = units::time::minute_t{3};
+  d_date_time.second = units::time::second_t{5};
+  actual_msg = carma_cooperative_perception::to_time_msg(d_date_time);
+
+  EXPECT_DOUBLE_EQ(actual_msg.sec, 185);
+  EXPECT_DOUBLE_EQ(actual_msg.nanosec, 0);
+
+  d_date_time.hour = units::time::hour_t{2};
+  d_date_time.minute = units::time::minute_t{0};
+  d_date_time.second = units::time::second_t{0};
+  actual_msg = carma_cooperative_perception::to_time_msg(d_date_time);
+
+  EXPECT_DOUBLE_EQ(actual_msg.sec, 7200);
+  EXPECT_DOUBLE_EQ(actual_msg.nanosec, 0);
+
+  d_date_time.hour = units::time::hour_t{2};
+  d_date_time.minute = units::time::minute_t{10};
+  d_date_time.second = units::time::second_t{30};
+  actual_msg = carma_cooperative_perception::to_time_msg(d_date_time);
+
+  EXPECT_DOUBLE_EQ(actual_msg.sec, 7830);
+  EXPECT_DOUBLE_EQ(actual_msg.nanosec, 0);
+
+  d_date_time.hour = units::time::hour_t{3};
+  d_date_time.minute = units::time::minute_t{0};
+  d_date_time.second = units::time::second_t{50.25};
+  actual_msg = carma_cooperative_perception::to_time_msg(d_date_time);
+
+  EXPECT_DOUBLE_EQ(actual_msg.sec, 10850);
+  EXPECT_DOUBLE_EQ(actual_msg.nanosec, 250000000);
+}
+
 TEST(ToDetectionMsg, Simple)
 {
   carma_v2x_msgs::msg::SensorDataSharingMessage sdsm_msg;


### PR DESCRIPTION
# PR Details
## Description

The `to_time_msg()` function in the `carma_cooperative_perception` package did not use the DDateTime minute and hour fields when converting `DDateTime` objects to their ROS message equivalents. This causes issues in the CP stack because the incoming detected objects will have their time stamps essentially roll back over to less than 1 minute.

It was not noticeable in previous tests because all of the simulations ran for less than a minute. Now, we are running simulations longer than a minute.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-863](https://usdot-carma.atlassian.net/browse/CDAR-863)

## Motivation and Context

Bug fix

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.


[CDAR-863]: https://usdot-carma.atlassian.net/browse/CDAR-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ