### PR TITLE
Account expired/passed maneuvers in indexing in plan_delegator

### DIFF
--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -607,7 +607,7 @@ namespace plan_delegator
 
         // Track the index of the starting maneuver in the maneuver plan that this trajectory plan service request is for
         uint16_t current_maneuver_index = 0;
-
+        int count_expired_maneuvers = 0;
         // Loop through maneuver list to make service call to applicable Tactical Plugin
         while(current_maneuver_index < latest_maneuver_plan_.maneuvers.size())
         {
@@ -620,6 +620,12 @@ namespace plan_delegator
                 RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Dropping expired maneuver: " << GET_MANEUVER_PROPERTY(maneuver, parameters.maneuver_id));
                 // Update the maneuver plan index for the next loop
                 ++current_maneuver_index;
+                // only LANE_FOLLOWING are expected to be contiguous,
+                // so accounting for expired maneuvers is crucial to correctly track the curr index
+                if (maneuver.type == carma_planning_msgs::msg::Maneuver::LANE_FOLLOWING)
+                {
+                    count_expired_maneuvers++;
+                }
                 continue;
             }
             lanelet::BasicPoint2d current_loc(latest_pose_.pose.position.x, latest_pose_.pose.position.y);
@@ -634,9 +640,14 @@ namespace plan_delegator
                 RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Dropping passed maneuver: " << GET_MANEUVER_PROPERTY(maneuver, parameters.maneuver_id));
                 // Update the maneuver plan index for the next loop
                 ++current_maneuver_index;
+                // only LANE_FOLLOWING are expected to be contiguous,
+                // so accounting for expired maneuvers is crucial to correctly track the curr index
+                if (maneuver.type == carma_planning_msgs::msg::Maneuver::LANE_FOLLOWING)
+                {
+                    count_expired_maneuvers++;
+                }
                 continue;
             }
-
 
             // get corresponding ros service client for plan trajectory
             auto maneuver_planner = GET_MANEUVER_PROPERTY(maneuver, parameters.planning_tactical_plugin);
@@ -702,8 +713,12 @@ namespace plan_delegator
             // This is required since inlanecruising_plugin can plan a trajectory over contiguous LANE_FOLLOWING maneuvers
             if(plan_response->related_maneuvers.size() > 0)
             {
-                current_maneuver_index = plan_response->related_maneuvers.back() + 1;
+                // also expired maneuvers were ignored, so it shouldn't affect the index
+                current_maneuver_index =
+                    plan_response->related_maneuvers.back() + 1 - count_expired_maneuvers;
             }
+            // safely reset the counter, because by this point they are accounted
+            count_expired_maneuvers = 0;
         }
 
         if (full_plan_generation_failed)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Currently plan_delegator could ignore a whole maneuver intermittently. 

For context, ILC can plan over multiple maneuvers using the related_maneuvers field even if only 1 maneuver was sent to be planned. Due to this, plan_delegator accounts for it, and increments its index for what maneuver to plan next using related_maneuvers size.

The problem arises when plan_delegator detects that current maneuver is passed or expired (due to vehicle traveling and planning is little delayed due to 1hz update rate of arbitrator), plan_delegator increments its index and moves on to the next one. However, it doesn't account for that early increment later when it adjusts its index for the related_maneuvers. 

For example, if it had if 2 contiguous LANE_FOLLOW maneuvers, but one is expired, its index increments to 1 (index 0 to 1). However, later when it adjusts for its related_maneuvers, it forgot it had 1 expired maneuver and shifts 2 indexes anyways, adding extra 1 than needed (index 1 + 2 = 3). So the index is 3 now, although 2 should have been planned.

This results in the next maneuver being ignored. This is intermittent because 1hz planning of strategic_plugin may or may not update in time for plan_delegator to not make that mistake.

And I currently only included LANE_FOLLOW as detection as I don't think other plugins use related_maneuvers, but wanted to be explicit.

Example log: 2025-07-22-11-44-34-332730-carma-1
Example mcap: rosbag2_2025-07-22_114434
in here: https://drive.google.com/drive/u/2/folders/18_9g4zMEtdCDIsmRTFPdJowpdmDA1GP-
Picture of CLC being ignored:
<img width="747" height="471" alt="image" src="https://github.com/user-attachments/assets/07ad3d48-2d6a-425a-a5d2-2c1aefb08e80" />


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-159
CDAD-152
<!-- e.g. CAR-123 -->

## Motivation and Context
Summit Point testing tempest release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO
Black Pacifica Summit point
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
