### PR TITLE
Fix lci strategic plugin unit test

### DIFF
--- a/lci_strategic_plugin/test/test_strategic_plugin_helpers.cpp
+++ b/lci_strategic_plugin/test/test_strategic_plugin_helpers.cpp
@@ -35,12 +35,12 @@ TEST_F(LCIStrategicTestFixture, supportedLightState)
   ASSERT_TRUE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED));
   ASSERT_TRUE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PROTECTED_CLEARANCE));
   ASSERT_TRUE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::STOP_AND_REMAIN));
+  ASSERT_TRUE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED));
 
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::UNAVAILABLE));
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::DARK));
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::STOP_THEN_PROCEED));
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PRE_MOVEMENT));
-  ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED));
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::PERMISSIVE_CLEARANCE));
   ASSERT_FALSE(lcip->supportedLightState(lanelet::CarmaTrafficSignalState::CAUTION_CONFLICTING_TRAFFIC));
 }
@@ -100,12 +100,12 @@ TEST_F(LCIStrategicTestFixture, validLightState)
   ASSERT_TRUE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED), rclcpp::Time(1e9 * 1)));
   ASSERT_TRUE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PROTECTED_CLEARANCE), rclcpp::Time(1e9 * 1)));
   ASSERT_TRUE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::STOP_AND_REMAIN), rclcpp::Time(1e9 * 1)));
-  
+  ASSERT_TRUE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED), rclcpp::Time(1e9 * 1)));
+
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::UNAVAILABLE), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::DARK), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::STOP_THEN_PROCEED), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PRE_MOVEMENT), rclcpp::Time(1e9 * 1)));
-  ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::PERMISSIVE_CLEARANCE), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(std::pair<boost::posix_time::ptime, lanelet::CarmaTrafficSignalState>(dummy_time, lanelet::CarmaTrafficSignalState::CAUTION_CONFLICTING_TRAFFIC), rclcpp::Time(1e9 * 1)));
   ASSERT_FALSE(lcip->validLightState(boost::none, rclcpp::Time(1e9 * 1)));
@@ -176,7 +176,7 @@ TEST_F(LCIStrategicTestFixture, composeStopAndWaitManeuverMessage)
   ASSERT_EQ(carma_planning_msgs::msg::Maneuver::STOP_AND_WAIT, result.type);
   ASSERT_EQ(carma_planning_msgs::msg::ManeuverParameters::NO_NEGOTIATION, result.stop_and_wait_maneuver.parameters.negotiation_type);
   ASSERT_EQ(carma_planning_msgs::msg::ManeuverParameters::HAS_TACTICAL_PLUGIN | carma_planning_msgs::msg::ManeuverParameters::HAS_FLOAT_META_DATA,
-            result.stop_and_wait_maneuver.parameters.presence_vector);  
+            result.stop_and_wait_maneuver.parameters.presence_vector);
   ASSERT_TRUE(config.stop_and_wait_plugin_name.compare(
                   result.stop_and_wait_maneuver.parameters.planning_tactical_plugin) == 0);
   ASSERT_TRUE(
@@ -232,7 +232,7 @@ TEST_F(LCIStrategicTestFixture, findSpeedLimit)
   auto ll_iterator = cmw_->getMap()->laneletLayer.find(1200);
   if (ll_iterator == cmw_->getMap()->laneletLayer.end())
     FAIL() << "Expected lanelet not present in map. Unit test may not be structured correctly";
-  
+
   ASSERT_NEAR(11.176, lcip->findSpeedLimit(*ll_iterator), 0.00001);
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR fixes failing unit tests in lci strategic plugin following an update to the logic in https://github.com/usdot-fhwa-stol/carma-platform/commit/905f3009574ee4ef97f7158a0accac69a508db44.

## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
