### PR TITLE
Fix carma exec gui

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -575,6 +575,7 @@ carma__exec() {
     else
         docker run \
             -e DISPLAY=$DISPLAY \
+            --runtime=$RUNTIME \
             --group-add video \
             --volume=$XSOCK:$XSOCK:rw \
             --volume=$XAUTH:$XAUTH:rw \


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
When `carma exec --gui` is called with a command, it correctly sets up nvidia runtime (such as `carma exec --gui "rviz"`
However, if it is just `carma exec --gui` the script is not setting the nvidia runtime, so `nvidia-smi` for example won't work.
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CAR-6061
<!-- e.g. CAR-123 -->

## Motivation and Context
During porting of rviz to rviz2, I have been using a lot of container with gui enabled. And noticed this inconsistency between two similar calls of same thing.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
fusion vehicle pc
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
