### PR TITLE
Add logic to carma script to account for env var in carma-config

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -360,7 +360,7 @@ carma__start() {
     fi
 
     # Extract environment variables from the carma-config container
-    echo "Extracting environment variables from carma-config..." > /dev/tty  # Make sure to print to terminal instead of returning
+    echo "Extracting environment variables from carma-config..."
     local env_vars=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/.env' | xargs)
 
@@ -393,7 +393,7 @@ carma__stop() {
     fi
 
     # Extract environment variables from the carma-config container
-    echo "Extracting environment variables from carma-config..." > /dev/tty  # Make sure to print to terminal instead of returning
+    echo "Extracting environment variables from carma-config..."
     local env_vars=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/.env' | xargs)
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -94,6 +94,8 @@ __get_image_from_config() {
             local TARGET_IMAGE=$IMAGE_BACKUP
             echoerr "Could not identify usable image from config so defaulting to image: $TARGET_IMAGE"
         fi
+
+        rm /tmp/.env
     else
         echoerr "No config detected or target image specified so using default: $TARGET_IMAGE"
     fi

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 #  Copyright (C) 2018-2022 LEIDOS.
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -16,13 +16,12 @@
 
 # Code below largely based on template from Stack Overflow:
 # https://stackoverflow.com/questions/37257551/defining-subcommands-that-take-arguments-in-bash
-# Question asked by user 
+# Question asked by user
 # DiogoSaraiva (https://stackoverflow.com/users/4465820/diogosaraiva)
-# and answered by user 
+# and answered by user
 # Charles Duffy (https://stackoverflow.com/users/14122/charles-duffy)
 # Attribution here is in line with Stack Overflow's Attribution policy cc-by-sa found here:
 # https://stackoverflow.blog/2009/06/25/attribution-required/
-
 
 __pull_newest_carma_base() {
     if [ "$1" = "-d" ]; then
@@ -38,7 +37,7 @@ __pull_newest_carma_base() {
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
         awk -F: '{print "usdotfhwastol/carma-base:"$3}' | tail -n 1)
     fi
-    
+
     echo "No local carma-base image found, pulling down the most recent from Dockerhub..."
     docker pull $remote_image
 }
@@ -54,11 +53,12 @@ echoerr() { echo "$@" 1>&2; }
 # The method will return the first tag that appears in the config for the possible organizations and images.
 # If the config is not set or an image cannot be found the method will return a carma-base image as the default.
 # The user can specify optional organizations or images as sed compatable regex lists.
-# For example calling 
+# For example calling
 #  $(__get_image_from_config 'carma-platform:\|carma-messenger:' 'usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate')
-# 
+#
 #  If no parameters are provided the defaults will be used
 ##
+
 __get_image_from_config() {
     local TARGET_IMAGE="usdotfhwastol/carma-base:latest"
     local SUPPORTED_ORANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
@@ -71,7 +71,7 @@ __get_image_from_config() {
 
     if [ -n "$2" ]
     then
-        
+
         local SUPPORTED_ORANIZATIONS="$2"
     fi
 
@@ -80,11 +80,14 @@ __get_image_from_config() {
 
         local IMAGE_BACKUP=$TARGET_IMAGE
 
-        # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
-        # then returns the name of the image.  
-        local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-            "sed -n -e '/image:\s*\($SUPPORTED_ORANIZATIONS\)\/\($SUPPORTED_IMAGES\)/ s/.*\image: *//p' /opt/carma/vehicle/config/docker-compose.yml | grep -m 1 '.*'")
-            
+        # Extract the .env file content from the carma-config volume
+        docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+
+        # Extract DOCKER_ORG and DOCKER_TAG from the .env file
+        source /tmp/.env
+
+        # Construct the image name using the values from the .env file
+        TARGET_IMAGE="${DOCKER_ORG}/carma-base:${DOCKER_TAG}"
 
         # If the sed resulted in an empty string then reset the tag
         if [ -z "$TARGET_IMAGE" ]; then
@@ -215,11 +218,11 @@ carma-config__list_remote() {
     elif [ "$1" = "-c" ]; then
         wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastolcandidate/carma-config/tags -O -  | \
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
-        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastolcandidate Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastolcandidate/carma-config\t"$3}' 
+        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastolcandidate Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastolcandidate/carma-config\t"$3}'
     else
         wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastol/carma-config/tags -O -  | \
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
-        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastol Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastol/carma-config\t"$3}'    
+        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastol Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastol/carma-config\t"$3}'
     fi
 }
 
@@ -247,14 +250,19 @@ carma-config__install() {
         echo "Cleaning up temporary containers from previous install..."
         docker rm carma-config-tmp
     fi
-    docker run --name carma-config-tmp $IMAGE_NAME
 
-    local CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose.yml' | sed s/carma-config/carma-config-tmp/g`"
-    local CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose-background.yml' | sed s/carma-config/carma-config-tmp/g`"
+    # Extract environment variables from the carma-config container
+    echo "Extracting environment variables from specified carma-config..."
+    docker run --name carma-config-tmp $IMAGE_NAME
+    local env_vars=$(docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c \
+        'cat /opt/carma/vehicle/config/.env' | xargs)
+
+    local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
 
     echo "Downloading $IMAGE_NAME dependencies..."
-    echo "$CARMA_DOCKER_FILE" | docker-compose -f - pull
-    echo "$CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -f - pull
+    echo "$processed_foreground_compose" | docker-compose -f - pull
+    echo "$processed_background_compose" | docker-compose -f - pull
 
     echo "Cleaning up temporary container..."
     docker rm carma-config-tmp
@@ -285,46 +293,92 @@ carma__fix_bag() {
 
     fi
 }
+
+__replace_env_vars_in_docker_compose_from_carma_config() {
+    local compose_file_content=$1
+    local env_vars=$2
+
+    # Convert env_vars to sed replacement commands
+    local sed_commands=$(echo "$env_vars" | tr ' ' '\n' | sed 's/\(.*\)=\(.*\)/s|${\1}|\2|g/')
+
+    # Apply the sed commands to the compose file content
+    local output=$(echo "$compose_file_content" | sed "$sed_commands")
+
+    # Output the modified docker-compose content
+    echo "$output"
+}
+
+__parse_docker_compose_using_env_vars(){
+    local compose_file_full_path=$1
+    local env_vars=$2
+
+    local original_compose_file=$(docker run --rm --volumes-from carma-config --entrypoint sh busybox:latest -c \
+        "cat ${compose_file_full_path}")
+
+    local processed_compose_file=$(__replace_env_vars_in_docker_compose_from_carma_config "$original_compose_file" "$env_vars")
+    echo "$processed_compose_file"
+}
+
 carma__start() {
+    # Check if the carma-config container exists
     if ! docker container inspect carma-config > /dev/null 2>&1; then
         echo "No existing CARMA configuration found, nothing to start. Please set a config."
         echo "Done."
         exit 1
     fi
 
-    echo "Starting CARMA background processes..."
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-    'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
-    docker-compose -f - -p carma-background up -d
+    # Extract environment variables from the carma-config container
+    echo "Extracting environment variables from carma-config..." > /dev/tty  # Make sure to print to terminal instead of returning
+    local env_vars=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+        'cat /opt/carma/vehicle/config/.env' | xargs)
 
-    if [ "$1" = "all" ]; then 
+    # Start CARMA background processes
+    echo "Starting CARMA background processes..."
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+    # Use the processed docker-compose content to start the background processes
+    echo "$processed_background_compose" | docker-compose -f - -p carma-background up -d
+
+    # Check if the argument "all" is passed to start the foreground processes
+    if [ "$1" = "all" ]; then
         shift
+        # Start CARMA Platform foreground processes
         echo "Starting CARMA Platform foreground processes..."
-        docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-        'cat /opt/carma/vehicle/config/docker-compose.yml' | \
-        docker-compose -f - -p carma up $@
+        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+        # Use the processed docker-compose content to start the foreground processes
+        echo "$processed_foreground_compose" | docker-compose -f - -p carma up $@
     elif [ ! -z "$1" ]; then
+        # Handle unrecognized arguments
         echo "Unrecognized argument \"start $1\""
     fi
 }
 
 carma__stop() {
+    # Check if the carma-config container exists
     if ! docker container inspect carma-config > /dev/null 2>&1; then
         echo "No existing CARMA configuration found, nothing to stop. Please set a config."
         echo "Done."
         exit 1
     fi
 
-    echo "Shutting down CARMA processes..."
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-    'cat /opt/carma/vehicle/config/docker-compose.yml' | \
-    docker-compose -f - -p carma down
+    # Extract environment variables from the carma-config container
+    echo "Extracting environment variables from carma-config..." > /dev/tty  # Make sure to print to terminal instead of returning
+    local env_vars=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+        'cat /opt/carma/vehicle/config/.env' | xargs)
 
-    if [ "$1" = "all" ]; then 
-        echo "Shutting down CARMA background processes..."
-        docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-        'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
-        docker-compose -f - -p carma-background down
+    # Shutdown CARMA background processes
+    echo "Shutting down CARMA background processes..."
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+    # Use the processed docker-compose content to start the background processes
+    echo "$processed_background_compose" | docker-compose -f - -p carma-background down
+
+    # Check if the argument "all" is passed to also shut down the background processes
+    if [ "$1" = "all" ]; then
+        # Start CARMA Platform foreground processes
+        echo "Shutting down CARMA processes..."
+        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+        # Use the processed docker-compose content to start the foreground processes
+        echo "$processed_foreground_compose" | docker-compose -f - -p carma down
+
         if [ "$2" = "fix_bag" ]; then
             echo "Trying to fix the last rosbag file..."
             carma__fix_bag
@@ -392,19 +446,19 @@ carma-config__status() {
 carma__exec() {
     local USERNAME=usdotfhwastol
     local TAG=latest
-    
+
     local TARGET_IMAGE="$USERNAME/carma-platform:$TAG"
 
     # Check if the -i argument was provided
     # If the image was specified then use that
 
-    if [ "$1" = "--gui" ]; then 
+    if [ "$1" = "--gui" ]; then
         local RUNTIME=nvidia
         echo "setting docker runtime to $RUNTIME"
         shift
     fi
 
-    if [ "$1" = "-i" ]; then 
+    if [ "$1" = "-i" ]; then
 
         if [ -z "$2" ]; then
             echo " When -i is specified you must enter a carma docker image and tag."
@@ -444,7 +498,7 @@ carma__exec() {
     if [ -n "$1" ]; then
 
         local COMMAND="source $INIT_FILE && ${@}"
-        
+
         docker run \
             -e DISPLAY=$DISPLAY \
             --runtime=$RUNTIME \
@@ -491,56 +545,56 @@ carma__help() {
 -------------------------------------------------------------------------------
 
 Please enter one of the following commands:
-    config: 
+    config:
         status (filename)
             - Report the current configuration status in total or for the
               specified file
         list_local
             - List available usdotfhwastol configurations on the host machine
-            -d 
+            -d
                 - List available usdotfhwastoldev configurations on the host machine
             -c
                 - List available usdotfhwastolcandidate configurations on the host machine
-        list_remote 
+        list_remote
             - List available usdotfhwastol configurations on Dockerhub
             -d
                 - List available usdotfhwastoldev configurations on Dockerhub
             -c
                 - List available usdotfhwastolcandidate configurations on Dockerhub
-        install <tag/image> 
-            - Install a configuration identified by <tag> and download 
+        install <tag/image>
+            - Install a configuration identified by <tag> and download
               dependencies. If <tag> is bare (no :), it is assumed to be a
               usdotfhwastol/carma-config tag.
             -d
                 - tag organization is assumed to be usdotfhwastoldev
             -c
                 - tag organization is assumed to be usdotfhwastolcandidate
-        set <tag/image> 
-            - Set the configuration to the version identified by <tag>. If 
-              <tag> is bare (no :), it is assumed to be a 
+        set <tag/image>
+            - Set the configuration to the version identified by <tag>. If
+              <tag> is bare (no :), it is assumed to be a
               usdotfhwastol/carma-config tag.
-        edit 
-            - Open a shell inside the current configuration storage with r/w 
+        edit
+            - Open a shell inside the current configuration storage with r/w
               permissions
-        inspect 
+        inspect
             - Open a shell inside the current configuration storage with r/o
               permissions
             -d
                 - uses a usdotfhwastoldev/carma-base image
             -c
                 - uses a usdotfhwastolcandidate/carma-base image
-        reset 
+        reset
             - Restore a configuration to its default state
-    start (all (docker-compose up args)) 
-        - Start the CARMA platform's background processes. If all, start 
+    start (all (docker-compose up args))
+        - Start the CARMA platform's background processes. If all, start
           everything.
         - Accepts the same flags as "docker-compose up"
-    stop (all (docker-compose down args)) 
-        - Stop the CARMA platform's foreground processes. If all, stop 
+    stop (all (docker-compose down args))
+        - Stop the CARMA platform's foreground processes. If all, stop
           everything.
         - Accepts the same flags as "docker-compose down"
         - fix_bag
-            - After stopping carma, checks if the last run's rosbag has been correctly saved. If not, fixes it to be replayable. 
+            - After stopping carma, checks if the last run's rosbag has been correctly saved. If not, fixes it to be replayable.
     exec <optional bash command>
         - Opens a new container with GUI support from the carma-platform or carma-messenger image with the version specified in docker compose. If no version is found it will use latest.
           This container can be used to interact with CARMA using ROS tooling such as Rviz and RQT.
@@ -559,7 +613,7 @@ Please enter one of the following commands:
     <script extension>
         - Script extensions can be added by placing a file in ~/.carma_script_extensions/ with the name of the new subcommand and no file extension.
           The file should contain a matching carma__<script extension>() function to recieve the commands.
-    help 
+    help
         - Display this information"
 HELP
 }

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -397,19 +397,19 @@ carma__stop() {
     local env_vars=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/.env' | xargs)
 
-    # Shutdown CARMA background processes
-    echo "Shutting down CARMA background processes..."
-    local processed_background_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
-    # Use the docker-compose content with environment variables replaced to start the background processes
-    echo "$processed_background_compose" | docker-compose -f - -p carma-background down
+    # Shutdown CARMA Platform foreground processes
+    echo "Shutting down CARMA processes..."
+    local processed_foreground_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+    # Use the docker-compose content with environment variables replaced to start the foreground processes
+    echo "$processed_foreground_compose" | docker-compose -f - -p carma down
 
     # Check if the argument "all" is passed to also shut down the background processes
     if [ "$1" = "all" ]; then
-        # Start CARMA Platform foreground processes
-        echo "Shutting down CARMA processes..."
-        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
-        # Use the docker-compose content with environment variables replaced to start the foreground processes
-        echo "$processed_foreground_compose" | docker-compose -f - -p carma down
+        # Shutdown CARMA background processes
+        echo "Shutting down CARMA background processes..."
+        local processed_background_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+        # Use the docker-compose content with environment variables replaced to start the background processes
+        echo "$processed_background_compose" | docker-compose -f - -p carma-background down
 
         if [ "$2" = "fix_bag" ]; then
             echo "Trying to fix the last rosbag file..."

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -254,13 +254,16 @@ carma-config__install() {
     fi
 
     # Extract environment variables from the carma-config container
-    echo "Extracting environment variables from specified carma-config..."
+    echo "Extracting environment variables from carma-config targeted to install..."
     docker run --name carma-config-tmp $IMAGE_NAME
+
+    # Parse environment variables as a space-separated string of key=value pairs.
     local env_vars=$(docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/.env' | xargs)
 
-    local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
-    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+    # Get the docker compose file content with environment variables replaced.
+    local processed_foreground_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
 
     echo "Downloading $IMAGE_NAME dependencies..."
     echo "$processed_foreground_compose" | docker-compose -f - pull
@@ -296,7 +299,19 @@ carma__fix_bag() {
     fi
 }
 
-__replace_env_vars_in_docker_compose_from_carma_config() {
+# Replace environment variables in the given Docker Compose file content using provided environment variables.
+#
+# This function takes the content of a Docker Compose file and a list of environment variables,
+# then replaces any placeholders in the Docker Compose file with their corresponding environment variable values using sed
+#
+# Args:
+#   $1: Docker Compose file content as a string.
+#   $2: Environment variables as a space-separated string of key=value pairs.
+#
+# Returns:
+#   The Docker Compose file content with environment variables replaced.
+
+__replace_env_vars_in_docker_compose_file() {
     local compose_file_content=$1
     local env_vars=$2
 
@@ -310,16 +325,31 @@ __replace_env_vars_in_docker_compose_from_carma_config() {
     echo "$output"
 }
 
-__parse_docker_compose_using_env_vars(){
+# Parse a Docker Compose file from a CARMA configuration and replace environment variables.
+#
+# This function retrieves the content of a Docker Compose file from the `carma-config` container,
+# replaces any environment variable placeholders with their corresponding values, and outputs the modified content.
+#
+# Args:
+#   $1: The full path to the Docker Compose file inside the `carma-config` container.
+#   $2: Environment variables as a space-separated string of key=value pairs.
+#
+# Returns:
+#   The Docker Compose file content with environment variables replaced.
+
+__parse_docker_compose_using_env_vars_in_carma_config() {
     local compose_file_full_path=$1
     local env_vars=$2
 
+    # Retrieve the original Docker Compose file content from the carma-config container
     local original_compose_file=$(docker run --rm --volumes-from carma-config --entrypoint sh busybox:latest -c \
         "cat ${compose_file_full_path}")
 
-    local processed_compose_file=$(__replace_env_vars_in_docker_compose_from_carma_config "$original_compose_file" "$env_vars")
+    # Replace environment variables in the Docker Compose file content
+    local processed_compose_file=$(__replace_env_vars_in_docker_compose_file "$original_compose_file" "$env_vars")
     echo "$processed_compose_file"
 }
+
 
 carma__start() {
     # Check if the carma-config container exists
@@ -336,8 +366,8 @@ carma__start() {
 
     # Start CARMA background processes
     echo "Starting CARMA background processes..."
-    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
-    # Use the processed docker-compose content to start the background processes
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+    # Use the docker-compose content with environment variables replaced to start the background processes
     echo "$processed_background_compose" | docker-compose -f - -p carma-background up -d
 
     # Check if the argument "all" is passed to start the foreground processes
@@ -345,8 +375,8 @@ carma__start() {
         shift
         # Start CARMA Platform foreground processes
         echo "Starting CARMA Platform foreground processes..."
-        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
-        # Use the processed docker-compose content to start the foreground processes
+        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+        # Use the docker-compose content with environment variables replaced to start the foreground processes
         echo "$processed_foreground_compose" | docker-compose -f - -p carma up $@
     elif [ ! -z "$1" ]; then
         # Handle unrecognized arguments
@@ -369,16 +399,16 @@ carma__stop() {
 
     # Shutdown CARMA background processes
     echo "Shutting down CARMA background processes..."
-    local processed_background_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
-    # Use the processed docker-compose content to start the background processes
+    local processed_background_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose-background.yml" "$env_vars")
+    # Use the docker-compose content with environment variables replaced to start the background processes
     echo "$processed_background_compose" | docker-compose -f - -p carma-background down
 
     # Check if the argument "all" is passed to also shut down the background processes
     if [ "$1" = "all" ]; then
         # Start CARMA Platform foreground processes
         echo "Shutting down CARMA processes..."
-        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
-        # Use the processed docker-compose content to start the foreground processes
+        local processed_foreground_compose=$(__parse_docker_compose_using_env_vars_in_carma_config "/opt/carma/vehicle/config/docker-compose.yml" "$env_vars")
+        # Use the docker-compose content with environment variables replaced to start the foreground processes
         echo "$processed_foreground_compose" | docker-compose -f - -p carma down
 
         if [ "$2" = "fix_bag" ]; then


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes the carma script to be able to run from any directory without relying on .env file to exist in the same directory. 
Depends on this PR: https://github.com/usdot-fhwa-stol/carma-config/pull/352

The proposed change on a high level:
- Bake the `.env` file into the `carma-config` container. (previously it didn't exist inside `carma config edit` for example).
- Whenever `carma *` script is run, **parse** all variables inside the `.env` file from the carma-config image set through volume
- use that parsed variables to **sed change** all instances found in the `docker-compose.yml` to run the individual services. This should work for any environment variables specified, not just `DOCKER_TAG` or `DOCKER_ORG` since some services require different org/tagging such as `OPS` or `v2xhub` etc.

Resulting behavior:
- Since the change is made by sed command to get hardcoded image names as before, the local `.env` file in host dir where `carma` is called will no longer work unless the `.env` file in carma-config was NOT able to replace. Then the local .env file will takeover using docker's native functionality and the variables in the docker-compose.yml wil be replaced. This is desirable for simulation runs for example where multiple variables such as ROUTE_FILE are specified in .env file 
- If the user wants to change the image name/tags, they can simply modify the .env file and rebuild or `carma config edit` and modify the `/opt/carma/vehicle/config/.env` file and restart. The change should persist as how `carma config edit` normally works. Or even hardcoding as before in the docker-compose.yml work as well.

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/ARC-82
<!-- e.g. CAR-123 -->

## Motivation and Context
During 4.5.0 release, we modifed the way DOCKER_ORG and DOCKER_TAG are specified by centralizing them into a single .env file in each carma-config folder for docker-compose.yml to load. However, currnently, when a carma-config image is built by our GitHub Actions CI processes, the resulting image still contains the {DOCKER_ORG} and {DOCKER_TAG} environment variable placeholders in the docker-compose.yml and docker-compose-background.yml files. This breaks the carma config install <carma-config image> functionality of the carma shell script. The carma start all functionality breaks with this as well. 

Workaround: If .env file exists in the same directory from where `carma` is called, then everything works fine. However, this is not a desired functionality as we want to call carma from anywhere.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
locally in VM. Results of each commands working:

file: 
[carma command results.txt](https://github.com/user-attachments/files/15842992/carma.command.results.txt)
in colored:
![image](https://github.com/usdot-fhwa-stol/carma-platform/assets/20613282/5bc7ab74-0c6f-4974-b106-926c3242502d)
![image](https://github.com/usdot-fhwa-stol/carma-platform/assets/20613282/f8154351-10c0-4858-b65f-b330faed7a4a)


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
