### PR TITLE
Fix basic_autonomy unit test

### DIFF
--- a/basic_autonomy/src/basic_autonomy.cpp
+++ b/basic_autonomy/src/basic_autonomy.cpp
@@ -1318,6 +1318,7 @@ namespace basic_autonomy
             if (yield_plan.trajectory_points.size() < 2)
             {
                 RCLCPP_WARN(node_handler->get_logger(), "Invalid Yield Trajectory");
+                return false;
             }
 
             RCLCPP_DEBUG_STREAM(node_handler->get_logger(), "Yield Trajectory Time" << rclcpp::Time(yield_plan.trajectory_points[0].target_time).seconds());

--- a/basic_autonomy/test/test_waypoint_generation.cpp
+++ b/basic_autonomy/test/test_waypoint_generation.cpp
@@ -38,7 +38,7 @@ namespace basic_autonomy
 {
 
     // Test to ensure Eigen::Isometry2d behaves like tf2::Transform
-    TEST(BasicAutonomyTest, validate_eigen)
+    TEST(BasicAutonomyTest, DISABLED_validate_eigen)
     {
         Eigen::Rotation2Dd frame_rot(M_PI_2);
         lanelet::BasicPoint2d origin(1, 1);
@@ -68,7 +68,7 @@ namespace basic_autonomy
         ASSERT_NEAR(M_PI_2, P_in_A_rot.smallestAngle(), 0.000000001);
     }
 
-    TEST(BasicAutonomyTest, test_name)
+    TEST(BasicAutonomyTest, DISABLED_test_name)
     {
 
         lanelet::BasicPoint2d p1(0.0, 0.0);
@@ -113,7 +113,7 @@ namespace basic_autonomy
 
     }
 
-    TEST(BasicAutonomyTest, constrain_to_time_boundary)
+    TEST(BasicAutonomyTest, DISABLED_constrain_to_time_boundary)
     {
 
         std::vector<waypoint_generation::PointSpeedPair> points;
@@ -162,7 +162,7 @@ namespace basic_autonomy
         ASSERT_NEAR(1.0, time_bound_points[5].speed, 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, get_nearest_point_index)
+    TEST(BasicAutonomyTest, DISABLED_get_nearest_point_index)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
         std::vector<lanelet::BasicPoint2d> basic_points;
@@ -201,7 +201,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
-    TEST(BasicAutonomyTest, get_nearest_basic_point_index)
+    TEST(BasicAutonomyTest, DISABLED_get_nearest_basic_point_index)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
 
@@ -231,7 +231,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
-    TEST(BasicAutonomyTest, get_nearest_index_by_downtrack_with_nonempty_points)
+    TEST(BasicAutonomyTest, DISABLED_get_nearest_index_by_downtrack_with_nonempty_points)
     {
         // Create CARMA World Model with custom Guidance Test Map
         std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -268,7 +268,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
     }
 
-    TEST(BasicAutonomyTest, get_nearest_index_by_downtrack_with_empty_points)
+    TEST(BasicAutonomyTest, DISABLED_get_nearest_index_by_downtrack_with_empty_points)
     {
         // Create CARMA World Model with custom Guidance Test Map
         std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -284,7 +284,7 @@ namespace basic_autonomy
         ASSERT_EQ(-1, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
     }
 
-    TEST(BasicAutonomyTest, split_point_speed_pairs)
+    TEST(BasicAutonomyTest, DISABLED_split_point_speed_pairs)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
 
@@ -330,7 +330,7 @@ namespace basic_autonomy
         ASSERT_NEAR(1.0, speeds[5], 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, compute_fit)
+    TEST(BasicAutonomyTest, DISABLED_compute_fit)
     {
         ///////////////////////
         // Check straight line
@@ -431,7 +431,7 @@ namespace basic_autonomy
         ASSERT_TRUE(!!fit_s_curve);
     }
 
-    TEST(BasicAutonomyTest, optimize_speed)
+    TEST(BasicAutonomyTest, DISABLED_optimize_speed)
     {
         std::vector<double> downtracks, curv_speeds;
         downtracks.push_back(0);
@@ -518,7 +518,7 @@ namespace basic_autonomy
         ASSERT_NEAR(expected_results[8], test_results[8], 0.001);
     }
 
-    TEST(BasicAutonomyTest, compute_curvature_at)
+    TEST(BasicAutonomyTest, DISABLED_compute_curvature_at)
     {
         ///////////////////////
         // Check straight line
@@ -601,7 +601,7 @@ namespace basic_autonomy
         ASSERT_NEAR(waypoint_generation::compute_curvature_at((*fit_circle), 0.12), waypoint_generation::compute_curvature_at((*fit_circle), 0.76), 0.005);
     }
 
-    TEST(BasicAutonomyTest, attach_back_points)
+    TEST(BasicAutonomyTest, DISABLED_attach_back_points)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
         std::vector<waypoint_generation::PointSpeedPair> future_points;
@@ -642,7 +642,7 @@ namespace basic_autonomy
         ASSERT_NEAR(6.0, result[4].point.y(), 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, test_lanechange_trajectory)
+    TEST(BasicAutonomyTest, DISABLED_test_lanechange_trajectory)
     {
         //Case 1: Lane change from start to end of adjacent lanelets
         std::string path = ament_index_cpp::get_package_share_directory("basic_autonomy");
@@ -729,7 +729,7 @@ namespace basic_autonomy
 
     }
 
-    TEST(BasicAutonomyTest, maneuvers_to_lanechange_points)
+    TEST(BasicAutonomyTest, DISABLED_maneuvers_to_lanechange_points)
     {
 
         std::string path = ament_index_cpp::get_package_share_directory("basic_autonomy");
@@ -796,7 +796,7 @@ namespace basic_autonomy
         basic_autonomy::waypoint_generation::create_lanechange_geometry(start_id, end_id,starting_downtrack, ending_downtrack, cmw, 1, 5);
     }
 
-    TEST(BasicAutonomyTest, lanefollow_geometry_visited_lanelets)
+    TEST(BasicAutonomyTest, DISABLED_lanefollow_geometry_visited_lanelets)
     {
 
         double starting_downtrack = 0;
@@ -886,10 +886,6 @@ namespace basic_autonomy
                                                                                     detailed_config, visited_lanelets), std::invalid_argument);
     }
 
-    // These tests has been temporarily disabled to support Continuous Improvement (CI) processes.
-    // Related GitHub Issue: <https://github.com/usdot-fhwa-stol/carma-platform/issues/2335>
-
-    /**
     TEST(BasicAutonomyTest, test_verify_yield)
     {
         auto node = std::make_shared<carma_ros2_utils::CarmaLifecycleNode>(rclcpp::NodeOptions());
@@ -920,7 +916,7 @@ namespace basic_autonomy
         ASSERT_TRUE(basic_autonomy::waypoint_generation::is_valid_yield_plan(node, tp));
 
         carma_planning_msgs::msg::TrajectoryPlan tp2;
-
+        //Test insufficient trajectory points
         carma_planning_msgs::msg::TrajectoryPlanPoint point_4;
         point_4.x = 5.0;
         point_4.y = 0.0;
@@ -931,25 +927,24 @@ namespace basic_autonomy
         ASSERT_FALSE(basic_autonomy::waypoint_generation::is_valid_yield_plan(node, tp2));
 
         carma_planning_msgs::msg::TrajectoryPlan tp3;
-
+        // Test old trajectory
         carma_planning_msgs::msg::TrajectoryPlanPoint point_5;
         point_5.x = 5.0;
         point_5.y = 0.0;
-        point_5.target_time = startTime;
+        point_5.target_time = rclcpp::Time(0,0);
         point_5.lane_id = "1";
         tp3.trajectory_points.push_back(point_5);
 
         carma_planning_msgs::msg::TrajectoryPlanPoint point_6;
         point_6.x = 10.0;
         point_6.y = 0.0;
-        point_6.target_time = startTime + rclcpp::Duration(1, 0);
+        point_6.target_time = rclcpp::Time(1,0);
         point_6.lane_id = "1";
         tp3.trajectory_points.push_back(point_6);
 
-        ASSERT_FALSE(basic_autonomy::waypoint_generation::is_valid_yield_plan(node, tp2));
+        ASSERT_FALSE(basic_autonomy::waypoint_generation::is_valid_yield_plan(node, tp3));
 
     }
-*/
 
 } // namespace basic_autonomy
 

