### PR TITLE
use correct volume in carma script

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -309,7 +309,7 @@ carma-config__install() {
     docker run --name carma-config-tmp $IMAGE_NAME
 
     # Extract the .env file content from the carma-config volume
-    docker run --rm --volumes-from carma-config:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
+    docker run --rm --volumes-from carma-config-tmp:ro busybox:latest cat /opt/carma/vehicle/config/.env > /tmp/.env 2>/dev/null  # suppress misleading error message that will occur for versions before 4.5.0
 
     # Extract DOCKER_ORG and DOCKER_TAG (and others) from the .env file
     set -o allexport
@@ -365,7 +365,7 @@ __get_compose_env_files() {
 
     # If user defined COMPOSE_ENV_FILES exists in the shell, it takes higher precedence over .env from carma-config and current directory .env
     if [ -n "${COMPOSE_ENV_FILES+x}" ]; then
-        echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES. 
+        echoerr "WARNING: COMPOSE_ENV_FILES is already defined in the shell: $COMPOSE_ENV_FILES.
             Setting it higher precedence than .env from carma-config and current directory .env (if it exists)"
         # This way, user defined COMPOSE_ENV_FILES still takes higher precedence.
         RETURN_COMPOSE_ENV_FILES="$RETURN_COMPOSE_ENV_FILES,$COMPOSE_ENV_FILES"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Issue is described in the jira link. But basically when `carma config install` is called, it created temporary volume of `carma-config-tmp` to read the `.env` file. 

However, currently it is mistakingly reading it from `carma-config` volume, instead of `carma-config-tmp`, which doesnt exist yet (or if existed, it would end up downloading previously set carma-config and not the one specified in install command). This PR fixes it with correct volume.

It was not caught before because I kept resetting or installing same images to verify. If different image was tested, I had tested 4.5.0 which doesnt use .env file. 

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/ARC-141
<!-- e.g. CAR-123 -->

## Motivation and Context
Fix for bug introduced in https://github.com/usdot-fhwa-stol/carma-platform/pull/2409
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
black pacifica and fusion vehicles
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
