### PR TITLE
add permissive movement to allowed

### DIFF
--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
@@ -289,11 +289,11 @@ private:
   bool isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state);
 
   /**
-   * \brief Returns the clearance duration
+   * \brief Returns the duration for the allowed movements
    * \param traffic_light The traffic light object to get the green duration for
-   * \return int value of the signal duration
+   * \return int value of the duration for the allowed movement
    */
-  int getClearanceDuration(lanelet::CarmaTrafficSignalPtr traffic_light);
+  int getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light);
 
   /**
    * \brief Method for performing maneuver planning when the current plugin state is TransitState::UNAVAILABLE

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
@@ -286,14 +286,14 @@ private:
    * \param state The traffic signal state to check for
    * \return bool value - True if state is PERMISSIVE_MOVEMENT_ALLOWED or PROTECTED_MOVEMENT_ALLOWED
    */
-  bool isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state);
+  bool isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state) const;
 
   /**
    * \brief Returns the duration for the allowed movements
    * \param traffic_light The traffic light object to get the green duration for
    * \return int value of the duration for the allowed movement
    */
-  int getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light);
+  boost::posix_time::time_duration getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light);
 
   /**
    * \brief Method for performing maneuver planning when the current plugin state is TransitState::UNAVAILABLE

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
@@ -281,6 +281,8 @@ private:
     lanelet::Id lane_id;  // The current lane id of the vehicle at time stamp
   };
 
+  bool isAllowedMovement(const lanelet::CarmaTrafficSignalState& state);
+
   /**
    * \brief Method for performing maneuver planning when the current plugin state is TransitState::UNAVAILABLE
    *        Therefor no maneuvers are planned but the system checks for the precense of traffic lights ahead of it

--- a/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
+++ b/lci_strategic_plugin/include/lci_strategic_plugin/lci_strategic_plugin.hpp
@@ -281,7 +281,19 @@ private:
     lanelet::Id lane_id;  // The current lane id of the vehicle at time stamp
   };
 
-  bool isAllowedMovement(const lanelet::CarmaTrafficSignalState& state);
+  /**
+   * \brief Method to check if the state is an allowed green movement state. Currently Permissive and Protected green are supported
+   * \param state The traffic signal state to check for
+   * \return bool value - True if state is PERMISSIVE_MOVEMENT_ALLOWED or PROTECTED_MOVEMENT_ALLOWED
+   */
+  bool isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state);
+
+  /**
+   * \brief Returns the clearance duration
+   * \param traffic_light The traffic light object to get the green duration for
+   * \return int value of the signal duration
+   */
+  int getClearanceDuration(lanelet::CarmaTrafficSignalPtr traffic_light);
 
   /**
    * \brief Method for performing maneuver planning when the current plugin state is TransitState::UNAVAILABLE

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -325,12 +325,10 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
     bool can_make_late_arrival = true;
 
     if (check_early)
-      can_make_early_arrival = ((early_arrival_state_by_algo_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED)
-      || (early_arrival_state_by_algo_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED));
+      can_make_early_arrival = isAllowedMovement(early_arrival_state_by_algo_optional.get().second);
 
     if (check_late)
-      can_make_late_arrival = (late_arrival_state_by_algo_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED)
-      || (late_arrival_state_by_algo_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED);
+      can_make_late_arrival = isAllowedMovement(late_arrival_state_by_algo_optional.get().second);
 
     // We will cross the light on the green phase even if we arrive early or late
     if (can_make_early_arrival && can_make_late_arrival)  // Green light
@@ -338,6 +336,11 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
     else
       return false;
 
+}
+
+bool LCIStrategicPlugin::isAllowedMovement(const lanelet::CarmaTrafficSignalState& state) {
+    return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED ||
+           state == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED;
 }
 
 std::vector<lanelet::ConstLanelet> LCIStrategicPlugin::getLaneletsBetweenWithException(double start_downtrack,
@@ -695,7 +698,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
     else
     {
-      if ((upper_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || (upper_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
+      if (isAllowedMovement(upper_optional.get().second))
       {
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected Upper GREEN case");
         return_params = traj_upper;
@@ -714,7 +717,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
     else
     {
-      if ((lower_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || (lower_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
+      if (isAllowedMovement(lower_optional.get().second))
       {
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected Lower GREEN case");
         return_params = traj_lower;
@@ -1100,8 +1103,7 @@ void LCIStrategicPlugin::planWhenWAITING(carma_planning_msgs::srv::PlanManeuvers
   if (config_.enable_carma_streets_connection && entering_time > current_state.stamp.seconds()) //uc3
     should_enter = false;
 
-  if ((current_light_state_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED || current_light_state_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED) &&
-        bool_optional_late_certainty.get() && should_enter) // if can make with certainty
+  if (isAllowedMovement(current_light_state_optional.get().second) && bool_optional_late_certainty.get() && should_enter) // if can make with certainty
   {
     transition_table_.signal(TransitEvent::RED_TO_GREEN_LIGHT);  // If the light is green send the light transition
                                                                  // signal

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -325,10 +325,10 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
     bool can_make_late_arrival = true;
 
     if (check_early)
-      can_make_early_arrival = isAllowedMovement(early_arrival_state_by_algo_optional.get().second);
+      can_make_early_arrival = isStateAllowedGreen(early_arrival_state_by_algo_optional.get().second);
 
     if (check_late)
-      can_make_late_arrival = isAllowedMovement(late_arrival_state_by_algo_optional.get().second);
+      can_make_late_arrival = isStateAllowedGreen(late_arrival_state_by_algo_optional.get().second);
 
     // We will cross the light on the green phase even if we arrive early or late
     if (can_make_early_arrival && can_make_late_arrival)  // Green light
@@ -338,7 +338,7 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
 
 }
 
-bool LCIStrategicPlugin::isAllowedMovement(const lanelet::CarmaTrafficSignalState& state) {
+bool LCIStrategicPlugin::isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state) {
     return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED ||
            state == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED;
 }
@@ -698,7 +698,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
     else
     {
-      if (isAllowedMovement(upper_optional.get().second))
+      if (isStateAllowedGreen(upper_optional.get().second))
       {
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected Upper GREEN case");
         return_params = traj_upper;
@@ -717,7 +717,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
     else
     {
-      if (isAllowedMovement(lower_optional.get().second))
+      if (isStateAllowedGreen(lower_optional.get().second))
       {
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected Lower GREEN case");
         return_params = traj_lower;
@@ -1103,7 +1103,7 @@ void LCIStrategicPlugin::planWhenWAITING(carma_planning_msgs::srv::PlanManeuvers
   if (config_.enable_carma_streets_connection && entering_time > current_state.stamp.seconds()) //uc3
     should_enter = false;
 
-  if (isAllowedMovement(current_light_state_optional.get().second) && bool_optional_late_certainty.get() && should_enter) // if can make with certainty
+  if (isStateAllowedGreen(current_light_state_optional.get().second) && bool_optional_late_certainty.get() && should_enter) // if can make with certainty
   {
     transition_table_.signal(TransitEvent::RED_TO_GREEN_LIGHT);  // If the light is green send the light transition
                                                                  // signal

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -338,8 +338,8 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
 
 }
 
-bool LCIStrategicPlugin::isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state) {
-    return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED ||
+bool LCIStrategicPlugin::isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state) const{
+    return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED |
            state == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED;
 }
 

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -339,7 +339,7 @@ boost::optional<bool> LCIStrategicPlugin::canArriveAtGreenWithCertainty(const rc
 }
 
 bool LCIStrategicPlugin::isStateAllowedGreen(const lanelet::CarmaTrafficSignalState& state) const{
-    return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED |
+    return state == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED ||
            state == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED;
 }
 

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -250,9 +250,10 @@ rclcpp::Duration LCIStrategicPlugin::get_earliest_entry_time(double remaining_di
 
 }
 
-int LCIStrategicPlugin::getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light)
+boost::posix_time::time_duration LCIStrategicPlugin::getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light)
 {
-  if(traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED])
+  // if(traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED])
+  if(traffic_light->signal_durations.find(lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) != traffic_light->signal_durations.end())
   {
     return traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED];
   }
@@ -379,7 +380,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "normal_arrival_signal_end_time: " << std::to_string(lanelet::time::toSec(normal_arrival_state_green_et_optional.get().first)));
 
         // nearest_green_signal_start_time = normal_arrival_signal_end_time (green guaranteed) - green_signal_duration
-        nearest_green_signal_start_time = rclcpp::Time(lanelet::time::toSec(getClearanceDuration(traffic_light)) * 1e9);
+        nearest_green_signal_start_time = rclcpp::Time(lanelet::time::toSec(getMovementAllowedDuration(traffic_light)));
       }
       else  // UC3
       {

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -130,7 +130,7 @@ std::optional<rclcpp::Time> LCIStrategicPlugin::get_nearest_green_entry_time(con
     curr_pair = signal->predictState(t + boost::posix_time::milliseconds(20)); // select next phase
     p = curr_pair.get().second;
     theta = curr_pair.get().first - t;
-    while ( t < eet || (p != lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) && (p != lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
+    while ( t < eet || ((p != lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) && (p != lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)))
     {
       if ( (p == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED || p == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED) && eet - t < theta)
       {
@@ -284,7 +284,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
     {
       if (lanelet::time::timeFromSec(nearest_green_entry_time.seconds()) < pair.first)
       {
-        if ((pair.second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED || pair.second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
+        if ((pair.second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || (pair.second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
         {
           RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "ET is inside the GREEN phase! where starting time: " << std::to_string(lanelet::time::toSec(traffic_light->recorded_start_time_stamps[i]))
             << ", ending time of that green signal is: " << std::to_string(lanelet::time::toSec(pair.first)));
@@ -382,7 +382,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
 
         for (size_t i = 0; i < traffic_light->recorded_start_time_stamps.size(); i++)
         {
-          if ((traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED  || traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED) &&
+          if (((traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED)  || (traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)) &&
             lanelet::time::timeFromSec(nearest_green_entry_time.seconds()) < traffic_light->recorded_time_stamps[i].first ) // Make sure it is in correct GREEN phase there are multiple
           {
             nearest_green_signal_start_time = rclcpp::Time(lanelet::time::toSec(traffic_light->recorded_start_time_stamps[i]) * 1e9);

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -73,8 +73,7 @@ std::optional<rclcpp::Time> LCIStrategicPlugin::get_nearest_green_entry_time(con
   bool has_green_signal = false;
   for (auto pair : signal->recorded_time_stamps)
   {
-    if ((pair.second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED || pair.second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED) &&
-      t <= pair.first )
+    if (isAllowedMovement(pair.second) && t <= pair.first )
     {
       has_green_signal = true;
       break;
@@ -92,9 +91,9 @@ std::optional<rclcpp::Time> LCIStrategicPlugin::get_nearest_green_entry_time(con
 
   boost::posix_time::time_duration theta =  curr_pair.get().first - t;   // remaining time left in this state
   auto p = curr_pair.get().second;
-  while ( 0.0 < g.total_milliseconds() || (p != lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED && p != lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)) //green
+  while ( 0.0 < g.total_milliseconds() || (!isAllowedMovement(p))) //green
   {
-    if (( p == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || p == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)
+    if (isAllowedMovement(p))
     {
       if (g < theta)
       {
@@ -130,9 +129,9 @@ std::optional<rclcpp::Time> LCIStrategicPlugin::get_nearest_green_entry_time(con
     curr_pair = signal->predictState(t + boost::posix_time::milliseconds(20)); // select next phase
     p = curr_pair.get().second;
     theta = curr_pair.get().first - t;
-    while ( t < eet || ((p != lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) && (p != lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)))
+    while ( t < eet || !isAllowedMovement(p))
     {
-      if ( (p == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED || p == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED) && eet - t < theta)
+      if ( (isAllowedMovement(p)) && eet - t < theta)
       {
         t = eet;
         theta = theta - (eet - t);
@@ -284,7 +283,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
     {
       if (lanelet::time::timeFromSec(nearest_green_entry_time.seconds()) < pair.first)
       {
-        if ((pair.second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || (pair.second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED))
+        if (isAllowedMovement(pair.second))
         {
           RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "ET is inside the GREEN phase! where starting time: " << std::to_string(lanelet::time::toSec(traffic_light->recorded_start_time_stamps[i]))
             << ", ending time of that green signal is: " << std::to_string(lanelet::time::toSec(pair.first)));
@@ -343,7 +342,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
 
     RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "early_arrival_state_green_et: " << early_arrival_state_green_et_optional.get().second);
 
-    bool can_make_early_arrival  = ((early_arrival_state_green_et_optional.get().second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) || (early_arrival_state_green_et_optional.get().second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED));
+    bool can_make_early_arrival  = isAllowedMovement(early_arrival_state_green_et_optional.get().second);
 
     // nearest_green_entry_time is by definition on green, so only check early_arrival
     if (can_make_early_arrival)  // Green light with Certainty
@@ -382,7 +381,7 @@ std::tuple<rclcpp::Time, bool, bool> LCIStrategicPlugin::get_final_entry_time_an
 
         for (size_t i = 0; i < traffic_light->recorded_start_time_stamps.size(); i++)
         {
-          if (((traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED)  || (traffic_light->recorded_time_stamps[i].second == lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED)) &&
+          if (isAllowedMovement(traffic_light->recorded_time_stamps[i].second) &&
             lanelet::time::timeFromSec(nearest_green_entry_time.seconds()) < traffic_light->recorded_time_stamps[i].first ) // Make sure it is in correct GREEN phase there are multiple
           {
             nearest_green_signal_start_time = rclcpp::Time(lanelet::time::toSec(traffic_light->recorded_start_time_stamps[i]) * 1e9);

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -250,7 +250,7 @@ rclcpp::Duration LCIStrategicPlugin::get_earliest_entry_time(double remaining_di
 
 }
 
-int LCIStrategicPlugin::getClearanceDuration(lanelet::CarmaTrafficSignalPtr traffic_light)
+int LCIStrategicPlugin::getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light)
 {
   if(traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED])
   {

--- a/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin_algo.cpp
@@ -252,7 +252,6 @@ rclcpp::Duration LCIStrategicPlugin::get_earliest_entry_time(double remaining_di
 
 boost::posix_time::time_duration LCIStrategicPlugin::getMovementAllowedDuration(lanelet::CarmaTrafficSignalPtr traffic_light)
 {
-  // if(traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED])
   if(traffic_light->signal_durations.find(lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED) != traffic_light->signal_durations.end())
   {
     return traffic_light->signal_durations[lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED];


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds Permissive movements to the lci strategic plugin planning logic. It extends the functionality for protected movements to permissive movements as well.
## Description
During voices integration testing it was found that SPAT messages published by the virtual econolite controller were being published with the permissive movement type.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
