### PR TITLE
fix lanechange start_llt_id picking logic

### DIFF
--- a/carma_wm/include/carma_wm/CARMAWorldModel.hpp
+++ b/carma_wm/include/carma_wm/CARMAWorldModel.hpp
@@ -265,6 +265,8 @@ public:
 
   std::vector<lanelet::SignalizedIntersectionPtr> getSignalizedIntersectionsAlongRoute(const lanelet::BasicPoint2d &loc) const;
 
+  std::optional<lanelet::ConstLanelet> getLaneletOnShortestPath(const std::vector<lanelet::ConstLanelet>& lanelets_to_filter) const;
+
   std::unordered_map<uint32_t, lanelet::Id> traffic_light_ids_;
 
   carma_wm::SignalizedIntersectionManager sim_; // records SPAT/MAP lane ids to lanelet ids

--- a/carma_wm/include/carma_wm/WorldModel.hpp
+++ b/carma_wm/include/carma_wm/WorldModel.hpp
@@ -436,7 +436,16 @@ class WorldModel
      * \return vector of underlying lanelet, empty vector if it is not part of any lanelet
      */
     virtual std::vector<lanelet::ConstLanelet> nonConnectedAdjacentLeft(const lanelet::BasicPoint2d& input_point, const unsigned int n = 10) const = 0;
-                                                                                             
+
+    /**
+     * \brief Given the vector of lanelets, returns the lanelet that's on the shortest path
+     *
+     * \param lanelets_to_filter  lanelets to pick from
+     * 
+     * \return lanelet on the shortest path from the input list. std::nullopt if no route is available or no lanelet is on the route
+     */
+    virtual std::optional<lanelet::ConstLanelet> getLaneletOnShortestPath(const std::vector<lanelet::ConstLanelet>& lanelets_to_filter) const = 0;
+                                                    
 };
 // Helpful using declarations for carma_wm classes
 using WorldModelConstPtr = std::shared_ptr<const WorldModel>;

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -1556,4 +1556,26 @@ namespace carma_wm
     }
   }
 
+  std::optional<lanelet::ConstLanelet> getLaneletOnShortestPath(const std::vector<lanelet::ConstLanelet>& lanelets_to_filter) const
+  {
+    if (!route_ || lanelets_to_filter.empty())
+    {
+      return std::nullopt;
+    }
+
+    std::optional<lanelet::ConstLanelet> lanelet_on_the_route = std::nullopt;
+    // pick a lanelet on the shortest path
+    for (const auto& llt : lanelets_to_filter)
+    {
+      auto shortest_path = route_->shortestPath();
+      if (std::find(shortest_path.begin(), shortest_path.end(), llt) != shortest_path.end())
+      {
+        lanelet_on_the_route = llt;
+        break;
+      }
+    }
+    
+    return lanelet_on_the_route;
+  }
+  
 } // namespace carma_wm

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -1556,7 +1556,7 @@ namespace carma_wm
     }
   }
 
