### PR TITLE
Cdar 882 Give enough duration for comfortable decel in yield_plugin

### DIFF
--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -930,31 +930,16 @@ namespace yield_plugin
     const double delta_v_max = fabs(goal_velocity - original_max_speed);
     RCLCPP_DEBUG_STREAM(nh_->get_logger(),"delta_v_max: " << delta_v_max << ", safety_gap: " << safety_gap);
 
-    // reference time, is the maximum time available to perform object avoidance (length of a trajectory)
-    const double max_allowed_trajectory_duration_in_s = get_trajectory_duration(original_tp);
-    // time required for comfortable deceleration
-    const double time_required_for_comfortable_decel_in_s = config_.acceleration_adjustment_factor * delta_v_max / config_.yield_max_deceleration_in_ms2;
+    const double time_required_for_comfortable_decel_in_s = config_.acceleration_adjustment_factor * 2 * goal_pos / delta_v_max;
+    const double min_time_required_for_comfortable_decel_in_s = delta_v_max / config_.yield_max_deceleration_in_ms2;
 
     // planning time for object avoidance
-    double planning_time_in_s = 0;
-
-    if (config_.min_obj_avoidance_plan_time_in_s < time_required_for_comfortable_decel_in_s
-      && time_required_for_comfortable_decel_in_s < max_allowed_trajectory_duration_in_s)
-    {
-      planning_time_in_s = time_required_for_comfortable_decel_in_s;
-    }
-    else if(time_required_for_comfortable_decel_in_s < config_.min_obj_avoidance_plan_time_in_s)
-    {
-      planning_time_in_s = config_.min_obj_avoidance_plan_time_in_s;
-    }
-    else
-    {
-      planning_time_in_s = max_allowed_trajectory_duration_in_s;
-    }
+    double planning_time_in_s = std::max({config_.min_obj_avoidance_plan_time_in_s, time_required_for_comfortable_decel_in_s, min_time_required_for_comfortable_decel_in_s});
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(),"time_required_for_comfortable_decel_in_s: " << time_required_for_comfortable_decel_in_s << ", min_time_required_for_comfortable_decel_in_s: " << min_time_required_for_comfortable_decel_in_s);
 
     RCLCPP_DEBUG_STREAM(nh_->get_logger(),"Object avoidance planning time: " << planning_time_in_s);
 
-    return generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, planning_time_in_s, original_max_speed);;
+    return generate_JMT_trajectory(original_tp, initial_pos, goal_pos, initial_velocity, goal_velocity, planning_time_in_s, original_max_speed);
   }
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR allows more time for comfortable deceleration. Previously it was capped by the original trajectory's planning duration, which is wrong because if an obstacle is detected, the vehicle might take longer time to come to a stop. 

<!--- Describe your changes in detail -->

## Related GitHub Issue
Partially fixes https://github.com/usdot-fhwa-stol/carma-platform/issues/2345
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-882
<!-- e.g. CAR-123 -->

## Motivation and Context
VRU verification test data analysis
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Sim PC1
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
