### PR TITLE
Fix rosbag2 with size 0 in humble

### DIFF
--- a/carma/launch/ros2_rosbag.launch.py
+++ b/carma/launch/ros2_rosbag.launch.py
@@ -32,7 +32,7 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
     vehicle_config_param_file_string = context.perform_substitution(vehicle_config_param_file)
 
     # Initialize string that will contain the regex for topics to exclude from the ROS 2 rosbag
-    exclude_topics = []  # Use a list instead of concatenating strings with |
+    exclude_topics = []
 
     overriding_qos_profiles = context.perform_substitution(rosbag2_qos_override_param_file)
 
@@ -62,9 +62,6 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
 
                 # Join the topics with | to create a proper regex
                 exclude_topics_regex = "|".join(exclude_topics) if exclude_topics else ""
-
-                # Debug print
-                print(f"Excluding topics with regex: {exclude_topics_regex}")
 
                 proc = ExecuteProcess(
                         cmd=['ros2', 'bag', 'record', '-a', '-s', 'mcap',

--- a/carma/launch/ros2_rosbag.launch.py
+++ b/carma/launch/ros2_rosbag.launch.py
@@ -31,7 +31,7 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
     # Convert LaunchConfiguration object to its string representation
     vehicle_config_param_file_string = context.perform_substitution(vehicle_config_param_file)
 
-    # Initialize string that will contain the regex for topics to exclude from the ROS 2 rosbag
+    # Initialize an array that will contain the regex for topics to exclude from the ROS 2 rosbag
     exclude_topics = []
 
     overriding_qos_profiles = context.perform_substitution(rosbag2_qos_override_param_file)

--- a/carma/launch/ros2_rosbag.launch.py
+++ b/carma/launch/ros2_rosbag.launch.py
@@ -64,11 +64,13 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
                         for topic in vehicle_config_params["excluded_can_topics"]:
                             exclude_topics_regex += str(topic) + "|"
 
+                print(f"Recording these: {exclude_topics_regex}")
                 proc = ExecuteProcess(
                         cmd=['ros2', 'bag', 'record', '-a', '-s', 'mcap',
                             '--qos-profile-overrides-path', overriding_qos_profiles,
                             '-o', '/opt/carma/logs/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S')),
-                            '-x', exclude_topics_regex],
+                            '-x', exclude_topics_regex
+                            ],
                         output='screen',
                         shell='true'
                     )

--- a/carma/launch/ros2_rosbag.launch.py
+++ b/carma/launch/ros2_rosbag.launch.py
@@ -32,7 +32,7 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
     vehicle_config_param_file_string = context.perform_substitution(vehicle_config_param_file)
 
     # Initialize string that will contain the regex for topics to exclude from the ROS 2 rosbag
-    exclude_topics_regex = ""
+    exclude_topics = []  # Use a list instead of concatenating strings with |
 
     overriding_qos_profiles = context.perform_substitution(rosbag2_qos_override_param_file)
 
