### PR TITLE
Improve plan_delegator to reuse last successful traj if new one failed

### DIFF
--- a/cooperative_lanechange/src/cooperative_lanechange_node.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange_node.cpp
@@ -292,7 +292,17 @@ namespace cooperative_lanechange
     RCLCPP_DEBUG_STREAM(get_logger(), "Starting CLC downtrack: " << maneuver_plan[0].lane_change_maneuver.start_dist);
 
     if(current_downtrack < maneuver_plan[0].lane_change_maneuver.start_dist - config_.starting_downtrack_range){
+<<<<<<< Updated upstream
       RCLCPP_DEBUG_STREAM(get_logger(), "Lane change trajectory will not be planned. current_downtrack is more than " << config_.starting_downtrack_range << " meters before starting CLC downtrack");
+=======
+      RCLCPP_ERROR_STREAM(get_logger(), "Lane change trajectory will not be planned. current_downtrack is more than " << config_.starting_downtrack_range << " meters before starting CLC downtrack");
+
+      std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
+
+      auto duration = end_time - start_time;
+      RCLCPP_ERROR_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+      RCLCPP_WARN_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+>>>>>>> Stashed changes
       return;
     }
     auto current_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, veh_pos, 10);
@@ -424,7 +434,15 @@ namespace cooperative_lanechange
       p.planner_plugin_name = get_plugin_name();
     }
 
+<<<<<<< Updated upstream
     return;