-  std::optional<lanelet::ConstLanelet> getLaneletOnShortestPath(const std::vector<lanelet::ConstLanelet>& lanelets_to_filter) const
+  std::optional<lanelet::ConstLanelet> CARMAWorldModel::getLaneletOnShortestPath(const std::vector<lanelet::ConstLanelet>& lanelets_to_filter) const
   {
     if (!route_ || lanelets_to_filter.empty())
     {

--- a/carma_wm/test/CARMAWorldModelTest.cpp
+++ b/carma_wm/test/CARMAWorldModelTest.cpp
@@ -1423,6 +1423,58 @@ TEST(CARMAWorldModelTest, getSignalsAlongRoute)
 
 }
 
+TEST(CARMAWorldModelTest, getLaneletOnShortestPath)
+{
+  // Create a complete map
+  test::MapOptions mp(1,1);
+  auto cmw_ptr = test::getGuidanceTestMap(mp);
+
+  std::vector<ConstLanelet> random_lanelets;
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1200));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1222));
+
+  // No route
+  auto lanelet_on_the_route = cmw_ptr->getLaneletOnShortestPath(random_lanelets);
+  EXPECT_EQ(lanelet_on_the_route, std::nullopt);
+
+  // No lanelet on route
+  random_lanelets = {};
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1220));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1222));
+  carma_wm::test::setRouteByIds({ 1200, 1201, 1202}, cmw_ptr);
+  lanelet_on_the_route = cmw_ptr->getLaneletOnShortestPath(random_lanelets);
+  EXPECT_EQ(lanelet_on_the_route, std::nullopt);
+
+  // 1 lanelet on the route
+  random_lanelets = {};
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1200));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1222));
+
+  lanelet_on_the_route = cmw_ptr->getLaneletOnShortestPath(random_lanelets);
+  EXPECT_EQ(lanelet_on_the_route, cmw_ptr->getMap()->laneletLayer.get(1200));
+
+  // 1 lanelet on the route
+  random_lanelets = {};
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1220));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1202));
+
+  lanelet_on_the_route = cmw_ptr->getLaneletOnShortestPath(random_lanelets);
+  EXPECT_EQ(lanelet_on_the_route, cmw_ptr->getMap()->laneletLayer.get(1202));
+
+  // 2 lanelets on the route, return earliest
+  random_lanelets = {};
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1200));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
+  random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1202));
+
+  lanelet_on_the_route = cmw_ptr->getLaneletOnShortestPath(random_lanelets);
+  EXPECT_EQ(lanelet_on_the_route, cmw_ptr->getMap()->laneletLayer.get(1200));
+}
+
 TEST(CARMAWorldModelTest, getIntersectionAlongRoute)
 {
   lanelet::Id id{1200};

--- a/carma_wm/test/CARMAWorldModelTest.cpp
+++ b/carma_wm/test/CARMAWorldModelTest.cpp
@@ -1429,7 +1429,7 @@ TEST(CARMAWorldModelTest, getLaneletOnShortestPath)
   test::MapOptions mp(1,1);
   auto cmw_ptr = test::getGuidanceTestMap(mp);
 
-  std::vector<ConstLanelet> random_lanelets;
+  std::vector<lanelet::ConstLanelet> random_lanelets;
   random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1200));
   random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1221));
   random_lanelets.push_back(cmw_ptr->getMap()->laneletLayer.get(1222));

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -1322,7 +1322,7 @@ void LCIStrategicPlugin::plan_maneuvers_callback(
 
   // get the lanelet that is on the route in case overlapping ones found
   auto llt_on_route_optional = wm_->getLaneletOnShortestPath(current_lanelets);
-  current_lanelet = llt_on_route_optional ? llt_on_route_optional.get() : current_lanelets[0];
+  current_lanelet = llt_on_route_optional ? llt_on_route_optional.value() : current_lanelets[0];
 
   lanelet::CarmaTrafficSignalPtr nearest_traffic_signal = nullptr;
 

--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -1321,15 +1321,8 @@ void LCIStrategicPlugin::plan_maneuvers_callback(
   }
 
   // get the lanelet that is on the route in case overlapping ones found
-  for (auto llt : current_lanelets)
-  {
-    auto route = wm_->getRoute()->shortestPath();
-    if (std::find(route.begin(), route.end(), llt) != route.end())
-    {
-      current_lanelet = llt;
-      break;
-    }
-  }
+  auto llt_on_route_optional = wm_->getLaneletOnShortestPath(current_lanelets);
+  current_lanelet = llt_on_route_optional ? llt_on_route_optional.get() : current_lanelets[0];
 
   lanelet::CarmaTrafficSignalPtr nearest_traffic_signal = nullptr;
 

--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -71,15 +71,8 @@ namespace light_controlled_intersection_tactical_plugin
         }
 
         // get the lanelet that is on the route in case overlapping ones found
-        for (auto llt : current_lanelets)
-        {
-            auto route = wm_->getRoute()->shortestPath();
-            if (std::find(route.begin(), route.end(), llt) != route.end())
-            {
-                current_lanelet = llt;
-                break;
-            }
-        }
+        auto llt_on_route_optional = wm_->getLaneletOnShortestPath(current_lanelets);
+        current_lanelet = llt_on_route_optional ? llt_on_route_optional.get() : current_lanelets[0];
 
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Current_lanelet: " << current_lanelet.id());
 

--- a/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
+++ b/light_controlled_intersection_tactical_plugin/src/light_controlled_intersection_tactical_plugin.cpp
@@ -72,7 +72,7 @@ namespace light_controlled_intersection_tactical_plugin
 
         // get the lanelet that is on the route in case overlapping ones found
         auto llt_on_route_optional = wm_->getLaneletOnShortestPath(current_lanelets);