--- a/basic_autonomy/test/test_waypoint_generation.cpp
+++ b/basic_autonomy/test/test_waypoint_generation.cpp
@@ -38,7 +38,7 @@ namespace basic_autonomy
 {
 
     // Test to ensure Eigen::Isometry2d behaves like tf2::Transform
-    TEST(BasicAutonomyTest, DISABLED_validate_eigen)
+    TEST(BasicAutonomyTest, validate_eigen)
     {
         Eigen::Rotation2Dd frame_rot(M_PI_2);
         lanelet::BasicPoint2d origin(1, 1);
@@ -68,7 +68,7 @@ namespace basic_autonomy
         ASSERT_NEAR(M_PI_2, P_in_A_rot.smallestAngle(), 0.000000001);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_test_name)
+    TEST(BasicAutonomyTest, test_name)
     {
 
         lanelet::BasicPoint2d p1(0.0, 0.0);
@@ -113,7 +113,7 @@ namespace basic_autonomy
 
     }
 
-    TEST(BasicAutonomyTest, DISABLED_constrain_to_time_boundary)
+    TEST(BasicAutonomyTest, constrain_to_time_boundary)
     {
 
         std::vector<waypoint_generation::PointSpeedPair> points;
@@ -162,7 +162,7 @@ namespace basic_autonomy
         ASSERT_NEAR(1.0, time_bound_points[5].speed, 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_get_nearest_point_index)
+    TEST(BasicAutonomyTest, get_nearest_point_index)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
         std::vector<lanelet::BasicPoint2d> basic_points;
@@ -201,7 +201,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
-    TEST(BasicAutonomyTest, DISABLED_get_nearest_basic_point_index)
+    TEST(BasicAutonomyTest, get_nearest_basic_point_index)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
 
@@ -231,7 +231,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_point_index(points, state));
     }
 
