### PR TITLE
Make pedestrian icon to have a constant orientation

### DIFF
--- a/object_visualizer/src/object_visualizer_node.cpp
+++ b/object_visualizer/src/object_visualizer_node.cpp
@@ -120,12 +120,10 @@ namespace object_visualizer
     marker.pose = pose;
 
     // Rotate the pose by 180 degrees around the Z axis to fix the STL asset's orientation
-    tf2::Quaternion q;
-    tf2::fromMsg(pose.orientation, q);
+    // Use fixed orientation
     tf2::Quaternion rotation;
     rotation.setRPY(0, 0, M_PI); // Rotate 180 degrees (π radians) around Z
-    q = rotation * q; // Apply rotation
-    marker.pose.orientation = tf2::toMsg(q);
+    marker.pose.orientation = tf2::toMsg(rotation);
 
     if (config_.use_pedestrian_icon && !config_.pedestrian_icon_path.empty()) {
       // Use a mesh resource marker for pedestrian representation

--- a/object_visualizer/src/object_visualizer_node.cpp
+++ b/object_visualizer/src/object_visualizer_node.cpp
@@ -135,7 +135,7 @@ namespace object_visualizer
 
       // Scale the pedestrian mesh appropriately
       marker.scale.x = config_.pedestrian_icon_scale;
-      marker.scale.y = config_.pedestrian_icon_scale;
+      marker.scale.y = - config_.pedestrian_icon_scale; // Invert Y to fix the STL orientation
       marker.scale.z = config_.pedestrian_icon_scale;
 
       // White color for the pedestrian icon


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
We wanted to fixthe orientation of the pedestrian to fit our desired narrative of our demo. New orientation:
<!--- Describe your changes in detail -->
![image](https://github.com/user-attachments/assets/4d47d99f-9f1b-4a8d-a7a1-ed61a25956d1)


## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
VIP demo
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
