### PR TITLE
Update BSM Generator to correctly pull heading from orientation in Cu…

### DIFF
--- a/bsm_generator/include/bsm_generator/bsm_generator_node.hpp
+++ b/bsm_generator/include/bsm_generator/bsm_generator_node.hpp
@@ -32,6 +32,8 @@
 #include <vector>
 
 #include <carma_ros2_utils/carma_lifecycle_node.hpp>
+#include <tf2/LinearMath/Transform.h>
+
 #include "bsm_generator/bsm_generator_worker.hpp"
 #include "bsm_generator/bsm_generator_config.hpp"
 

--- a/bsm_generator/include/bsm_generator/bsm_generator_worker.hpp
+++ b/bsm_generator/include/bsm_generator/bsm_generator_worker.hpp
@@ -21,6 +21,9 @@
 #include <vector>
 #include <climits>
 #include <random>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 
 namespace bsm_generator
 {
@@ -107,6 +110,10 @@ namespace bsm_generator
              * \return Vehicle heading value (minimum limit is 0.0, maximum limit is 359.9875)
              */
             float getHeadingInRange(const float heading);
+            /**
+             * \brief Function to convert a quaternion to a positive NED heading value
+             */
+            float getHeading(const geometry_msgs::msg::Quaternion & quaternion);
 
         private:
             // Random number generator for BSM id

--- a/bsm_generator/package.xml
+++ b/bsm_generator/package.xml
@@ -38,6 +38,9 @@
   <depend>j2735_v2x_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>lanelet2_io</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/bsm_generator/src/bsm_generator_node.cpp
+++ b/bsm_generator/src/bsm_generator_node.cpp
@@ -87,8 +87,6 @@ namespace bsm_generator
                                                               std::bind(&BSMGenerator::steerWheelAngleCallback, this, std_ph::_1));
     brake_sub_ = create_subscription<std_msgs::msg::Float64>("brake_position", 1,
                                                               std::bind(&BSMGenerator::brakeCallback, this, std_ph::_1));
-    heading_sub_ = create_subscription<gps_msgs::msg::GPSFix>("gnss_fix_fused", 1,
-                                                              std::bind(&BSMGenerator::headingCallback, this, std_ph::_1));
     georeference_sub_ = create_subscription<std_msgs::msg::String>("georeference", 1,
                                                               std::bind(&BSMGenerator::georeferenceCallback, this, std_ph::_1));
 
@@ -181,9 +179,12 @@ namespace bsm_generator
     bsm_.core_data.longitude = coord.lon;
     bsm_.core_data.latitude = coord.lat;
     bsm_.core_data.elev = coord.ele;
+    
+    bsm_.core_data.heading = worker->getHeadingInRange(static_cast<float>(worker->getHeading(msg->pose.orientation)));
     bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.LONGITUDE_AVAILABLE;
     bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.LATITUDE_AVAILABLE;
     bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.ELEVATION_AVAILABLE;
+    bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.HEADING_AVAILABLE;
   }
 
   void BSMGenerator::headingCallback(const gps_msgs::msg::GPSFix::UniquePtr msg)

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -97,4 +97,29 @@ namespace bsm_generator
     {
         return std::max(std::min(heading, 359.9875f), 0.0f);
     }
+
+    float BSMGeneratorWorker::getHeading(const geometry_msgs::msg::Quaternion & quaternion)
+    {
+        tf2::Quaternion orientation;
+        orientation.setX(quaternion.x);
+        orientation.setY(quaternion.y);
+        orientation.setZ(quaternion.z);
+        orientation.setW(quaternion.w);
+      
+        double roll;
+        double pitch;
+        double yaw;
+        tf2::Matrix3x3(orientation).getRPY(roll, pitch, yaw);
+        // Convert yaw radians to degrees
+        yaw = yaw * 180 / M_PI;
+        // Convert to NED frame
+        yaw = -yaw+90;
+        // Convert to range [0, 360]
+        yaw = std::fmod(yaw, 360.0);
+        if ( yaw < 0  )
+        {
+          yaw = 360 + yaw;
+        }
+        return static_cast<float>(yaw);
+    }
 } // namespace bsm_generator