@@ -46,31 +46,31 @@ def record_ros2_rosbag(context: LaunchContext, vehicle_config_param_file, rosbag
 
                 if "exclude_default" in vehicle_config_params:
                     if (vehicle_config_params["exclude_default"] == True) and ("excluded_default_topics" in vehicle_config_params):
-                        for topic in vehicle_config_params["excluded_default_topics"]:
-                            exclude_topics_regex += str(topic) + "|"
+                        exclude_topics.extend(vehicle_config_params["excluded_default_topics"])
 
                 if "exclude_lidar" in vehicle_config_params:
                     if (vehicle_config_params["exclude_lidar"] == True) and ("excluded_lidar_topics" in vehicle_config_params):
-                        for topic in vehicle_config_params["excluded_lidar_topics"]:
-                            exclude_topics_regex += str(topic) + "|"
+                        exclude_topics.extend(vehicle_config_params["excluded_lidar_topics"])
 
                 if "exclude_camera" in vehicle_config_params:
                     if (vehicle_config_params["exclude_camera"] == True) and ("excluded_camera_topics" in vehicle_config_params):
-                        for topic in vehicle_config_params["excluded_camera_topics"]:
-                            exclude_topics_regex += str(topic) + "|"
+                        exclude_topics.extend(vehicle_config_params["excluded_camera_topics"])
 
                 if "exclude_can" in vehicle_config_params:
                     if (vehicle_config_params["exclude_can"] == True) and ("excluded_can_topics" in vehicle_config_params):
-                        for topic in vehicle_config_params["excluded_can_topics"]:
-                            exclude_topics_regex += str(topic) + "|"
+                        exclude_topics.extend(vehicle_config_params["excluded_can_topics"])
 
-                print(f"Recording these: {exclude_topics_regex}")
+                # Join the topics with | to create a proper regex
+                exclude_topics_regex = "|".join(exclude_topics) if exclude_topics else ""
+
+                # Debug print
+                print(f"Excluding topics with regex: {exclude_topics_regex}")
+
                 proc = ExecuteProcess(
                         cmd=['ros2', 'bag', 'record', '-a', '-s', 'mcap',
                             '--qos-profile-overrides-path', overriding_qos_profiles,
                             '-o', '/opt/carma/logs/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S')),
-                            '-x', exclude_topics_regex
-                            ],
+                            '-x', exclude_topics_regex],
                         output='screen',
                         shell='true'
                     )


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
When we switched to Humble, rosbag2 started not recording anymore. 
`rosbag2 record -a -s mcap` works fine which means the issue is the regex. 
Previous regex had trailing `|` in the end, which is causing the issue:
```
(.*)/received_messages|(.*)/sent_messages|(.*)/scan|/detection/lidar_detector/objects|/detection/lidar_detector/objects_markers|/hardware_interface/lidar/points_raw|/hardware_interface/camera/projection_matrix/detection/lidar_detector/cloud_clusters|/environment/range_vision_fusion_01/detection/lidar_detector/objects|/environment/detection/fusion_tools/objects|/environment/detection/fusion_tools/objects_markers|/environment/detection/object_tracker/objects|/environment/detection/object_tracker/objects_markers|/environment/detection/objects|/hardware_interface/camera/camera_info|/hardware_interface/camera/image_raw|/hardware_interface/camera/image_rect|/hardware_interface/camera/image_rects|/hardware_interface/camera/projection_matrix/detection/lidar_detector/cloud_clusters|/environment/range_vision_fusion_01/detection/image_detector/objects|/environment/vision_beyond_track_01/detection/image_detector/objects|/environment/detection/fusion_tools/objects|/environment/detection/fusion_tools/objects_markers|/environment/detection/object_tracker/objects|/environment/detection/object_tracker/objects_markers|/environment/detection/objects|
```

While new regex now doesn't have that, which makes it work fine:

```
(.*)/received_messages|(.*)/sent_messages|(.*)/scan|/detection/lidar_detector/objects|/detection/lidar_detector/objects_markers|/hardware_interface/lidar/points_raw|/hardware_interface/camera/projection_matrix/detection/lidar_detector/cloud_clusters|/environment/range_vision_fusion_01/detection/lidar_detector/objects|/environment/detection/fusion_tools/objects|/environment/detection/fusion_tools/objects_markers|/environment/detection/object_tracker/objects|/environment/detection/object_tracker/objects_markers|/environment/detection/objects|/hardware_interface/camera/camera_info|/hardware_interface/camera/image_raw|/hardware_interface/camera/image_rect|/hardware_interface/camera/image_rects|/hardware_interface/camera/projection_matrix/detection/lidar_detector/cloud_clusters|/environment/range_vision_fusion_01/detection/image_detector/objects|/environment/vision_beyond_track_01/detection/image_detector/objects|/environment/detection/fusion_tools/objects|/environment/detection/fusion_tools/objects_markers|/environment/detection/object_tracker/objects|/environment/detection/object_tracker/objects_markers|/environment/detection/objects
```
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
ARC-179
## Motivation and Context
ROS2 humble upgrade
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
SIM PC 1 development image
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