+=======
+    std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
+
+    auto duration = end_time - start_time;
+    RCLCPP_ERROR_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+    RCLCPP_WARN_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+>>>>>>> Stashed changes
   }
 
   void CooperativeLaneChangePlugin::add_trajectory_to_response(carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req,

--- a/cooperative_lanechange/src/cooperative_lanechange_node.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange_node.cpp
@@ -292,17 +292,14 @@ namespace cooperative_lanechange
     RCLCPP_DEBUG_STREAM(get_logger(), "Starting CLC downtrack: " << maneuver_plan[0].lane_change_maneuver.start_dist);
 
     if(current_downtrack < maneuver_plan[0].lane_change_maneuver.start_dist - config_.starting_downtrack_range){
-<<<<<<< Updated upstream
-      RCLCPP_DEBUG_STREAM(get_logger(), "Lane change trajectory will not be planned. current_downtrack is more than " << config_.starting_downtrack_range << " meters before starting CLC downtrack");
-=======
       RCLCPP_ERROR_STREAM(get_logger(), "Lane change trajectory will not be planned. current_downtrack is more than " << config_.starting_downtrack_range << " meters before starting CLC downtrack");
 
       std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
 
       auto duration = end_time - start_time;
-      RCLCPP_ERROR_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
-      RCLCPP_WARN_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
->>>>>>> Stashed changes
+      RCLCPP_DEBUG_STREAM(
+        rclcpp::get_logger("cooperative_lanechange"),
+        "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
       return;
     }
     auto current_lanelets = lanelet::geometry::findNearest(wm_->getMap()->laneletLayer, veh_pos, 10);
@@ -434,15 +431,12 @@ namespace cooperative_lanechange
       p.planner_plugin_name = get_plugin_name();
     }
 
-<<<<<<< Updated upstream
-    return;
-=======
     std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_ERROR_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
-    RCLCPP_WARN_STREAM(get_logger(), "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
->>>>>>> Stashed changes
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("cooperative_lanechange"),
+      "CLC ExecutionTime: " << std::chrono::duration<double>(duration).count());
   }
 
   void CooperativeLaneChangePlugin::add_trajectory_to_response(carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req,

--- a/cooperative_lanechange/src/cooperative_lanechange_node.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange_node.cpp
@@ -292,7 +292,9 @@ namespace cooperative_lanechange
     RCLCPP_DEBUG_STREAM(get_logger(), "Starting CLC downtrack: " << maneuver_plan[0].lane_change_maneuver.start_dist);
 
     if(current_downtrack < maneuver_plan[0].lane_change_maneuver.start_dist - config_.starting_downtrack_range){
-      RCLCPP_ERROR_STREAM(get_logger(), "Lane change trajectory will not be planned. current_downtrack is more than " << config_.starting_downtrack_range << " meters before starting CLC downtrack");
+      RCLCPP_WARN_STREAM(get_logger(),
+      "Lane change trajectory will not be planned. current_downtrack is more than "
+      << config_.starting_downtrack_range << " meters before starting CLC downtrack");
 
       std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
 

--- a/cooperative_lanechange/src/cooperative_lanechange_node.cpp
+++ b/cooperative_lanechange/src/cooperative_lanechange_node.cpp
@@ -264,6 +264,8 @@ namespace cooperative_lanechange
     carma_planning_msgs::srv::PlanTrajectory::Request::SharedPtr req,
     carma_planning_msgs::srv::PlanTrajectory::Response::SharedPtr resp)
   {
+    std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
+
     // Set boolean flag if this is the first time this service has been called
     if (!clc_called_)
     {

--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -129,8 +129,9 @@ void InLaneCruisingPlugin::plan_trajectory_callback(
   std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
 
   auto duration = end_time - start_time;
-  RCLCPP_WARN_STREAM(nh_->get_logger(), "ILC ExecutionTime: " << std::chrono::duration<double>(duration).count());
-  RCLCPP_ERROR_STREAM(nh_->get_logger(), "ILC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+  RCLCPP_DEBUG_STREAM(
+    rclcpp::get_logger("inlanecruising_plugin"),
+    "ILC ExecutionTime: " << std::chrono::duration<double>(duration).count());
 }
 
 void InLaneCruisingPlugin::set_yield_client(carma_ros2_utils::ClientPtr<carma_planning_msgs::srv::PlanTrajectory> client)

--- a/inlanecruising_plugin/src/inlanecruising_plugin.cpp
+++ b/inlanecruising_plugin/src/inlanecruising_plugin.cpp
@@ -129,7 +129,8 @@ void InLaneCruisingPlugin::plan_trajectory_callback(
   std::chrono::system_clock::time_point end_time = std::chrono::system_clock::now();  // Planning complete
 
   auto duration = end_time - start_time;
-  RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::chrono::duration<double>(duration).count());
+  RCLCPP_WARN_STREAM(nh_->get_logger(), "ILC ExecutionTime: " << std::chrono::duration<double>(duration).count());
+  RCLCPP_ERROR_STREAM(nh_->get_logger(), "ILC ExecutionTime: " << std::chrono::duration<double>(duration).count());
 }
 
 void InLaneCruisingPlugin::set_yield_client(carma_ros2_utils::ClientPtr<carma_planning_msgs::srv::PlanTrajectory> client)

--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -37,4 +37,4 @@ duration_to_signal_before_lane_change: 2.5
 # Int: The maximum number of times plan_delegator attempts to generate a trajectory before giving up
 # When trajectory generations fails, it reuses the last successful trajectory until tries again
 # in the next iteration.
-max_traj_generation_reattempt: 5
+max_traj_generation_reattempt: 3

--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -33,3 +33,8 @@ duration_to_signal_before_lane_change: 2.5
 # Units: Milliseconds
 # Configured in VehicleConfigPrams.yaml in carma-config
 # tactical_plugin_service_call_timeout: 100
+
+# Int: The maximum number of times plan_delegator attempts to generate a trajectory before giving up
+# When trajectory generations fails, it reuses the last successful trajectory until tries again
+# in the next iteration.
+max_traj_generation_reattempt: 5

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -189,6 +189,7 @@ namespace plan_delegator
 
         private:
             // ROS Publishers
+            std::optional<carma_planning_msgs::msg::TrajectoryPlan> last_successful_traj_;
             carma_ros2_utils::PubPtr<carma_planning_msgs::msg::TrajectoryPlan> traj_pub_;
             carma_ros2_utils::PubPtr<carma_planning_msgs::msg::UpcomingLaneChangeStatus> upcoming_lane_change_status_pub_;
             carma_ros2_utils::PubPtr<autoware_msgs::msg::LampCmd> turn_signal_command_pub_;

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -79,6 +79,7 @@ namespace plan_delegator
         double duration_to_signal_before_lane_change = 2.5; // (Seconds) If an upcoming lane change will begin in under this time threshold, a turn signal activation command will be published.
         int tactical_plugin_service_call_timeout = 100; // (Milliseconds) The maximum duration that Plan Delegator will wait after calling a tactical plugin's trajectory planning service; if trajectory
                                                         // generation takes longer than this, then planning will immediately end for the current trajectory planning iteration.
+        int max_traj_generation_reattempt = 5; // The maximum number of times plan_delegator attempts to generate a trajectory before giving up
 
         // Stream operator for this config
         friend std::ostream &operator<<(std::ostream &output, const Config &c)
@@ -89,6 +90,8 @@ namespace plan_delegator
             << "trajectory_planning_rate: " << c.trajectory_planning_rate << std::endl
             << "max_trajectory_duration: " << c.max_trajectory_duration << std::endl
             << "min_crawl_speed: " << c.min_crawl_speed << std::endl
+            << "tactical_plugin_service_call_timeout: " << c.tactical_plugin_service_call_timeout << std::endl
+            << "max_traj_generation_reattempt: " << c.max_traj_generation_reattempt << std::endl
             << "duration_to_signal_before_lane_change: " << c.duration_to_signal_before_lane_change << std::endl
             << "}" << std::endl;
         return output;
@@ -205,6 +208,7 @@ namespace plan_delegator
             rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
 
             bool guidance_engaged = false;
+            int consecutive_traj_gen_failure_num_ = 0; // Number of consecutive trajectory generation failures
 
             double length_to_front_bumper_ = 3.0;
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -142,6 +142,7 @@ namespace plan_delegator
         config_.max_trajectory_duration = declare_parameter<double>("trajectory_duration_threshold", config_.max_trajectory_duration);
         config_.min_crawl_speed = declare_parameter<double>("min_speed", config_.min_crawl_speed);
         config_.duration_to_signal_before_lane_change = declare_parameter<double>("duration_to_signal_before_lane_change", config_.duration_to_signal_before_lane_change);
+        config_.max_traj_generation_reattempt = declare_parameter<int>("max_traj_generation_reattempt", config_.max_traj_generation_reattempt);
         config_.tactical_plugin_service_call_timeout = declare_parameter<int>("tactical_plugin_service_call_timeout", config_.tactical_plugin_service_call_timeout);
     }
 
@@ -157,6 +158,7 @@ namespace plan_delegator
         get_parameter<double>("min_speed", config_.min_crawl_speed);
         get_parameter<double>("duration_to_signal_before_lane_change", config_.duration_to_signal_before_lane_change);
         get_parameter<int>("tactical_plugin_service_call_timeout", config_.tactical_plugin_service_call_timeout);
+        get_parameter<int>("max_traj_generation_reattempt", config_.max_traj_generation_reattempt);
 
         RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Done loading parameters: " << config_);
 
@@ -730,21 +732,33 @@ namespace plan_delegator
             trajectory_plan.header.stamp = get_clock()->now();
             last_successful_traj_ = trajectory_plan;
             traj_pub_->publish(trajectory_plan);
+            consecutive_traj_gen_failure_num_ = 0;
         }
         else
         {
+            consecutive_traj_gen_failure_num_ ++;
             RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
                 "Guidance is engaged, but new planned trajectory has less than 2 points. " <<
-                "It will not be published!");
-            if (last_successful_traj_.has_value())
+                "It will not be published! Consecutive failure count: "
+                << consecutive_traj_gen_failure_num_);
+
+            if (last_successful_traj_.has_value()
+                && consecutive_traj_gen_failure_num_
+                    <= config_.max_traj_generation_reattempt)
             {
                 RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
-                    "Instead, last available trajectory is published with outdated timestamp of:" <<
-                    std::to_string(
+                    "Instead, last available trajectory is published with outdated timestamp of:"
+                    << std::to_string(
                         rclcpp::Time(last_successful_traj_.value().header.stamp).seconds()));
                 traj_pub_->publish(last_successful_traj_.value());
             }
