### PR TITLE
Fix predicted state being far away from the object's location

### DIFF
--- a/motion_computation/src/psm_to_external_object_convertor.cpp
+++ b/motion_computation/src/psm_to_external_object_convertor.cpp
@@ -214,16 +214,11 @@ void convert(
 
   std::vector<geometry_msgs::msg::Pose> predicted_poses;
 
-  if (in_msg.presence_vector & carma_v2x_msgs::msg::PSM::HAS_PATH_PREDICTION) {
-    // Based on the vehicle frame used in j2735 positive should be to the right
-    // and negative to the left
-    predicted_poses = impl::sample_2d_path_from_radius(
-      out_msg.pose.pose, out_msg.velocity.twist.linear.x,
-      -in_msg.path_prediction.radius_of_curvature, pred_period, pred_step_size);
-  } else {
-    predicted_poses = impl::sample_2d_linear_motion(
-      out_msg.pose.pose, out_msg.velocity.twist.linear.x, pred_period, pred_step_size);
-  }
+  // TODO: For demo purpose, we are forcing linear motion prediction temporarily
+  // by ignoring psm.path_prediction.radius_of_curvature field of the PSM
+  predicted_poses = impl::sample_2d_linear_motion(
+    out_msg.pose.pose, out_msg.velocity.twist.linear.x, pred_period, pred_step_size);
+
 
   out_msg.predictions = impl::predicted_poses_to_predicted_state(
     predicted_poses, out_msg.velocity.twist.linear.x, rclcpp::Time(out_msg.header.stamp),
@@ -306,16 +301,14 @@ std::vector<geometry_msgs::msg::Pose> sample_2d_linear_motion(
   double total_dt = 0;
 
   while (total_dt < period) {
-    // Compute the 2d position and orientation in the Pose frame
+    // Increment time
     total_dt += step_size;
-    double dx_from_start = velocity * total_dt;  // Assuming linear motion in pose frame
+    double distance = velocity * total_dt;  // Total distance traveled
 
-    double x = pose.position.x + dx_from_start;
+    // Create a transform that moves forward along the local x-axis by 'distance'
+    tf2::Transform pose_to_sample(tf2::Quaternion::getIdentity(), tf2::Vector3(distance, 0, 0));
 
-    tf2::Vector3 position(x, 0, 0);
-
-    // Convert the position and orientation in the pose frame to the map frame
-    tf2::Transform pose_to_sample(tf2::Quaternion::getIdentity(), position);
+    // Transform to map coordinates
     tf2::Transform map_to_sample = pose_in_map * pose_to_sample;
 
     geometry_msgs::msg::Pose sample_pose;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes an issue where the predicted state of an object from PSM is far away from itself:
![image](https://github.com/user-attachments/assets/277a08fc-fb0a-495e-b1e9-a8278d6162e4)

This is because the old code was adding pose's x value to the predicted state again, which is random and incorrect if are using 2 transforms of Pose_TF * Predicted_state_dist_to_travel_TF. 


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Found this during VIP demo prep using PSM
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
With mock PSM's
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
