### PR TITLE
Fix cellular connection between CARMA Platform and CARMA Cloud

### DIFF
--- a/carma/launch/message.launch.py
+++ b/carma/launch/message.launch.py
@@ -211,10 +211,10 @@ def generate_launch_description():
     # Info needed for opening the tunnels
     # TODO: Investigate if this can be further cleaned up
     REMOTE_USER="ubuntu"
-    REMOTE_ADDR="www.carma-cloud.com"
-    KEY_FILE="carma-cloud-test-1.pem"
+    REMOTE_ADDR="carma-cloud.com" # Dev instance is www.carma-cloud.com, prod instance is carma-cloud.com
+    KEY_FILE="carma-cloud-1.pem" # Dev key is carma-cloud-test-1.pem, prod key is carma-cloud-1.pem
     HOST_PORT="33333" # This port is forwarded to remote host (carma-cloud)
-    REMOTE_PORT="10001" # This port is forwarded to local host
+    REMOTE_PORT="22222" # This port is forwarded to local host
     param_launch_path = os.path.join(
         get_package_share_directory('carma_cloud_client'), 'launch/scripts')
 
@@ -247,5 +247,3 @@ def generate_launch_description():
         carma_v2x_container,
         subsystem_controller
     ])
-
-

--- a/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
+++ b/carma_cloud_client/include/carma_cloud_client/carma_cloud_client_config.hpp
@@ -28,7 +28,7 @@ namespace carma_cloud_client
   struct Config
   {
     //host machine IP
-    std::string url ="http://127.0.0.1:"; 
+    std::string url ="http://127.0.0.1:";
     std::string base_hb = "/carmacloud/v2xhub";
     //URL for traffic control request
     std::string base_req = "/carmacloud/tcmreq";
@@ -43,7 +43,7 @@ namespace carma_cloud_client
     int fetchtime = 15;
 
     uint16_t webport = 22222;
-	  std::string webip = "WebServiceIP";
+    std::string webip = "WebServiceIP";
 
     // Stream operator for this config
     friend std::ostream &operator<<(std::ostream &output, const Config &c)
@@ -57,6 +57,8 @@ namespace carma_cloud_client
            << "list: " << c.list << std::endl
            << "fetchtime: " << c.fetchtime << std::endl
            << "method: " << c.method << std::endl
+           << "webport: " << c.webport << std::endl
+           << "webip: " << c.webip << std::endl
            << "}" << std::endl;
       return output;
     }

--- a/carma_cloud_client/launch/carma_cloud_client_launch.py
+++ b/carma_cloud_client/launch/carma_cloud_client_launch.py
@@ -33,21 +33,21 @@ This file is can be used to launch the CARMA carma_cloud_client_node.
 def open_tunnels():
 
     REMOTE_USER="ubuntu"
-    REMOTE_ADDR="www.carma-cloud.com"
-    KEY_FILE="carma-cloud-test-1.pem"
+    REMOTE_ADDR="carma-cloud.com" # Dev instance is www.carma-cloud.com, prod instance is carma-cloud.com
+    KEY_FILE="carma-cloud-1.pem" # Dev key is carma-cloud-test-1.pem, prod key is carma-cloud-1.pem
     HOST_PORT="33333" # This port is forwarded to remote host (carma-cloud)
-    REMOTE_PORT="33333" # This port is forwarded to local host 
+    REMOTE_PORT="22222" # This port is forwarded to local host
 
     param_launch_path = os.path.join(
         get_package_share_directory('carma_cloud_client'), 'launch/scripts')
-        
-    
+
+
     cmd = param_launch_path + '/open_tunnels.sh'
 
     subprocess.check_call(['chmod','u+x', cmd])
 
     key_path = "/opt/carma/vehicle/calibration/cloud_permission"
-    
+
     key = key_path + '/' + KEY_FILE
 
     subprocess.check_call(['sudo','chmod','400', key])
@@ -61,12 +61,12 @@ def generate_launch_description():
     log_level = LaunchConfiguration('log_level')
     declare_log_level_arg = DeclareLaunchArgument(
         name ='log_level', default_value='WARN')
-    
+
     # Get parameter file path
     param_file_path = os.path.join(
         get_package_share_directory('carma_cloud_client'), 'config/parameters.yaml')
 