-
+            else
+            {
+                RCLCPP_ERROR_STREAM(rclcpp::get_logger("plan_delegator"),
+                    "No valid trajectory is available to publish! "
+                    "Please check the planner plugins and their configurations.");
+                throw std::runtime_error("No valid trajectory is available to publish!");
+            }
         }
     }
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -742,6 +742,7 @@ namespace plan_delegator
                 "It will not be published! Consecutive failure count: "
                 << consecutive_traj_gen_failure_num_);
 
+            // case where traj generation fails after a successful one
             if (last_successful_traj_.has_value()
                 && consecutive_traj_gen_failure_num_
                     <= config_.max_traj_generation_reattempt)
@@ -751,6 +752,13 @@ namespace plan_delegator
                     << std::to_string(
                         rclcpp::Time(last_successful_traj_.value().header.stamp).seconds()));
                 traj_pub_->publish(last_successful_traj_.value());
+            }
+            // case where traj generation fails from the beginning
+            else if (!last_successful_traj_.has_value() &&
+                consecutive_traj_gen_failure_num_ <= config_.max_traj_generation_reattempt)
+            {
+                RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
+                    "Instead, tried publishing last available trajectory, but it is not available!");
             }
             else
             {

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -593,6 +593,7 @@ namespace plan_delegator
     carma_planning_msgs::msg::TrajectoryPlan PlanDelegator::planTrajectory()
     {
         carma_planning_msgs::msg::TrajectoryPlan latest_trajectory_plan;
+        bool full_plan_generation_failed = false;
         if(!guidance_engaged)
         {
             RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Guidance is not engaged. Plan delegator will not plan trajectory.");
@@ -653,6 +654,7 @@ namespace plan_delegator
             {
                 RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),"Unsuccessful service call to trajectory planner:" << maneuver_planner << " for plan ID " << std::string(latest_maneuver_plan_.maneuver_plan_id));
                 // if one service call fails, it should end plan immediately because it is there is no point to generate plan with empty space
+                full_plan_generation_failed = true;
                 break;
             }
 
@@ -665,6 +667,7 @@ namespace plan_delegator
                     "Found invalid trajectory with less than 2 trajectory "
                     << "points for maneuver_plan_id: "
                     << std::string(latest_maneuver_plan_.maneuver_plan_id));