-        current_lanelet = llt_on_route_optional ? llt_on_route_optional.get() : current_lanelets[0];
+        current_lanelet = llt_on_route_optional ? llt_on_route_optional.value() : current_lanelets[0];
 
         RCLCPP_DEBUG_STREAM(rclcpp::get_logger("light_controlled_intersection_tactical_plugin"), "Current_lanelet: " << current_lanelet.id());
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -498,7 +498,7 @@ namespace plan_delegator
 
                 if(!previous_lanelets.empty()){
                     auto llt_on_route_optional = wm_->getLaneletOnShortestPath(previous_lanelets);
-                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.get() : previous_lanelets[0];
+                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.value() : previous_lanelets[0];
 
                     // lane_ids array is ordered by increasing downtrack, so this new starting lanelet is inserted at the front
                     maneuver.lane_following_maneuver.lane_ids.insert(maneuver.lane_following_maneuver.lane_ids.begin(), std::to_string(previous_lanelet_to_add.id()));
@@ -540,7 +540,7 @@ namespace plan_delegator
                 auto previous_lanelets = wm_->getMapRoutingGraph()->previous(original_starting_lanelet, false);
                 if(!previous_lanelets.empty()){
                     auto llt_on_route_optional = wm_->getLaneletOnShortestPath(previous_lanelets);
-                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.get() : previous_lanelets[0];
+                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.value() : previous_lanelets[0];
                     setManeuverStartingLaneletId(maneuver, previous_lanelet_to_add.id());
                 }
                 else{

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -495,20 +495,11 @@ namespace plan_delegator
             if(adjusted_start_dist < original_starting_lanelet_centerline_start_point_dt){
 
                 auto previous_lanelets = wm_->getMapRoutingGraph()->previous(original_starting_lanelet, false);
-                auto previous_lanelet_to_add = previous_lanelets[0];
-
-                // pick a lanelet on the shortest path
-                for (const auto& llt : previous_lanelets)
-                {
-                    auto route = wm_->getRoute()->shortestPath();
-                    if (std::find(route.begin(), route.end(), llt) != route.end())
-                    {
-                        previous_lanelet_to_add = llt;
-                        break;
-                    }
-                }
 
                 if(!previous_lanelets.empty()){
+                    auto llt_on_route_optional = wm_->getLaneletOnShortestPath(previous_lanelets);
+                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.get() : previous_lanelets[0];
+
                     // lane_ids array is ordered by increasing downtrack, so this new starting lanelet is inserted at the front
                     maneuver.lane_following_maneuver.lane_ids.insert(maneuver.lane_following_maneuver.lane_ids.begin(), std::to_string(previous_lanelet_to_add.id()));
 
@@ -547,20 +538,10 @@ namespace plan_delegator
 
             if(adjusted_start_dist < original_starting_lanelet_centerline_start_point_dt){
                 auto previous_lanelets = wm_->getMapRoutingGraph()->previous(original_starting_lanelet, false);
-                auto previous_lanelet_to_add = previous_lanelets[0];
                 if(!previous_lanelets.empty()){
-                    // pick a lanelet on the shortest path
-                    for (const auto& llt : previous_lanelets)
-                    {
-                        auto route = wm_->getRoute()->shortestPath();
-                        if (std::find(route.begin(), route.end(), llt) != route.end())
-                        {
-                            previous_lanelet_to_add = llt;
-                            break;
-                        }
-                    }
+                    auto llt_on_route_optional = wm_->getLaneletOnShortestPath(previous_lanelets);
+                    lanelet::ConstLanelet previous_lanelet_to_add = llt_on_route_optional ? llt_on_route_optional.get() : previous_lanelets[0];
                     setManeuverStartingLaneletId(maneuver, previous_lanelet_to_add.id());
-                    
                 }
                 else{
                     RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"), "No previous lanelet was found for lanelet " << original_starting_lanelet.id());

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -547,9 +547,20 @@ namespace plan_delegator
 
             if(adjusted_start_dist < original_starting_lanelet_centerline_start_point_dt){
                 auto previous_lanelets = wm_->getMapRoutingGraph()->previous(original_starting_lanelet, false);
-
+                auto previous_lanelet_to_add = previous_lanelets[0];
                 if(!previous_lanelets.empty()){
-                    setManeuverStartingLaneletId(maneuver, previous_lanelets[0].id());
+                    // pick a lanelet on the shortest path
+                    for (const auto& llt : previous_lanelets)
+                    {
+                        auto route = wm_->getRoute()->shortestPath();
+                        if (std::find(route.begin(), route.end(), llt) != route.end())
+                        {
+                            previous_lanelet_to_add = llt;
+                            break;
+                        }
+                    }
+                    setManeuverStartingLaneletId(maneuver, previous_lanelet_to_add.id());
+                    
                 }
                 else{
                     RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"), "No previous lanelet was found for lanelet " << original_starting_lanelet.id());


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Main change is the plan_delegator is not filtering lanelet on shortest path when determining previous lanelet for cooperative lanechange maneuver. This makes the tactical plugin not able to generate trajectory because it may pick a lanelet that doesn't have adjacent lanelet for example in an intersection. Therefore, it needs to pick a lanelet on the actual shortest path.

Also since filtering a lanelet that's on the shortest path functionality is often repeated and needed, I refactored it out to carma_wm.


<!--- Describe your changes in detail -->

## Related GitHub Issue
resolves: https://github.com/usdot-fhwa-stol/carma-platform/issues/2391
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CAR-6050
<!-- e.g. CAR-123 -->

## Motivation and Context
Discovered during unsignalized workzone demo for 06/11/2024. Please see the issue.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on passenger vehicles on TFHRC with testing environment enabled for unsignalized workzone. checked out from carma-system-4.5.0
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
