### PR TITLE
Workaround to fix issue where sometimes cooperative_lanechange doesn't plan trajectory ahead

### DIFF
--- a/cooperative_lanechange/config/parameters.yaml
+++ b/cooperative_lanechange/config/parameters.yaml
@@ -74,7 +74,7 @@ min_timestep : 0.1
 
 # Double:  The range from the start from which the plugin can start working
 # Units: meters
-starting_downtrack_range : 5.0
+starting_downtrack_range : 10.0
 
 # Double: Fraction of the maneuver that has been completed. Starting fraction specifies a higher urgency of in the request to lane change
 starting_fraction : 0.2


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
During preparation of vip demo on 4/24/2025, we discovered that CLC doesn't get planned ahead for certain map configuration. 

It was first discovered in basic travel simulator where the vehicle travels to west and through workzone event on innovation drive. Vehicle only planned lanechange trajectory when it passed the starting location of lanechange. Currently it is unknown why the plugin doesn't plan ahead, but increasing this `starting_downtrack_range` works.

In real life vehicle, same map actually ended up being okay sometimes, but sometimes it doesn't. So the starting location or the variance of real life GPS might be affecting it.

This PR currently increases the default value, so that the upcoming demos work without issue at least.


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CAR-6122
Discovered the issue in https://usdot-carma.atlassian.net/browse/VOI-441
Which has a video of the issue
<!-- e.g. CAR-123 -->

## Motivation and Context
Workzone demo for vip client on 04/24/2025
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Demoed on BP and WP
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