+                full_plan_generation_failed = true;
                 break;
             }
             //Remove duplicate point from start of trajectory
@@ -701,6 +704,15 @@ namespace plan_delegator
             }
         }
 
+        if (full_plan_generation_failed)
+        {
+            RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
+                "Plan_delegator's current run wasn't fully able to generate trajectory!");
+
+            carma_planning_msgs::msg::TrajectoryPlan empty_plan;
+            return empty_plan;
+        }
+
         return latest_trajectory_plan;
     }
 
@@ -716,13 +728,23 @@ namespace plan_delegator
         if(isTrajectoryValid(trajectory_plan))
         {
             trajectory_plan.header.stamp = get_clock()->now();
+            last_successful_traj_ = trajectory_plan;
             traj_pub_->publish(trajectory_plan);
         }
         else
         {
             RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
-                "Guidance is engaged, but planned trajectory has less than 2 points. " <<
+                "Guidance is engaged, but new planned trajectory has less than 2 points. " <<
                 "It will not be published!");
+            if (last_successful_traj_.has_value())
+            {
+                RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
+                    "Instead, last available trajectory is published with outdated timestamp of:" <<
+                    std::to_string(
+                        rclcpp::Time(last_successful_traj_.value().header.stamp).seconds()));
+                traj_pub_->publish(last_successful_traj_.value());
+            }
+
         }
     }
 

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -292,11 +292,7 @@ namespace yield_plugin
       rclcpp::Time end_time = system_clock.now();  // Planning complete
 
       auto duration = end_time - start_time;
