### PR TITLE
edits to make motion computation publish predictions when external ob…

### DIFF
--- a/motion_computation/config/parameters.yaml
+++ b/motion_computation/config/parameters.yaml
@@ -22,7 +22,7 @@ enable_bsm_processing: false
 
 # Boolean: If true then PSM messages will be converted to ExternalObjects.
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_psm_processing: false
+enable_psm_processing: true
 
 # Boolean: If true then MobilityPath messages will be converted to ExternalObjects.
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
@@ -30,7 +30,7 @@ enable_mobility_path_processing: false
 
 # Boolean: If true then ExternalObjects generated from sensor data will be processed.
 #          If other object sources are enabled, they will be synchronized but no fusion will occur (objects may be duplicated)
-enable_sensor_processing: false
+enable_sensor_processing: true
 
 # Boolean: True if CTRV motion model should be used for the object type. False, if CV should be used:
 enable_ctrv_for_unknown_obj: true

--- a/motion_computation/src/motion_computation_worker.cpp
+++ b/motion_computation/src/motion_computation_worker.cpp
@@ -36,7 +36,7 @@ void MotionComputationWorker::predictionLogic(
   carma_perception_msgs::msg::ExternalObjectList sensor_list;
   sensor_list.header = obj_list->header;
 
-  if (!obj_list || obj_list->objects.empty()) {
+  if (!obj_list) {
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR fixes an issue in motion_computation node where the motion computation prediction logic is rejected when the external_object topic comes in as empty.

This is not desired behavior since processing for other message types should happen even in the absence of detected sensor objects.
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