--- a/bsm_generator/test/test_bsm_generator_worker.cpp
+++ b/bsm_generator/test/test_bsm_generator_worker.cpp
@@ -107,6 +107,21 @@ TEST(BSMWorkerTest, testHeading)
     EXPECT_NEAR(300.001f, worker.getHeadingInRange(300.001f), 0.0001);
 }
 
+TEST(BSMWorkerTest, testHeading) {
+    bsm_generator::BSMGeneratorWorker worker;
+    geometry_msgs::msg::Quaternion q;
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.0;
+    q.w = 1.0;
+    EXPECT_NEAR(0.0f, worker.getHeading(q), 0.0001);
+    q.x = 1.0;
+    EXPECT_NEAR(90.0f, worker.getHeading(q), 0.0001);
+    q.x = 0.7071;
+    q.y = 0.7071;
+    EXPECT_NEAR(45.0f, worker.getHeading(q), 0.0001);
+}
+
 int main(int argc, char ** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/bsm_generator/test/test_bsm_generator_worker.cpp
+++ b/bsm_generator/test/test_bsm_generator_worker.cpp
@@ -99,7 +99,7 @@ TEST(BSMWorkerTest, testBrakeAppliedStatus)
     EXPECT_EQ(0, worker.getBrakeAppliedStatus(0));
 }
 
-TEST(BSMWorkerTest, testHeading)
+TEST(BSMWorkerTest, testHeadingInRange)
 {
     bsm_generator::BSMGeneratorWorker worker;
     EXPECT_NEAR(359.9875f, worker.getHeadingInRange(360.0f), 0.0001);
@@ -110,16 +110,56 @@ TEST(BSMWorkerTest, testHeading)
 TEST(BSMWorkerTest, testHeading) {
     bsm_generator::BSMGeneratorWorker worker;
     geometry_msgs::msg::Quaternion q;
+    // Yaw of 0 degrees ENU or 90 degrees NED
     q.x = 0.0;
     q.y = 0.0;
     q.z = 0.0;
     q.w = 1.0;
-    EXPECT_NEAR(0.0f, worker.getHeading(q), 0.0001);
-    q.x = 1.0;
-    EXPECT_NEAR(90.0f, worker.getHeading(q), 0.0001);
-    q.x = 0.7071;
-    q.y = 0.7071;
-    EXPECT_NEAR(45.0f, worker.getHeading(q), 0.0001);
+    EXPECT_FLOAT_EQ(90.0, worker.getHeading(q));
+    // Yaw of 45 degrees ENU or 45 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.3826834;
+    q.w = 0.9238795;
+    EXPECT_FLOAT_EQ(45.0, worker.getHeading(q));
+    // Yaw of 90 degrees ENU or 0 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.7071;
+    q.w = 0.7071;
+    EXPECT_FLOAT_EQ(0.0, worker.getHeading(q));
+    // Yaw of 135 degrees ENU or 315 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.9238795;
+    q.w = 0.3826834;
+    EXPECT_FLOAT_EQ(315.0, worker.getHeading(q));
+    // Yaw of 180 degrees ENU or 270 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 1;
+    q.w = 0.0;
+    EXPECT_FLOAT_EQ(270.0, worker.getHeading(q));
+    // Yaw of 225 degrees ENU or 225 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.9238795;
+    q.w = -0.3826834;
+    EXPECT_FLOAT_EQ(225.0, worker.getHeading(q));
+    // Yaw of 270 degrees ENU or 180 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.7071;
+    q.w = -0.7071;
+    EXPECT_FLOAT_EQ(180.0, worker.getHeading(q));
+    // Yaw of 315 degrees ENU or 135 degrees NED
+    q.x = 0.0;
+    q.y = 0.0;
+    q.z = 0.3826834;
+    q.w = -0.9238795;
+    EXPECT_FLOAT_EQ(135.0, worker.getHeading(q));
+   
+
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update BSM Generator to pull heading from Pose since this should work both in SIM and in Vehicle
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
TT-177
<!-- e.g. CAR-123 -->

## Motivation and Context
Fix BSM heading in SIM
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