-      RCLCPP_WARN_STREAM(nh_->get_logger(),
-        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
-      RCLCPP_ERROR_STREAM(nh_->get_logger(),
-        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
-      RCLCPP_ERROR_STREAM(rclcpp::get_logger("yield_plugin"),
+      RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"),
         "ExecutionTime Yield: " << std::to_string(duration.seconds()));
       return;
     }
@@ -374,10 +370,8 @@ namespace yield_plugin
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_WARN_STREAM(nh_->get_logger(),
-        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
-      RCLCPP_ERROR_STREAM(rclcpp::get_logger("yield_plugin"),
-        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"),
+      "ExecutionTime Yield: " << std::to_string(duration.seconds()));
   }
 
   carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::update_traj_for_cooperative_behavior(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double current_speed)
@@ -746,10 +740,6 @@ namespace yield_plugin
         const auto distance{std::hypot(x1 - x2, y1 - y2)};
 
         smallest_dist = std::min(distance, smallest_dist);
-        // RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt
-        //   << ", x1: " << x1 << ", y1: " << y1
-        //   << ", x2: " << x2 << ", y2: " << y2
-        //   << ", p2a_t:" << std::to_string(p2a_t));
 
         // Following "if logic" assumes the traj2 is a simple cv model, aka, traj2 point is a straight line over time.
         // And current traj1 point is fixed in this iteration.
@@ -781,8 +771,9 @@ namespace yield_plugin
         return collision_result;
       }
     }
-    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"), "Smallest_dist: " << smallest_dist);
-    RCLCPP_WARN_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist);
+    RCLCPP_DEBUG_STREAM(
+      rclcpp::get_logger("yield_plugin"),
+      "Was not able to find collision: smallest_dist: " << smallest_dist);
 
     // No collision detected
     return std::nullopt;

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -292,8 +292,12 @@ namespace yield_plugin
       rclcpp::Time end_time = system_clock.now();  // Planning complete
 
       auto duration = end_time - start_time;
-      RCLCPP_DEBUG_STREAM(nh_->get_logger(),
-        "ExecutionTime: " << std::to_string(duration.seconds()));
+      RCLCPP_WARN_STREAM(nh_->get_logger(),
+        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
+      RCLCPP_ERROR_STREAM(nh_->get_logger(),
+        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
+      RCLCPP_ERROR_STREAM(rclcpp::get_logger("yield_plugin"),
+        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
       return;
     }
 
@@ -346,12 +350,12 @@ namespace yield_plugin
       // return original trajectory if no difference in trajectory points a.k.a no collision
       if (fabs(get_trajectory_end_time(original_trajectory) - get_trajectory_end_time(yield_trajectory)) < EPSILON)
       {
-        
+
         resp->trajectory_plan = original_trajectory;
         // Reset the collision prevention variables
         first_time_stopped_to_prevent_collision_ = std::nullopt;
         last_traj_plan_committed_to_stopping_ = std::nullopt;
-        
+
       }
       else
       {
@@ -370,7 +374,10 @@ namespace yield_plugin
     rclcpp::Time end_time = system_clock.now();  // Planning complete
 
     auto duration = end_time - start_time;
-    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "ExecutionTime: " << std::to_string(duration.seconds()));
+    RCLCPP_WARN_STREAM(nh_->get_logger(),
+        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
+      RCLCPP_ERROR_STREAM(rclcpp::get_logger("yield_plugin"),
+        "ExecutionTime Yield: " << std::to_string(duration.seconds()));
   }
 
   carma_planning_msgs::msg::TrajectoryPlan YieldPlugin::update_traj_for_cooperative_behavior(const carma_planning_msgs::msg::TrajectoryPlan& original_tp, double current_speed)
@@ -739,10 +746,10 @@ namespace yield_plugin
         const auto distance{std::hypot(x1 - x2, y1 - y2)};
 
         smallest_dist = std::min(distance, smallest_dist);
-        RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt
-          << ", x1: " << x1 << ", y1: " << y1
-          << ", x2: " << x2 << ", y2: " << y2
-          << ", p2a_t:" << std::to_string(p2a_t));
+        // RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"), "Smallest_dist: " << smallest_dist << ", distance: " << distance << ", dt: " << dt
+        //   << ", x1: " << x1 << ", y1: " << y1
+        //   << ", x2: " << x2 << ", y2: " << y2
+        //   << ", p2a_t:" << std::to_string(p2a_t));
 
         // Following "if logic" assumes the traj2 is a simple cv model, aka, traj2 point is a straight line over time.
         // And current traj1 point is fixed in this iteration.
@@ -774,6 +781,8 @@ namespace yield_plugin
         return collision_result;
       }
     }
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("yield_plugin"), "Smallest_dist: " << smallest_dist);
+    RCLCPP_WARN_STREAM(nh_->get_logger(), "Smallest_dist: " << smallest_dist);
 
     // No collision detected
     return std::nullopt;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

