### PR TITLE
Separate callback groups for plan_delegator and arbitrator

### DIFF
--- a/arbitrator/include/arbitrator_node.hpp
+++ b/arbitrator/include/arbitrator_node.hpp
@@ -37,14 +37,14 @@
 #include "tree_planner.hpp"
 
 
-namespace arbitrator 
+namespace arbitrator
 {
     /**
      * An arbitrator node instance with currently used configuration/planning paradigms
-     * 
+     *
      * Governs the interactions of plugins during the maneuver planning phase of
      * the CARMA planning process by internally using a worker class with generic planning interface.
-     * 
+     *
      */
     class ArbitratorNode : public carma_ros2_utils::CarmaLifecycleNode
     {
@@ -53,24 +53,26 @@ namespace arbitrator
              * @brief Constructor
              */
             explicit ArbitratorNode(const rclcpp::NodeOptions& options);
-            
+
             ////
             // Overrides
             ////
             carma_ros2_utils::CallbackReturn handle_on_configure(const rclcpp_lifecycle::State &);
             carma_ros2_utils::CallbackReturn handle_on_activate(const rclcpp_lifecycle::State &);
-        
+
         private:
             // helper function to parse plugin_priorities param from yaml as a json
             std::map<std::string, double> plugin_priorities_map_from_json(const std::string& json_string);
             carma_ros2_utils::SubPtr<geometry_msgs::msg::TwistStamped> twist_sub_;
-            
+
             Config config_;
              // wm listener pointer and pointer to the actual wm object
             std::shared_ptr<carma_wm::WMListener> wm_listener_;
             carma_wm::WorldModelConstPtr wm_;
             std::shared_ptr<Arbitrator> arbitrator_;
             rclcpp::TimerBase::SharedPtr bumper_pose_timer_;
+            // Create a cb group for the arbitrator run timer to ensure it does not block other cb
+            rclcpp::CallbackGroup::SharedPtr arbitrator_run_callback_group_;
             rclcpp::TimerBase::SharedPtr arbitrator_run_;
 
     };

--- a/arbitrator/src/arbitrator_node.cpp
+++ b/arbitrator/src/arbitrator_node.cpp
@@ -99,9 +99,12 @@ namespace arbitrator
                                 std::chrono::milliseconds(100),
                                 [this]() {this->arbitrator_->bumper_pose_cb();});
 
+        arbitrator_run_callback_group_ =
+            create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
         arbitrator_run_ = create_timer(get_clock(),
-                                std::chrono::duration<double>(1/(config_.planning_frequency * 2 )), //there is waiting state between each planning state
-                                [this]() {this->arbitrator_->run();});
+            std::chrono::duration<double>(1/(config_.planning_frequency * 2 )), //there is waiting state between each planning state
+            [this]() {this->arbitrator_->run();}, arbitrator_run_callback_group_);
         //The intention is to keep the arbitrator planning at intended frequency - 1s. Looks like ROS2 conversion kept the WAITING state from ROS1,
         //which occurs between PLANNING state in the state machine. So if the timer calls state callback each 1 second, the arbitrator ends up planning
         //every 2s due to PLANNING > WAITING > PLANNING transition. That's why the frequency is doubled.

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -200,6 +200,8 @@ namespace plan_delegator
             carma_ros2_utils::SubPtr<carma_planning_msgs::msg::GuidanceState> guidance_state_sub_;
 
             rclcpp::TimerBase::SharedPtr traj_timer_;
+            // Separate callback group for the timer to avoid blocking other callbacks like pose
+            rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
 
             bool guidance_engaged = false;
 
@@ -208,7 +210,7 @@ namespace plan_delegator
             // TF listenser
             std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
             std::shared_ptr<tf2_ros::TransformListener> tf2_listener_;
-            
+
             // Object to store information regarding the next upcoming lane change in latest_maneuver_plan_; empty if no upcoming lane change exists in latest_maneuver_plan_
             boost::optional<LaneChangeInformation> upcoming_lane_change_information_;
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -179,9 +179,10 @@ namespace plan_delegator
 
     carma_ros2_utils::CallbackReturn PlanDelegator::handle_on_activate(const rclcpp_lifecycle::State &)
     {
+        timer_callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
         traj_timer_ = create_timer(get_clock(),
             std::chrono::milliseconds((int)(1 / config_.trajectory_planning_rate * 1000)),
-            std::bind(&PlanDelegator::onTrajPlanTick, this));
+            std::bind(&PlanDelegator::onTrajPlanTick, this), timer_callback_group_);
          return CallbackReturn::SUCCESS;
     }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

arbitrator and plan_delegator's callbacks should not be all in the same callback group.

- If they are, despite being muti-threaded node, this means that its callbacks will only run 1 at a time. There are two types of callbacks in the node - subscriptions that update current state like pose and twist AND 10hz timer that does service calls to other tactical plugins.
- plan_delegator calls tactical plugins every 10hz, but if its response from the plugins take more time, that callback is set to run immediately after previous callback is finished.
- since only 1 callback can run, the service call callback type is blocking other callbacks, like state subscriptions, keeping the node's pose and twist info same and outdated. This is apparently because timer callback is prioritized over others in ROS2 ([Ref1](https://robotics.stackexchange.com/questions/107041/ros2-multi-threaded-executor-timers-block-subscriber-callbacks) and [Ref2](http://ris.utwente.nl/ws/portalfiles/portal/327031921/Timing-Aware_ROS_2_Architecture_and_System_Optimization.pdf))

This was actually tested to be true locally. I made CLC's plan_trajectory function to forcefully sleep for 300ms while calling it from plan_delegator at 10hz. Even the sim PCs were not able to update its pose and twist unless I made the callback group separate (this would apply to arbitrator too, and who knows other nodes with timers that may have computationally high callbacks)

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
Partially fixes: TODO:
<!-- e.g. CAR-123 -->

## Motivation and Context
Workzone/TIM + CP testing using Pacifica showed repeated failure in generating lanechange trajectory at Summit Point.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See above.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
