### PR TITLE
CDAD-137 Fix Traffic Incident Parser so that it doesn’t ignore some messages and speed limit change

### DIFF
--- a/traffic_incident_parser/include/traffic_incident_parser/traffic_incident_parser_worker.hpp
+++ b/traffic_incident_parser/include/traffic_incident_parser/traffic_incident_parser_worker.hpp
@@ -46,7 +46,7 @@ class TrafficIncidentParserWorker
  public:
 
   using PublishTrafficControlCallback = std::function<void(const carma_v2x_msgs::msg::TrafficControlMessage&)>;
-  constexpr double MphToMetersPerSec = 0.44704; //Convert miles per hour to meters per second
+  const double MphToMetersPerSec = 0.44704; //Convert miles per hour to meters per second
 
 
   /*!

--- a/traffic_incident_parser/include/traffic_incident_parser/traffic_incident_parser_worker.hpp
+++ b/traffic_incident_parser/include/traffic_incident_parser/traffic_incident_parser_worker.hpp
@@ -46,6 +46,8 @@ class TrafficIncidentParserWorker
  public:
 
   using PublishTrafficControlCallback = std::function<void(const carma_v2x_msgs::msg::TrafficControlMessage&)>;
+  constexpr double MphToMetersPerSec = 0.44704; //Convert miles per hour to meters per second
+
 
   /*!
    * \brief TrafficIncidentParserWorker constructor

--- a/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
+++ b/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
@@ -103,7 +103,7 @@ namespace traffic_incident_parser
         double temp_down_track=stod(stringParserHelper(downtrack_str,downtrack_str.find_last_of("down_track:")));
         double temp_up_track=stod(stringParserHelper(uptrack_str,uptrack_str.find_last_of("up_track:")));
         double temp_min_gap=stod(stringParserHelper(min_gap_str,min_gap_str.find_last_of("min_gap:")));
-        double temp_speed_advisory=stod(stringParserHelper(speed_advisory_str,speed_advisory_str.find_last_of("advisory_speed:")));
+        double temp_speed_advisory=stod(stringParserHelper(speed_advisory_str,speed_advisory_str.find_last_of("advisory_speed:"))) * MphToMetersPerSec;
         std::string temp_event_reason=stringParserHelper(event_reason_str,event_reason_str.find_last_of("event_reason:"));
         std::string temp_event_type=stringParserHelper(event_type_str,event_type_str.find_last_of("event_type:"));
 
@@ -280,6 +280,11 @@ namespace traffic_incident_parser
         if(!wm_->getMap())
         {
             RCLCPP_WARN_STREAM(logger_->get_logger(), "Traffic Incident Parser is composing a Traffic Control Message, but it has not loaded the map yet. Returning empty list");
+            return {};
+        }
+        if(!wm_->getRoute())
+        {
+            RCLCPP_WARN_STREAM(logger_->get_logger(), "Traffic Incident Parser is composing a Traffic Control Message, but route is not selected yet. Returning empty list");
             return {};
         }
         if (projection_msg_ == "")

--- a/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
+++ b/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
@@ -31,6 +31,21 @@ namespace traffic_incident_parser
 
     void TrafficIncidentParserWorker::mobilityOperationCallback(carma_v2x_msgs::msg::MobilityOperation::UniquePtr mobility_msg)
     {
+        if(!wm_->getMap())
+        {
+            RCLCPP_WARN_STREAM(logger_->get_logger(), "The map is not loaded yet, ignoring the Traffic Incident Mobility Message");
+            return;
+        }
+        if (projection_msg_ == "")
+        {
+            RCLCPP_WARN_STREAM(logger_->get_logger(), "The georeference is not loaded yet, ignoring the Traffic Incident Mobility Message");
+            return;
+        }
+        if(!wm_->getRoute())
+        {
+            RCLCPP_WARN_STREAM(logger_->get_logger(), "The route is not loaded yet, ignoring the Traffic Incident Mobility Message");
+            return;
+        }
 
         if(mobility_msg->strategy=="carma3/Incident_Use_Case")
         {
@@ -277,21 +292,7 @@ namespace traffic_incident_parser
     std::vector<carma_v2x_msgs::msg::TrafficControlMessageV01> TrafficIncidentParserWorker::composeTrafficControlMesssages()
     {
         RCLCPP_DEBUG_STREAM(logger_->get_logger(), "In composeTrafficControlMesssages");
-        if(!wm_->getMap())
-        {
-            RCLCPP_WARN_STREAM(logger_->get_logger(), "Traffic Incident Parser is composing a Traffic Control Message, but it has not loaded the map yet. Returning empty list");
-            return {};
-        }
-        if(!wm_->getRoute())
-        {
-            RCLCPP_WARN_STREAM(logger_->get_logger(), "Traffic Incident Parser is composing a Traffic Control Message, but route is not selected yet. Returning empty list");
-            return {};
-        }
-        if (projection_msg_ == "")
-        {
-            RCLCPP_WARN_STREAM(logger_->get_logger(), "Traffic Incident Parser is composing a Traffic Control Message, but georeference has not loaded yet. Returning empty list");
-            return {};
-        }
+
         local_point_=getIncidentOriginPoint();
         RCLCPP_DEBUG_STREAM(logger_->get_logger(), "Responder point in map frame: " << local_point_.x() << ", " << local_point_.y());
         auto current_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, local_point_, 1);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Two issues are addressed in this PR:
CDAD-137: TIM Use case: traffic incident parser is ignoring some messages
CDAD-138: TIM Use case: carma-platform is ignoring speed limit change from ERV

It seems like if the move-over MOM is published before the route is selected, it is being ignored. The reason is that a geofence is created from the first received MOM, but since route is not loaded yet, it is not applied by world model.
However, the Traffic Incident Parser will save the message and will ignore all the future messages if they are the same as the first one. So when the route is selected, new geofences wont be created anymore.

There was also a mismatch between speed units. The MOM has an advisory speed value in mph, which was not being converted to m/s

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/CDAD-137
https://usdot-carma.atlassian.net/browse/CDAD-138

## Motivation and Context

To have a functioning TIM use case

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