I applied a fix to the plan_delegator regarding the flickering trajectory. I confirmed on all the 10 runs that the flickering issue was happening 1-3 times (mostly due to yield_plugin timeout and our basic_autonomy not being able to generate traj near the end of lanelet), but the platform was able to overcome them. 

This happens because plan_delegator publishes a trajectory even if it is not usable because it is considered valid if it has 2 points. So sometimes out of A B C plugins (in that order), B may not generate valid trajectory due to timeout (yielding).  Then if A gave only 5 points, which is not useful as the vehicle is almost passing those points but still valid, plan_delegator uses that trajectory.

We could further discuss what should be valid trajectory.

But for now, I coded it to use last successful trajectory if plan_delegator was not able to generate traj fully from all plugins instructed.

We uploaded the runs in: https://drive.google.com/drive/folders/1-CKYiyqI_TKpzsBhKUxzKMm35RvLhvo1?usp=sharing

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
CDAD-152
CDAD-159
## Motivation and Context
Tempest release testing and ITSWC 2025 Demo
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Summit Point 10/10 successful runs
<img width="1210" height="773" alt="image" src="https://github.com/user-attachments/assets/2d7f02c6-2060-41e2-997c-47853feb754f" />

In each runs, the issue would have happened following times:
```
July 21 Testing
1. Happened 3 times - highest 0.34s
2. Happened 3 times - highest ILC ExecutionTime: 0.277474 ( ExecutionTime Yield: 0.264261)
3. Happened 2 times - highest ExecutionTime Yield: 0.398444
4. Happened 2 times - highest ILC ExecutionTime: 0.275721 ( ExecutionTime Yield: 0.241054)
5. Happened 1 time - ILC ExecutionTime: 0.268358 ( ExecutionTime Yield: 0.260101), but happened because of 'is at or past the planned end distance. Couldn't generate trajectory"
6. Happened 1 time - ILC ExecutionTime: 0.237326 ( ExecutionTime Yield: 0.225053),  but happened because of 'is at or past the planned end distance. Couldn't generate trajectory"
7. 0 happened
8 Happened 2 times - ILC ExecutionTime: 0.311489 (ExecutionTime Yield: 0.501016), 1 time for " 'is at or past the planned end distance. Couldn't generate trajectory""
9. Happened 1 time -ILC ExecutionTime: 0.317286 (ExecutionTime Yield: 0.288118)
10. Happened 2 times - ILC ExecutionTime: 0.305264 ( ExecutionTime Yield: 0.343301)
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