-    TEST(BasicAutonomyTest, DISABLED_get_nearest_index_by_downtrack_with_nonempty_points)
+    TEST(BasicAutonomyTest, get_nearest_index_by_downtrack_with_nonempty_points)
     {
         // Create CARMA World Model with custom Guidance Test Map
         std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -268,7 +268,7 @@ namespace basic_autonomy
         ASSERT_EQ(3, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
     }
 
-    TEST(BasicAutonomyTest, DISABLED_get_nearest_index_by_downtrack_with_empty_points)
+    TEST(BasicAutonomyTest, get_nearest_index_by_downtrack_with_empty_points)
     {
         // Create CARMA World Model with custom Guidance Test Map
         std::shared_ptr<carma_wm::CARMAWorldModel> wm = std::make_shared<carma_wm::CARMAWorldModel>();
@@ -284,7 +284,7 @@ namespace basic_autonomy
         ASSERT_EQ(-1, waypoint_generation::get_nearest_index_by_downtrack(points, wm, target_downtrack));
     }
 
-    TEST(BasicAutonomyTest, DISABLED_split_point_speed_pairs)
+    TEST(BasicAutonomyTest, split_point_speed_pairs)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
 
@@ -330,7 +330,7 @@ namespace basic_autonomy
         ASSERT_NEAR(1.0, speeds[5], 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_compute_fit)
+    TEST(BasicAutonomyTest, compute_fit)
     {
         ///////////////////////
         // Check straight line
@@ -431,7 +431,7 @@ namespace basic_autonomy
         ASSERT_TRUE(!!fit_s_curve);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_optimize_speed)
+    TEST(BasicAutonomyTest, optimize_speed)
     {
         std::vector<double> downtracks, curv_speeds;
         downtracks.push_back(0);
@@ -518,7 +518,7 @@ namespace basic_autonomy
         ASSERT_NEAR(expected_results[8], test_results[8], 0.001);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_compute_curvature_at)
+    TEST(BasicAutonomyTest, compute_curvature_at)
     {
         ///////////////////////
         // Check straight line
@@ -601,7 +601,7 @@ namespace basic_autonomy
         ASSERT_NEAR(waypoint_generation::compute_curvature_at((*fit_circle), 0.12), waypoint_generation::compute_curvature_at((*fit_circle), 0.76), 0.005);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_attach_back_points)
+    TEST(BasicAutonomyTest, attach_back_points)
     {
         std::vector<waypoint_generation::PointSpeedPair> points;
         std::vector<waypoint_generation::PointSpeedPair> future_points;
@@ -642,7 +642,7 @@ namespace basic_autonomy
         ASSERT_NEAR(6.0, result[4].point.y(), 0.0000001);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_test_lanechange_trajectory)
+    TEST(BasicAutonomyTest, test_lanechange_trajectory)
     {
         //Case 1: Lane change from start to end of adjacent lanelets
         std::string path = ament_index_cpp::get_package_share_directory("basic_autonomy");
@@ -729,7 +729,7 @@ namespace basic_autonomy
 
     }
 
-    TEST(BasicAutonomyTest, DISABLED_maneuvers_to_lanechange_points)
+    TEST(BasicAutonomyTest, maneuvers_to_lanechange_points)
     {
 
         std::string path = ament_index_cpp::get_package_share_directory("basic_autonomy");
@@ -796,7 +796,7 @@ namespace basic_autonomy
         basic_autonomy::waypoint_generation::create_lanechange_geometry(start_id, end_id,starting_downtrack, ending_downtrack, cmw, 1, 5);
     }
 
-    TEST(BasicAutonomyTest, DISABLED_lanefollow_geometry_visited_lanelets)
+    TEST(BasicAutonomyTest, lanefollow_geometry_visited_lanelets)
     {
 
         double starting_downtrack = 0;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fixes an issue in basic_autonomy which causes yield plans to not be checked correctly.
Also fixes unit tests failing because of this invalid check. 
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
https://usdot-carma.atlassian.net/browse/CAR-6009

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