-        
+
     # Launch node(s) in a carma container to allow logging to be configured
     container = ComposableNodeContainer(
         package='carma_ros2_utils',
@@ -74,7 +74,7 @@ def generate_launch_description():
         namespace=GetCurrentNamespace(),
         executable='carma_component_container_mt',
         composable_node_descriptions=[
-            
+
             # Launch the core node(s)
             ComposableNode(
                     package='carma_cloud_client',

--- a/carma_cloud_client/launch/scripts/call.sh
+++ b/carma_cloud_client/launch/scripts/call.sh
@@ -1,7 +1,7 @@
 
 REMOTE_USER="ubuntu";
-REMOTE_ADDR="carma-cloud.com";
-KEY_FILE="carma-cloud-1.pem";
+REMOTE_ADDR="carma-cloud.com"; # Dev instance is www.carma-cloud.com, prod instance is carma-cloud.com
+KEY_FILE="carma-cloud-1.pem"; # Dev key is carma-cloud-test-1.pem, prod key is carma-cloud-1.pem
 HOST_PORT="33333"; # This port is forwarded to remote host (carma-cloud) and port: 8080
 REMOTE_PORT="22222"; # This port is forwarded to local host (v2xhub) and port: 22222
 sudo ./open_tunnels.sh -u $REMOTE_USER -a $REMOTE_ADDR -r $HOST_PORT -k $KEY_FILE -p $REMOTE_PORT

--- a/carma_cloud_client/launch/scripts/call.sh
+++ b/carma_cloud_client/launch/scripts/call.sh
@@ -3,5 +3,5 @@ REMOTE_USER="ubuntu";
 REMOTE_ADDR="carma-cloud.com";
 KEY_FILE="carma-cloud-1.pem";
 HOST_PORT="33333"; # This port is forwarded to remote host (carma-cloud) and port: 8080
-REMOTE_PORT="10001"; # This port is forwarded to local host (v2xhub) and port: 22222
+REMOTE_PORT="22222"; # This port is forwarded to local host (v2xhub) and port: 22222
 sudo ./open_tunnels.sh -u $REMOTE_USER -a $REMOTE_ADDR -r $HOST_PORT -k $KEY_FILE -p $REMOTE_PORT

--- a/carma_cloud_client/launch/scripts/call.sh
+++ b/carma_cloud_client/launch/scripts/call.sh
@@ -1,8 +1,7 @@
 
 REMOTE_USER="ubuntu";
-REMOTE_ADDR="www.carma-cloud.com";
-KEY_FILE="carma-cloud-test-1.pem";
+REMOTE_ADDR="carma-cloud.com";
+KEY_FILE="carma-cloud-1.pem";
 HOST_PORT="33333"; # This port is forwarded to remote host (carma-cloud) and port: 8080
 REMOTE_PORT="10001"; # This port is forwarded to local host (v2xhub) and port: 22222
 sudo ./open_tunnels.sh -u $REMOTE_USER -a $REMOTE_ADDR -r $HOST_PORT -k $KEY_FILE -p $REMOTE_PORT
-# sudo ./open_tunnels.sh -u ubuntu -a carma-cloud.com -r 33333 -k carma-cloud-1.pem -p 10001

--- a/carma_cloud_client/launch/scripts/open_tunnels.sh
+++ b/carma_cloud_client/launch/scripts/open_tunnels.sh
@@ -51,10 +51,10 @@ if sudo lsof -t -i:$HOST_PORT >/dev/null; then
 fi
 
 
-# Open forward tunnel: This port (33333) is forwarded to remote host (carma-cloud) and port: 8080 
+# Open forward tunnel: This port (33333) is forwarded to remote host (carma-cloud) and port: 8080
 echo "Open forward tunnel..."
 
-CMD="/usr/bin/ssh -4 -f -i $KEY_FILE -L $HOST_PORT:localhost:8080 -N -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o UserKnownHostsFile=/dev/null -o LogLevel=quiet $REMOTE_USER@$REMOTE_ADDR" # -f runs ssh in background after it authenticates, -N creates a tunnel without running remote commands to save resources, -T disables pseudo-tty allocation 
+CMD="/usr/bin/ssh -4 -f -i $KEY_FILE -L $HOST_PORT:localhost:8080 -N -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o UserKnownHostsFile=/dev/null -o LogLevel=quiet $REMOTE_USER@$REMOTE_ADDR" # -f runs ssh in background after it authenticates, -N creates a tunnel without running remote commands to save resources, -T disables pseudo-tty allocation
 ps -x -o pid,cmd | grep "$CMD" > $TEMP_FILE # write the contents of the ps command to a file, it only prints the pid and the command line command used to create the entry
 while read -r line; do # read the lines of the file with ps command
     case "$line" in
@@ -73,12 +73,12 @@ done < $TEMP_FILE
 rm $TEMP_FILE
 exec $CMD &> /dev/null  # create the new tunnel
 
-if [ "$?" -eq 0 ]; then  
-     echo "Forward tunnel is successfully opened!" 
+if [ "$?" -eq 0 ]; then
+     echo "Forward tunnel is successfully opened!"
 fi
 
 if sudo lsof -t -i:$HOST_PORT >/dev/null; then
-    echo "Forward tunnel is successfully opened!"  
+    echo "Forward tunnel is successfully opened!"
 fi
 
 
@@ -90,7 +90,7 @@ if ssh -i  $KEY_FILE  $REMOTE_USER@$REMOTE_ADDR "sudo lsof -Pi:$REMOTE_PORT -sTC
     echo "Closed exiting remote port $REMOTE_PORT"
 fi
 
-# open reverse tunnel:  carma-cloud remote port (10001) is forwarded to local host (v2xhub) and port: 22222
+# open reverse tunnel:  carma-cloud remote port (22222) is forwarded to local host (v2xhub) and port: 22222
 echo "Open reverse tunnel..."
 
 # open http tunnel, port-forwarding from  REMOTE_PORT to port 22222 (222222: running in v2xhub)
@@ -115,8 +115,8 @@ exec $CMD &> /dev/null  # create the new tunnel
 
 
 
-if [ "$?" -eq 0 ]; then   
+if [ "$?" -eq 0 ]; then
    if ssh -i $KEY_FILE $REMOTE_USER@$REMOTE_ADDR "sudo lsof -Pi:$REMOTE_PORT -sTCP:LISTEN" >/dev/null; then
-        echo "Reverse tunnel is successfully opened!" 
-    fi 
+        echo "Reverse tunnel is successfully opened!"
+    fi
 fi

--- a/carma_cloud_client/src/carma_cloud_client_node.cpp
+++ b/carma_cloud_client/src/carma_cloud_client_node.cpp
@@ -148,16 +148,11 @@ namespace carma_cloud_client
 
     }
 
-
-
-    char port[config_.port.size() + 1];
-    strcpy(port, config_.port.c_str());
-
     char list[config_.list.size() + 1];
     strcpy(list, config_.list.c_str());
 
     // with port and list
-    sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=\"%s\" list=\"%s\"><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",port, list, reqid, reqseq,scale,bounds_str);
+    sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest port=\"%s\" list=\"%s\"><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>", std::to_string(config_.webport).c_str(), list, reqid, reqseq,scale,bounds_str);
 
     RCLCPP_DEBUG_STREAM(  get_logger(), "xml_str: " << xml_str);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes fixes for the cellular connection between CARMA Platform and CARMA Cloud, which can be used to support the cellular communication of TrafficControlRequest and TrafficControlMessage messages (rather than using C-V2X communications with V2X Hub) for geofence-related (e.g., work zone) use cases.

Notable updates include:
- Fixing the remote port (referred to as the webport in some locations) by changing it to `22222`, which is expected by CARMA Cloud.
- Updating the targeted carma-cloud instance and the associated .pem key file to the production instance (carma-cloud.com with key file carma-cloud-1.pem) since this is targeted for the Stingray release.
- Making comments more verbose in some locations to support future testing/troubleshooting.

It will be beneficial to do another pass on these scripts (launch files and tunnel scripts) and the package's README in the future for additional cleanup, but this work is not included in this PR due to time constraints associated with the release.

Related PRs:
- https://github.com/usdot-fhwa-stol/carma-vehicle-calibration/pull/140

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
N/A

## Related Jira Key

<!-- e.g. CAR-123 -->
ARC-402

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Without remote port/webport fix, TCMs will not be received back from CARMA Cloud.

Without the switch to the production carma-cloud instance, the release will not use the correct carma-cloud instance.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the Ford Fusion with the production CARMA Cloud instance. A closed lane section was included in CARMA Cloud and it was located within CARMA Platform's planned route. It was verified that CARMA Platform rerouted successfully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
