### PR TITLE
Add logic to carma script to account for env var in carma-config

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -55,7 +55,7 @@ echoerr() { echo "$@" 1>&2; }
 # If the config is not set or an image cannot be found the method will return a carma-base image as the default.
 # The user can specify optional organizations or images as sed compatable regex lists.
 # For example calling
-#  $(__get_image_from_config 'carma-platform:\|carma-messenger:' 'usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate')
+#  $(__get_image_from_config 'carma-platform\|carma-messenger' 'usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate')
 #
 #  If no parameters are provided the defaults will be used
 ##
@@ -63,7 +63,7 @@ __get_image_from_config() {
     # Default image is the most recent carma-base image
     local DEFAULT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
     local SUPPORTED_ORGANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
-    local SUPPORTED_IMAGES="carma-platform:\|carma-messenger:"
+    local SUPPORTED_IMAGES="carma-platform\|carma-messenger"
 
     if [ -n "$1" ]; then
         SUPPORTED_IMAGES="$1"
@@ -81,8 +81,21 @@ __get_image_from_config() {
         # Extract DOCKER_ORG and DOCKER_TAG from the .env file
         source /tmp/.env
 
-        # Construct the image name using the values from the .env file
-        local TARGET_IMAGE="${DOCKER_ORG}/carma-base:${DOCKER_TAG}"
+        # Construct the image name using the values from the .env file and given SUPPORTED_IMAGES options
+
+        # Split SUPPORTED_IMAGES into an array
+        local IFS='\|'
+        read -ra IMAGE_ARRAY <<< "$SUPPORTED_IMAGES"
+
+        for IMAGE in "${IMAGE_ARRAY[@]}"; do
+            TARGET_IMAGE="${DOCKER_ORG}/${IMAGE}:${DOCKER_TAG}"
+
+            # Verify target image exists
+            if [ -n "$(docker images -q $TARGET_IMAGE 2> /dev/null)" ]; then
+                IMAGE_FOUND=1
+                break
+            fi
+        done
 
         # Check if TARGET_IMAGE exists locally
         if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "^${TARGET_IMAGE}$"; then
@@ -159,7 +172,7 @@ carma-config__edit() {
 
     echo "Opening shell inside carma-config container with read/write privileges..."
 
-    local carma_base=$(__get_image_from_config carma-base:)
+    local carma_base=$(__get_image_from_config carma-base)
     if [[ -z $carma_base ]]; then
         __pull_newest_carma_base
         carma_base=$(__get_most_recent_carma_base)
@@ -449,7 +462,7 @@ carma__exec() {
         shift
     # If the image was not specified try to use what was in the carma config
     else
-        local TARGET_IMAGE=$(__get_image_from_config 'carma-platform:\|carma-messenger:')
+        local TARGET_IMAGE=$(__get_image_from_config 'carma-platform\|carma-messenger')
     fi
 
     # Verify target image exists

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -190,10 +190,18 @@ carma-config__set() {
 }
 
 carma__attach() {
+    # Extract the .env file content from the carma-config volume
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
+
+    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
+    set -o allexport
+    source /tmp/.env 2>/dev/null # suppress misleading error message that will occur for versions before 4.5.0
+    set +o allexport
+
     local CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose.yml'`"
 
     echo "Attaching to CARMA container STDOUT..."
-    echo "$CARMA_DOCKER_FILE" | docker-compose -p carma -f - logs --follow --tail=10
+    echo "$CARMA_DOCKER_FILE" | docker-compose -p carma logs -f - logs --follow --tail=10
 }
 
 carma-config__edit() {

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -99,8 +99,22 @@ __get_image_from_config() {
         # Check if TARGET_IMAGE exists locally
         if [ $IMAGE_FOUND -eq 0 ]; then
             echoerr "TARGET_IMAGE with DOCKER_ORG=${DOCKER_ORG} DOCKER_TAG=${DOCKER_TAG} does not exist locally for these images: ${SUPPORTED_IMAGES},
-                defaulting to most recent carma-base image: $DEFAULT_IMAGE"
-            TARGET_IMAGE=$DEFAULT_IMAGE
+                trying to get most recent images from these: ${SUPPORTED_IMAGES}"
+
+            for IMAGE in "${IMAGE_ARRAY[@]}"; do
+                TARGET_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E "$IMAGE" | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
+
+                # Verify target image exists
+                if [ -n "$(docker images -q $TARGET_IMAGE 2> /dev/null)" ]; then
+                    IMAGE_FOUND=1
+                    break
+                fi
+            done
+
+            if [ $IMAGE_FOUND -eq 0 ]; then
+            echoerr "Trying to use default image: ${DEFAULT_IMAGE}"
+                TARGET_IMAGE=$DEFAULT_IMAGE
+            fi
         fi
 
         rm /tmp/.env

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -60,11 +60,9 @@ echoerr() { echo "$@" 1>&2; }
 # The user can specify optional images as sed compatable regex lists.
 # For example calling
 #  $(__get_image_from_config 'carma-platform\|carma-messenger')
-#
-#  If no parameters are provided the defaults will be used
 ##
 __get_image_from_config() {
-    # Default image is the most recent carma-base image
+    # Default image is the most recent carma-base image by time of creation
     local DEFAULT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
     local SUPPORTED_ORANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
     local SUPPORTED_IMAGES="carma-platform\|carma-messenger"
@@ -77,6 +75,7 @@ __get_image_from_config() {
     if docker container inspect carma-config > /dev/null 2>&1; then
 
         # NOTE: Before and including carma-system-4.5.0, image can be directly grabbed from config docker-compose using sed
+        # This approach needs to be used for versions for and before carma-system-4.5.0 because the /opt/carma/vehicle/config/.env file is not defined
         # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
         # then returns the name of the image.
         local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -329,11 +329,12 @@ __get_compose_env_files() {
     # If variable is not set, modify to get default values
     RETURN_COMPOSE_ENV_FILES="/tmp/.env"
 
-    # Check if local .env file exists
+    # If local .env file exists, it takes higher precedence over carma-config .env file
     if [ -f ".env" ]; then
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
     fi
 
+    # If user defined COMPOSE_ENV_FILES exists in the shell, it takes higher precedence over other default .env files
     if [ -n "${COMPOSE_ENV_FILES+x}" ]; then
         echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES. Appending it to default COMPOSE_ENV_FILES"
         # This way, user defined COMPOSE_ENV_FILES still takes higher precedence.
@@ -356,7 +357,7 @@ carma__start() {
     # Extract the .env file content from the carma-config volume and save temporarily
     docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
-    # Set .env file in carma-config as default and lowest precedence over any other env files
+    # Get correct order of .env file precedence. From low to high: carma-config .env, local .env, user defined.
     COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)
 
     echo "Starting CARMA background processes..."
@@ -387,7 +388,7 @@ carma__stop() {
     # Extract the .env file content from the carma-config volume
     docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
-    # Set .env file in carma-config as default and lowest precedence over any other env files
+    # Get correct order of .env file precedence. From low to high: carma-config .env, local .env, user defined.
     COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)
 
     echo "Shutting down CARMA processes..."

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -324,6 +324,25 @@ carma__fix_bag() {
 
     fi
 }
+
+__get_compose_env_files() {
+    # If variable is not set, modify to get default values
+    RETURN_COMPOSE_ENV_FILES="/tmp/.env"
+
+    # Check if local .env file exists
+    if [ -f ".env" ]; then
+        RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
+    fi
+
+    if [ -n "${COMPOSE_ENV_FILES+x}" ]; then
+        echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES. Appending it to default COMPOSE_ENV_FILES"
+        # This way, user defined COMPOSE_ENV_FILES still takes higher precedence.
+        RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,$COMPOSE_ENV_FILES"
+    fi
+
+    echo "$RETURN_COMPOSE_ENV_FILES"
+}
+
 carma__start() {
     if ! docker container inspect carma-config > /dev/null 2>&1; then
         echo "No existing CARMA configuration found, nothing to start. Please set a config."
@@ -331,27 +350,28 @@ carma__start() {
         exit 1
     fi
 
-    # Extract the .env file content from the carma-config volume
+    # Capture all extra arguments
+    EXTRA_ARGS=("$@")
+
+    # Extract the .env file content from the carma-config volume and save temporarily
     docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
-    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
-    set -o allexport
-    source /tmp/.env
-    set +o allexport
+    # Set .env file in carma-config as default and lowest precedence over any other env files
+    COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)
 
     echo "Starting CARMA background processes..."
     docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
     'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
-    docker-compose -f - -p carma-background up -d
+        COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES_WITH_DEFAULT", docker-compose -f - -p carma-background "${EXTRA_ARGS[@]:1}" up -d
 
-    if [ "$1" = "all" ]; then
+    if [[ "${EXTRA_ARGS[0]}" == "all" ]]; then
         shift
         echo "Starting CARMA Platform foreground processes..."
         docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/docker-compose.yml' | \
-        docker-compose -f - -p carma up $@
-    elif [ ! -z "$1" ]; then
-        echo "Unrecognized argument \"start $1\""
+            COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES_WITH_DEFAULT", docker-compose -f - -p carma "${EXTRA_ARGS[@]:1}" up
+    elif [[ ! -z "${EXTRA_ARGS[0]}" ]]; then
+        echo "Unrecognized argument \"start ${EXTRA_ARGS[0]}\""
     fi
 
     rm /tmp/.env
@@ -367,21 +387,19 @@ carma__stop() {
     # Extract the .env file content from the carma-config volume
     docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
-    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
-    set -o allexport
-    source /tmp/.env
-    set +o allexport
+    # Set .env file in carma-config as default and lowest precedence over any other env files
+    COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)
 
     echo "Shutting down CARMA processes..."
     docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
     'cat /opt/carma/vehicle/config/docker-compose.yml' | \
-    docker-compose -f - -p carma down
+    COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES_WITH_DEFAULT", docker-compose -f - -p carma down
 
     if [ "$1" = "all" ]; then
         echo "Shutting down CARMA background processes..."
         docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
-        docker-compose -f - -p carma-background down
+        COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES_WITH_DEFAULT", docker-compose -f - -p carma-background down
         if [ "$2" = "fix_bag" ]; then
             echo "Trying to fix the last rosbag file..."
             carma__fix_bag
@@ -594,10 +612,14 @@ Please enter one of the following commands:
         - Start the CARMA platform's background processes. If all, start
           everything.
         - Accepts the same flags as "docker-compose up"
+        - NOTE: Uses COMPOSE_ENV_FILES under the hood for env files.
+          Precedence from lowest to highest: .env in carma-config, local .env, existing COMPOSE_ENV_FILES in shell.
     stop (all (docker-compose down args))
         - Stop the CARMA platform's foreground processes. If all, stop
           everything.
         - Accepts the same flags as "docker-compose down"
+        - NOTE: Uses COMPOSE_ENV_FILES under the hood for env files.
+          Precedence from lowest to highest: .env in carma-config, local .env, existing COMPOSE_ENV_FILES in shell.
         - fix_bag
             - After stopping carma, checks if the last run's rosbag has been correctly saved. If not, fixes it to be replayable.
     exec <optional bash command>

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 #  Copyright (C) 2018-2022 LEIDOS.
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -16,9 +16,9 @@
 
 # Code below largely based on template from Stack Overflow:
 # https://stackoverflow.com/questions/37257551/defining-subcommands-that-take-arguments-in-bash
-# Question asked by user 
+# Question asked by user
 # DiogoSaraiva (https://stackoverflow.com/users/4465820/diogosaraiva)
-# and answered by user 
+# and answered by user
 # Charles Duffy (https://stackoverflow.com/users/14122/charles-duffy)
 # Attribution here is in line with Stack Overflow's Attribution policy cc-by-sa found here:
 # https://stackoverflow.blog/2009/06/25/attribution-required/
@@ -38,7 +38,7 @@ __pull_newest_carma_base() {
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
         awk -F: '{print "usdotfhwastol/carma-base:"$3}' | tail -n 1)
     fi
-    
+
     echo "No local carma-base image found, pulling down the most recent from Dockerhub..."
     docker pull $remote_image
 }
@@ -54,9 +54,9 @@ echoerr() { echo "$@" 1>&2; }
 # The method will return the first tag that appears in the config for the possible organizations and images.
 # If the config is not set or an image cannot be found the method will return a carma-base image as the default.
 # The user can specify optional organizations or images as sed compatable regex lists.
-# For example calling 
+# For example calling
 #  $(__get_image_from_config 'carma-platform:\|carma-messenger:' 'usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate')
-# 
+#
 #  If no parameters are provided the defaults will be used
 ##
 __get_image_from_config() {
@@ -71,7 +71,7 @@ __get_image_from_config() {
 
     if [ -n "$2" ]
     then
-        
+
         local SUPPORTED_ORANIZATIONS="$2"
     fi
 
@@ -80,17 +80,22 @@ __get_image_from_config() {
 
         local IMAGE_BACKUP=$TARGET_IMAGE
 
-        # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
-        # then returns the name of the image.  
-        local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
-            "sed -n -e '/image:\s*\($SUPPORTED_ORANIZATIONS\)\/\($SUPPORTED_IMAGES\)/ s/.*\image: *//p' /opt/carma/vehicle/config/docker-compose.yml | grep -m 1 '.*'")
-            
+        # Extract the .env file content from the carma-config volume
+        docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+
+        # Extract DOCKER_ORG and DOCKER_TAG from the .env file
+        source /tmp/.env
+
+        # Construct the image name using the values from the .env file
+        TARGET_IMAGE="${DOCKER_ORG}/carma-base:${DOCKER_TAG}"
 
         # If the sed resulted in an empty string then reset the tag
         if [ -z "$TARGET_IMAGE" ]; then
             local TARGET_IMAGE=$IMAGE_BACKUP
             echoerr "Could not identify usable image from config so defaulting to image: $TARGET_IMAGE"
         fi
+
+        rm /tmp/.env
     else
         echoerr "No config detected or target image specified so using default: $TARGET_IMAGE"
     fi
@@ -215,11 +220,11 @@ carma-config__list_remote() {
     elif [ "$1" = "-c" ]; then
         wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastolcandidate/carma-config/tags -O -  | \
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
-        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastolcandidate Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastolcandidate/carma-config\t"$3}' 
+        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastolcandidate Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastolcandidate/carma-config\t"$3}'
     else
         wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastol/carma-config/tags -O -  | \
         sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
-        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastol Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastol/carma-config\t"$3}'    
+        awk -F: 'BEGIN {print "Remotely available images from usdotfhwastol Dockerhub:\nIMAGE\t\t\t\tTAG"} {print "usdotfhwastol/carma-config\t"$3}'
     fi
 }
 
@@ -248,6 +253,14 @@ carma-config__install() {
         docker rm carma-config-tmp
     fi
     docker run --name carma-config-tmp $IMAGE_NAME
+
+    # Extract the .env file content from the carma-config volume
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+
+    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
+    set -o allexport
+    source /tmp/.env
+    set +o allexport
 
     local CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose.yml' | sed s/carma-config/carma-config-tmp/g`"
     local CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose-background.yml' | sed s/carma-config/carma-config-tmp/g`"
@@ -292,12 +305,20 @@ carma__start() {
         exit 1
     fi
 
+    # Extract the .env file content from the carma-config volume
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+
+    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
+    set -o allexport
+    source /tmp/.env
+    set +o allexport
+
     echo "Starting CARMA background processes..."
     docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
     'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
     docker-compose -f - -p carma-background up -d
 
-    if [ "$1" = "all" ]; then 
+    if [ "$1" = "all" ]; then
         shift
         echo "Starting CARMA Platform foreground processes..."
         docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
@@ -306,6 +327,8 @@ carma__start() {
     elif [ ! -z "$1" ]; then
         echo "Unrecognized argument \"start $1\""
     fi
+
+    rm /tmp/.env
 }
 
 carma__stop() {
@@ -315,12 +338,20 @@ carma__stop() {
         exit 1
     fi
 
+    # Extract the .env file content from the carma-config volume
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+
+    # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
+    set -o allexport
+    source /tmp/.env
+    set +o allexport
+
     echo "Shutting down CARMA processes..."
     docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
     'cat /opt/carma/vehicle/config/docker-compose.yml' | \
     docker-compose -f - -p carma down
 
-    if [ "$1" = "all" ]; then 
+    if [ "$1" = "all" ]; then
         echo "Shutting down CARMA background processes..."
         docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
         'cat /opt/carma/vehicle/config/docker-compose-background.yml' | \
@@ -337,6 +368,8 @@ carma__stop() {
     elif [ ! -z "$1" ]; then
         echo "Unrecognized argument \"stop $1\""
     fi
+
+    rm /tmp/.env
 }
 
 carma__ps() {
@@ -392,19 +425,19 @@ carma-config__status() {
 carma__exec() {
     local USERNAME=usdotfhwastol
     local TAG=latest
-    
+
     local TARGET_IMAGE="$USERNAME/carma-platform:$TAG"
 
     # Check if the -i argument was provided
     # If the image was specified then use that
 
-    if [ "$1" = "--gui" ]; then 
+    if [ "$1" = "--gui" ]; then
         local RUNTIME=nvidia
         echo "setting docker runtime to $RUNTIME"
         shift
     fi
 
-    if [ "$1" = "-i" ]; then 
+    if [ "$1" = "-i" ]; then
 
         if [ -z "$2" ]; then
             echo " When -i is specified you must enter a carma docker image and tag."
@@ -444,7 +477,7 @@ carma__exec() {
     if [ -n "$1" ]; then
 
         local COMMAND="source $INIT_FILE && ${@}"
-        
+
         docker run \
             -e DISPLAY=$DISPLAY \
             --runtime=$RUNTIME \
@@ -491,56 +524,56 @@ carma__help() {
 -------------------------------------------------------------------------------
 
 Please enter one of the following commands:
-    config: 
+    config:
         status (filename)
             - Report the current configuration status in total or for the
               specified file
         list_local
             - List available usdotfhwastol configurations on the host machine
-            -d 
+            -d
                 - List available usdotfhwastoldev configurations on the host machine
             -c
                 - List available usdotfhwastolcandidate configurations on the host machine
-        list_remote 
+        list_remote
             - List available usdotfhwastol configurations on Dockerhub
             -d
                 - List available usdotfhwastoldev configurations on Dockerhub
             -c
                 - List available usdotfhwastolcandidate configurations on Dockerhub
-        install <tag/image> 
-            - Install a configuration identified by <tag> and download 
+        install <tag/image>
+            - Install a configuration identified by <tag> and download
               dependencies. If <tag> is bare (no :), it is assumed to be a
               usdotfhwastol/carma-config tag.
             -d
                 - tag organization is assumed to be usdotfhwastoldev
             -c
                 - tag organization is assumed to be usdotfhwastolcandidate
-        set <tag/image> 
-            - Set the configuration to the version identified by <tag>. If 
-              <tag> is bare (no :), it is assumed to be a 
+        set <tag/image>
+            - Set the configuration to the version identified by <tag>. If
+              <tag> is bare (no :), it is assumed to be a
               usdotfhwastol/carma-config tag.
-        edit 
-            - Open a shell inside the current configuration storage with r/w 
+        edit
+            - Open a shell inside the current configuration storage with r/w
               permissions
-        inspect 
+        inspect
             - Open a shell inside the current configuration storage with r/o
               permissions
             -d
                 - uses a usdotfhwastoldev/carma-base image
             -c
                 - uses a usdotfhwastolcandidate/carma-base image
-        reset 
+        reset
             - Restore a configuration to its default state
-    start (all (docker-compose up args)) 
-        - Start the CARMA platform's background processes. If all, start 
+    start (all (docker-compose up args))
+        - Start the CARMA platform's background processes. If all, start
           everything.
         - Accepts the same flags as "docker-compose up"
-    stop (all (docker-compose down args)) 
-        - Stop the CARMA platform's foreground processes. If all, stop 
+    stop (all (docker-compose down args))
+        - Stop the CARMA platform's foreground processes. If all, stop
           everything.
         - Accepts the same flags as "docker-compose down"
         - fix_bag
-            - After stopping carma, checks if the last run's rosbag has been correctly saved. If not, fixes it to be replayable. 
+            - After stopping carma, checks if the last run's rosbag has been correctly saved. If not, fixes it to be replayable.
     exec <optional bash command>
         - Opens a new container with GUI support from the carma-platform or carma-messenger image with the version specified in docker compose. If no version is found it will use latest.
           This container can be used to interact with CARMA using ROS tooling such as Rviz and RQT.
@@ -559,7 +592,7 @@ Please enter one of the following commands:
     <script extension>
         - Script extensions can be added by placing a file in ~/.carma_script_extensions/ with the name of the new subcommand and no file extension.
           The file should contain a matching carma__<script extension>() function to recieve the commands.
-    help 
+    help
         - Display this information"
 HELP
 }

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -350,7 +350,7 @@ __get_compose_env_files() {
 
     # If .env file exists in current directory, it takes higher precedence over carma-config .env file
     if [ -f ".env" ]; then
-        echoerr "NOTE: .env file detected in current directory, considering its values for current carma session."
+        echoerr "NOTE: .env file detected in current directory, taking its values for consideration for current carma session."
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
     fi
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -350,7 +350,7 @@ __get_compose_env_files() {
 
     # If .env file exists in current directory, it takes higher precedence over carma-config .env file
     if [ -f ".env" ]; then
-        echoerr "NOTE: .env file detected in current directory, taking its values for consideration for current carma session."
+        echoerr "NOTE: .env file detected in current directory, including its values for consideration for current carma session."
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
     fi
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -65,6 +65,7 @@ echoerr() { echo "$@" 1>&2; }
 __get_image_from_config() {
     # Default image is the most recent carma-base image
     local DEFAULT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
+    local SUPPORTED_ORANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
     local SUPPORTED_IMAGES="carma-platform\|carma-messenger"
 
     if [ -n "$1" ]; then
@@ -73,7 +74,22 @@ __get_image_from_config() {
 
     # Check if carma-config is set. If so, use what was in the carma config
     if docker container inspect carma-config > /dev/null 2>&1; then
+
+        # Before and including carma-system-4.5.0, image can be directly grabbed from config docker-compose using sed
+        # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
+        # then returns the name of the image.
+        local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+            "sed -n -e '/image:\s*\($SUPPORTED_ORANIZATIONS\)\/\($SUPPORTED_IMAGES\)/ s/.*\image: *//p' /opt/carma/vehicle/config/docker-compose.yml | grep -m 1 '.*'")
+
+        # If the sed resulted in valid image, then return
+        if [ -n "$TARGET_IMAGE" ]; then
+            echo "$TARGET_IMAGE"
+            return 0
+        fi
+
+        # Else, possibly newer config than carma-system-4.5.0...
         local IMAGE_FOUND=0
+
         # Extract the .env file content from the carma-config volume
         docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
@@ -281,11 +297,11 @@ carma-config__install() {
     docker run --name carma-config-tmp $IMAGE_NAME
 
     # Extract the .env file content from the carma-config volume
-    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
 
     # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
     set -o allexport
-    source /tmp/.env
+    source /tmp/.env 2>/dev/null # suppress misleading error message that will occur for versions before 4.5.0
     set +o allexport
 
     local CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config-tmp:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/config/docker-compose.yml' | sed s/carma-config/carma-config-tmp/g`"
@@ -355,7 +371,7 @@ carma__start() {
     EXTRA_ARGS=("$@")
 
     # Extract the .env file content from the carma-config volume and save temporarily
-    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
 
     # Get correct order of .env file precedence. From low to high: carma-config .env, local .env, user defined.
     COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)
@@ -386,7 +402,7 @@ carma__stop() {
     fi
 
     # Extract the .env file content from the carma-config volume
-    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
+    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
 
     # Get correct order of .env file precedence. From low to high: carma-config .env, local .env, user defined.
     COMPOSE_ENV_FILES_WITH_DEFAULT=$(__get_compose_env_files)

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -350,6 +350,7 @@ __get_compose_env_files() {
 
     # If .env file exists in current directory, it takes higher precedence over carma-config .env file
     if [ -f ".env" ]; then
+        echoerr "NOTE: .env file detected in current directory, considering its values for current carma session."
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
     fi
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -60,7 +60,8 @@ echoerr() { echo "$@" 1>&2; }
 #  If no parameters are provided the defaults will be used
 ##
 __get_image_from_config() {
-    local DEFAULT_IMAGE="usdotfhwastol/carma-base:latest"
+    # Default image is the most recent carma-base image
+    local DEFAULT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
     local SUPPORTED_ORGANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
     local SUPPORTED_IMAGES="carma-platform:\|carma-messenger:"
 
@@ -74,9 +75,6 @@ __get_image_from_config() {
 
     # Check if carma-config is set. If so, use what was in the carma config
     if docker container inspect carma-config > /dev/null 2>&1; then
-        # use backup image as the most recent carma-base docker image
-        local IMAGE_BACKUP=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
-
         # Extract the .env file content from the carma-config volume
         docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
@@ -88,19 +86,18 @@ __get_image_from_config() {
 
         # Check if TARGET_IMAGE exists locally
         if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "^${TARGET_IMAGE}$"; then
-            echoerr "TARGET_IMAGE ($TARGET_IMAGE) does not exist locally, defaulting to most recent carma-base image: $IMAGE_BACKUP"
-            TARGET_IMAGE=$IMAGE_BACKUP
-        fi
-
-        if [ -z "$TARGET_IMAGE" ]; then
+            echoerr "TARGET_IMAGE ($TARGET_IMAGE) does not exist locally, defaulting to most recent carma-base image: $DEFAULT_IMAGE"
             TARGET_IMAGE=$DEFAULT_IMAGE
-            echoerr "No recent carma-base image found, using default image: $TARGET_IMAGE"
         fi
 
         rm /tmp/.env
     else
         echoerr "No config detected or target image specified so using default: $DEFAULT_IMAGE"
         TARGET_IMAGE=$DEFAULT_IMAGE
+    fi
+
+    if [ -z "$TARGET_IMAGE" ]; then
+        echoerr "No recent carma-base image found, please download or build carma-base image locally."
     fi
 
     echo "$TARGET_IMAGE"

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -202,6 +202,8 @@ carma__attach() {
 
     echo "Attaching to CARMA container STDOUT..."
     echo "$CARMA_DOCKER_FILE" | docker-compose -p carma logs -f - logs --follow --tail=10
+
+    rm /tmp/.env
 }
 
 carma-config__edit() {

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -50,31 +50,30 @@ __pull_newest_carma_base() {
 echoerr() { echo "$@" 1>&2; }
 
 ##
-# Method returns a fully specified docker image name and tag based on the currently set carma-config.
-# The method will return the first tag that appears in the config for the possible organizations and images.
-# If the config is not set or an image cannot be found the method will return a carma-base image as the default.
-# The user can specify optional organizations or images as sed compatable regex lists.
+# Method returns a fully specified docker image name and tag based on the currently set carma-config
+# The method extracts DOCKER_ORG and DOCKER_TAG from the .env file in carma-config to look for
+# combinations from SUPPORTED_IMAGES that exist locally.
+# If the config is not set or an image cannot be found the method will return most recent
+# carma-base image as the default.
+# If none is possible from above, returns error message.
+# The user can specify optional images as sed compatable regex lists.
 # For example calling
-#  $(__get_image_from_config 'carma-platform\|carma-messenger' 'usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate')
+#  $(__get_image_from_config 'carma-platform\|carma-messenger')
 #
 #  If no parameters are provided the defaults will be used
 ##
 __get_image_from_config() {
     # Default image is the most recent carma-base image
     local DEFAULT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
-    local SUPPORTED_ORGANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
     local SUPPORTED_IMAGES="carma-platform\|carma-messenger"
 
     if [ -n "$1" ]; then
         SUPPORTED_IMAGES="$1"
     fi
 
-    if [ -n "$2" ]; then
-        SUPPORTED_ORGANIZATIONS="$2"
-    fi
-
     # Check if carma-config is set. If so, use what was in the carma config
     if docker container inspect carma-config > /dev/null 2>&1; then
+        local IMAGE_FOUND=0
         # Extract the .env file content from the carma-config volume
         docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
 
@@ -98,8 +97,9 @@ __get_image_from_config() {
         done
 
         # Check if TARGET_IMAGE exists locally
-        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "^${TARGET_IMAGE}$"; then
-            echoerr "TARGET_IMAGE ($TARGET_IMAGE) does not exist locally, defaulting to most recent carma-base image: $DEFAULT_IMAGE"
+        if [ $IMAGE_FOUND -eq 0 ]; then
+            echoerr "TARGET_IMAGE with DOCKER_ORG=${DOCKER_ORG} DOCKER_TAG=${DOCKER_TAG} does not exist locally for these images: ${SUPPORTED_IMAGES},
+                defaulting to most recent carma-base image: $DEFAULT_IMAGE"
             TARGET_IMAGE=$DEFAULT_IMAGE
         fi
 

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -54,8 +54,9 @@ echoerr() { echo "$@" 1>&2; }
 # The method extracts DOCKER_ORG and DOCKER_TAG from the .env file in carma-config to look for
 # combinations from SUPPORTED_IMAGES that exist locally.
 # If the config is not set or an image cannot be found the method will return most recent
-# carma-base image as the default.
-# If none is possible from above, returns error message.
+# SUPPORTED_IMAGES image as the default.
+# If that fails, returns the most recent carma-base image.
+# If none is possible from all above, returns error message.
 # The user can specify optional images as sed compatable regex lists.
 # For example calling
 #  $(__get_image_from_config 'carma-platform\|carma-messenger')
@@ -75,7 +76,7 @@ __get_image_from_config() {
     # Check if carma-config is set. If so, use what was in the carma config
     if docker container inspect carma-config > /dev/null 2>&1; then
 
-        # Before and including carma-system-4.5.0, image can be directly grabbed from config docker-compose using sed
+        # NOTE: Before and including carma-system-4.5.0, image can be directly grabbed from config docker-compose using sed
         # sed command finds the first instance of an image which is part of the set defined in SUPPORTED_ORGANIZATIONS and SUPPORTED_IMAGES.
         # then returns the name of the image.
         local TARGET_IMAGE=$(docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
@@ -87,7 +88,7 @@ __get_image_from_config() {
             return 0
         fi
 
-        # Else, possibly newer config than carma-system-4.5.0...
+        # NOTE: Else, possibly newer config than carma-system-4.5.0 which uses `/opt/carma/vehicle/config/.env`...
         local IMAGE_FOUND=0
 
         # Extract the .env file content from the carma-config volume
@@ -96,7 +97,7 @@ __get_image_from_config() {
         # Extract DOCKER_ORG and DOCKER_TAG from the .env file
         source /tmp/.env
 
-        # Construct the image name using the values from the .env file and given SUPPORTED_IMAGES options
+        # 1. Construct the image name using the values from the .env file and given SUPPORTED_IMAGES options
 
         # Split SUPPORTED_IMAGES into an array
         local IFS='\|'
@@ -117,6 +118,7 @@ __get_image_from_config() {
             echoerr "TARGET_IMAGE with DOCKER_ORG=${DOCKER_ORG} DOCKER_TAG=${DOCKER_TAG} does not exist locally for these images: ${SUPPORTED_IMAGES},
                 trying to get most recent images from these: ${SUPPORTED_IMAGES}"
 
+            # 2. Get most recent images of SUPPORTED_IMAGES
             for IMAGE in "${IMAGE_ARRAY[@]}"; do
                 TARGET_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E "$IMAGE" | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
 
@@ -127,6 +129,7 @@ __get_image_from_config() {
                 fi
             done
 
+            # 3. Get most recent carma-base image
             if [ $IMAGE_FOUND -eq 0 ]; then
             echoerr "Trying to use default image: ${DEFAULT_IMAGE}"
                 TARGET_IMAGE=$DEFAULT_IMAGE
@@ -342,17 +345,18 @@ carma__fix_bag() {
 }
 
 __get_compose_env_files() {
-    # If variable is not set, modify to get default values
+    # If variable is not set, modify to get default values from carma-config
     RETURN_COMPOSE_ENV_FILES="/tmp/.env"
 
-    # If local .env file exists, it takes higher precedence over carma-config .env file
+    # If .env file exists in current directory, it takes higher precedence over carma-config .env file
     if [ -f ".env" ]; then
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,.env"
     fi
 
-    # If user defined COMPOSE_ENV_FILES exists in the shell, it takes higher precedence over other default .env files
+    # If user defined COMPOSE_ENV_FILES exists in the shell, it takes higher precedence over .env from carma-config and current directory .env
     if [ -n "${COMPOSE_ENV_FILES+x}" ]; then
-        echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES. Appending it to default COMPOSE_ENV_FILES"
+        echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES. 
+            Setting it higher precedence than .env from carma-config and current directory .env (if it exists)"
         # This way, user defined COMPOSE_ENV_FILES still takes higher precedence.
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,$COMPOSE_ENV_FILES"
     fi

--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -60,25 +60,22 @@ echoerr() { echo "$@" 1>&2; }
 #  If no parameters are provided the defaults will be used
 ##
 __get_image_from_config() {
-    local TARGET_IMAGE="usdotfhwastol/carma-base:latest"
-    local SUPPORTED_ORANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
+    local DEFAULT_IMAGE="usdotfhwastol/carma-base:latest"
+    local SUPPORTED_ORGANIZATIONS="usdotfhwastol\|usdotfhwastoldev\|usdotfhwastolcandidate"
     local SUPPORTED_IMAGES="carma-platform:\|carma-messenger:"
 
-    if [ -n "$1" ]
-    then
-        local SUPPORTED_IMAGES="$1"
+    if [ -n "$1" ]; then
+        SUPPORTED_IMAGES="$1"
     fi
 
-    if [ -n "$2" ]
-    then
-
-        local SUPPORTED_ORANIZATIONS="$2"
+    if [ -n "$2" ]; then
+        SUPPORTED_ORGANIZATIONS="$2"
     fi
 
     # Check if carma-config is set. If so, use what was in the carma config
     if docker container inspect carma-config > /dev/null 2>&1; then
-
-        local IMAGE_BACKUP=$TARGET_IMAGE
+        # use backup image as the most recent carma-base docker image
+        local IMAGE_BACKUP=$(docker images --format '{{.Repository}}:{{.Tag}} {{.CreatedAt}}' | grep -E 'carma-base' | grep -v '<none>' | sort -k 2 -r | head -n 1 | awk '{print $1}')
 
         # Extract the .env file content from the carma-config volume
         docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env
@@ -87,22 +84,27 @@ __get_image_from_config() {
         source /tmp/.env
 
         # Construct the image name using the values from the .env file
-        TARGET_IMAGE="${DOCKER_ORG}/carma-base:${DOCKER_TAG}"
+        local TARGET_IMAGE="${DOCKER_ORG}/carma-base:${DOCKER_TAG}"
 
-        # If the sed resulted in an empty string then reset the tag
+        # Check if TARGET_IMAGE exists locally
+        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "^${TARGET_IMAGE}$"; then
+            echoerr "TARGET_IMAGE ($TARGET_IMAGE) does not exist locally, defaulting to most recent carma-base image: $IMAGE_BACKUP"
+            TARGET_IMAGE=$IMAGE_BACKUP
+        fi
+
         if [ -z "$TARGET_IMAGE" ]; then
-            local TARGET_IMAGE=$IMAGE_BACKUP
-            echoerr "Could not identify usable image from config so defaulting to image: $TARGET_IMAGE"
+            TARGET_IMAGE=$DEFAULT_IMAGE
+            echoerr "No recent carma-base image found, using default image: $TARGET_IMAGE"
         fi
 
         rm /tmp/.env
     else
-        echoerr "No config detected or target image specified so using default: $TARGET_IMAGE"
+        echoerr "No config detected or target image specified so using default: $DEFAULT_IMAGE"
+        TARGET_IMAGE=$DEFAULT_IMAGE
     fi
 
     echo "$TARGET_IMAGE"
 }
-
 __get_most_recent_carma_base() {
     if [ "$1" = "-d" ]; then
         local USERNAME=usdotfhwastoldev


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes the carma script to be able to run from any directory without relying on .env file to exist in the same directory. 
Depends on this PR: https://github.com/usdot-fhwa-stol/carma-config/pull/352

**The proposed change on a high level:**
- Bake the `.env` file into the `carma-config` container. Since `.env` file specifies carma version now, it makes sense to include it in the config, which is intended to track carma version.
- Use COMPOSE_ENV_FILES functionality under the hood from docker which allows the user to specify multiple .env files (NOTE: needs docker-compose 2.23.0+ version). `carma` script now modifies that variable as below (highest to lowest precedence):
    - 1 user defined shell COMPOSE_ENV_FILES values
    - 2 local .env file where `carma` is called
    - 3 .env file specified in `carma config` currently set
This way, `carma` script always has default values from carma-config wherever it's called. Additionally, user can still use the variable as docker intended. 
NOTE: docker actually uses local `.env` file only as the last resort such as if no `.env` file is specified, so it doesn't always use. Currently I implemented such that it uses .env as 2nd to last precedence as long as it exists, as it makes sense in my head. For anyone who is interested, here is the docker [env file precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/). 
- Fixed previously broken feature of using `extra_args` in `carma start all extra_args` as input to `docker-compose up` command. Now it works as intended where the user can input extra flags `--env-file` or `--progress` etc. 

**Resulting behavior:**
- **NEW Behavior**: docker-compose needed to be updated to latest (or more than 2.23.0) which is now 2.27.1
- **NEW Behavior**: If multiple `.env` files are specified, such as local `.env`, `.env` files in COMPOSE_ENV_FILES etc, all of them are loaded including `.env` from `carma-config`. If overlapping values exist, above precedence is used to overwrite.
NOTE: if `--env-file` argument is used in `carma start all --env-file /path/to/env`, docker ignores COMPOSE_ENV_FILES. It is still same behavior as that.
- **OLD Behavior**: `carma config edit` uses `carma-base` that tries to use same version as specified in its `.env` inside. If fails, just uses most recent `carma-base`. In the end, it shouldn't matter which version of `carma-base` is used as it is only for editing `volume`
- **Old behavior**: `carma config install <image>` tries to pull down images specified in `.env` of `<config-image>`. It doesn't make sense to use any other `.env` here as the user is trying to download specific version in `<config-image>`
- **OLD Behavior + fixes**: `carma exec` 
     - 1 first tries to open `carma-platform` or `carma-messenger` using version specified inside current `.env` in `carma-config`. 
     - 2 If it fails, try to use most recent `carma-platform` or `carma-messenger` images. 
     NOTE: Here, previously the script tried to use `usdotfhwastol/carma-base:latest` instead which often doesn't exist and script failed. This was undesirable such as when custom image like `local/carma-platform:latest` is used, then the script used to fail.
     - 3 if that also fails, try to use most recent `carma-base` image. 
     - 4 if that fails, return by logging error
     NOTE: notice here that `carma exec` is uses only `.env` file from carma-config to open the container, which how it worked before. Using any other `.env` file is overengineering and not needed. `carma exec` has extra argument of `-i` to specify specific image anyways. 
     
- **OLD Behavior**: In most cases, if the user wants to change the image name/tags (or any other variable), they can simply modify the .env file and rebuild `<config-image>` or `carma config edit` and modify the `/opt/carma/vehicle/config/.env` file and restart. Or even hardcoding as before in the docker-compose.yml work as well without worrying about any `.env` files. However, they can now use different `.env` files now as mentioned before, which has higher precedence than the one in `<carma-config>` 
-  **OLD Behavior**: `carma` script is still backwards compatible to `<config-image>` before (and including) carma-system-4.5.0, which didn't have `.env` files. I accomplished it by keeping old relevant logics in `__get_image_from_config` (most new ones are backwards compatible anyways). 
NOTE: I suppressed some potential error messages that would have occured due to older versions as they are not errors (such as not finding `.env` file in `<config-image>` and there will be other actual error messages if there was an actual issue). 


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/ARC-82
<!-- e.g. CAR-123 -->

## Motivation and Context
During 4.5.0 release, we modifed the way DOCKER_ORG and DOCKER_TAG are specified by centralizing them into a single .env file in each carma-config folder for docker-compose.yml to load. However, currently, when a carma-config image is built by our GitHub Actions CI processes, the resulting image still contains the {DOCKER_ORG} and {DOCKER_TAG} environment variable placeholders in the docker-compose.yml and docker-compose-background.yml files. This breaks all of the `carma *` functionality of the carma shell script. 

Workaround: If .env file exists in the same directory from where `carma` is called, then everything works fine. However, this is not a desired functionality as we want to call carma from anywhere.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
locally in VM. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

I also updated [carma installation guide here](https://usdot-carma.atlassian.net/wiki/spaces/CRMPLT/pages/486178841/Setup+CARMA+Platform+Prerequisites) to use the most recent version of docker-compose instead of hardcoding it
