### PR TITLE
Update capabilities_interface.tpp

### DIFF
--- a/arbitrator/include/capabilities_interface.tpp
+++ b/arbitrator/include/capabilities_interface.tpp
@@ -27,7 +27,7 @@
 #include <thread>
 namespace arbitrator
 {
-    constexpr auto MAX_RETRY_ATTEMPTS {10};
+    constexpr auto MAX_RETRY_ATTEMPTS {2};
 
     template<typename MSrvReq, typename MSrvRes>
     std::map<std::string, std::shared_ptr<MSrvRes>>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Arbitrator is getting frozen due to too many repeated failed calls. 
With 500ms service call timeout, the arbitrator can only afford maximum 2 calls to satisfy 1hz operation. 
Arbitrator should at least retry 2nd time again because sometimes ROS service call can fail due to unknown error. 
Without retrying, the next planning will be after 1second, which is too late for some planning such as checking red light in lci_strategic_plugin.

<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/2385
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CAR-6039
<!-- e.g. CAR-123 -->

## Motivation and Context
Demos after 4.5.0 frequently encounter this issue by default because some nodes in ROS2 are not integration tested well but converted. This makes some of the nodes fail to activate or just due to host machine's performance, and repeated calls to such failed nodes freeze the arbitrator for up to 5 sec with 10 retry attempts.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
integration tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
