### PR TITLE
Avoid race condition when updating maneuver_plan in plan_delegator

### DIFF
--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -152,7 +152,11 @@ namespace plan_delegator
 
             /**
              * \brief Generate new PlanTrajecory service request based on current planning progress
-             * \return a PlanTrajectoryRequest which is ready to be used in the following service call
+             * \param latest_trajectory_plan The trajectory plan to append the resulting trajectory
+             * \param locked_maneuver_plan The maneuver plan to send to the tactical plugin
+             * \param current_maneuver_index The idx of the maneuver in the maneuver plan that
+                this request is for
+             * \return a PlanTrajectoryRequest to be used in the service call to the tactical plugin
              */
             std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
                 composePlanTrajectoryRequest(

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -154,7 +154,11 @@ namespace plan_delegator
              * \brief Generate new PlanTrajecory service request based on current planning progress
              * \return a PlanTrajectoryRequest which is ready to be used in the following service call
              */
-            std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request> composePlanTrajectoryRequest(const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan, const uint16_t& current_maneuver_index) const;
+            std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
+                composePlanTrajectoryRequest(
+                    const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
+                    const carma_planning_msgs::msg::Maneuver& maneuver, const uint16_t&
+                    current_maneuver_index) const;
 
             /**
              * \brief Lookup transfrom from front bumper to base link

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -157,8 +157,8 @@ namespace plan_delegator
             std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
                 composePlanTrajectoryRequest(
                     const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
-                    const carma_planning_msgs::msg::Maneuver& maneuver, const uint16_t&
-                    current_maneuver_index) const;
+                    const carma_planning_msgs::msg::Maneuver& locked_maneuver_plan,
+                    const uint16_t& current_maneuver_index) const;
 
             /**
              * \brief Lookup transfrom from front bumper to base link

--- a/plan_delegator/include/plan_delegator.hpp
+++ b/plan_delegator/include/plan_delegator.hpp
@@ -161,7 +161,7 @@ namespace plan_delegator
             std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
                 composePlanTrajectoryRequest(
                     const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
-                    const carma_planning_msgs::msg::Maneuver& locked_maneuver_plan,
+                    const carma_planning_msgs::msg::ManeuverPlan& locked_maneuver_plan,
                     const uint16_t& current_maneuver_index) const;
 
             /**

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -414,10 +414,14 @@ namespace plan_delegator
         return false;
     }
 
-    std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request> PlanDelegator::composePlanTrajectoryRequest(const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan, const uint16_t& current_maneuver_index) const
+    std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
+    PlanDelegator::composePlanTrajectoryRequest(
+        const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
+        const carma_planning_msgs::msg::Maneuver& maneuver,
+        const uint16_t& current_maneuver_index) const
     {
         auto plan_req = std::make_shared<carma_planning_msgs::srv::PlanTrajectory::Request>();
-        plan_req->maneuver_plan = latest_maneuver_plan_;
+        plan_req->maneuver_plan = maneuver;
 
         // set current vehicle state if we have NOT planned any previous trajectories
         if(latest_trajectory_plan.trajectory_points.empty())
@@ -603,6 +607,7 @@ namespace plan_delegator
         }
         // latest_maneuver_plan may get updated, so this is to avoid race condition
         const auto& locked_maneuver_plan = latest_maneuver_plan_;
+
         // Flag for the first received trajectory plan service response
         bool first_trajectory_plan = true;
 
@@ -637,7 +642,6 @@ namespace plan_delegator
                 continue;
             }
 
-
             // get corresponding ros service client for plan trajectory
             auto maneuver_planner = GET_MANEUVER_PROPERTY(maneuver, parameters.planning_tactical_plugin);
 
@@ -646,7 +650,8 @@ namespace plan_delegator
             RCLCPP_DEBUG_STREAM(rclcpp::get_logger("plan_delegator"),"Current planner: " << maneuver_planner);
 
             // compose service request
-            auto plan_req = composePlanTrajectoryRequest(latest_trajectory_plan, current_maneuver_index);
+            auto plan_req = composePlanTrajectoryRequest(
+                latest_trajectory_plan, locked_maneuver_plan, current_maneuver_index);
 
             auto future_response = client->async_send_request(plan_req);
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -417,11 +417,11 @@ namespace plan_delegator
     std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
     PlanDelegator::composePlanTrajectoryRequest(
         const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
-        const carma_planning_msgs::msg::Maneuver& maneuver,
+        const carma_planning_msgs::msg::Maneuver& locked_maneuver_plan,
         const uint16_t& current_maneuver_index) const
     {
         auto plan_req = std::make_shared<carma_planning_msgs::srv::PlanTrajectory::Request>();
-        plan_req->maneuver_plan = maneuver;
+        plan_req->maneuver_plan = locked_maneuver_plan;
 
         // set current vehicle state if we have NOT planned any previous trajectories
         if(latest_trajectory_plan.trajectory_points.empty())

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -601,7 +601,8 @@ namespace plan_delegator
             RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Guidance is not engaged. Plan delegator will not plan trajectory.");
             return latest_trajectory_plan;
         }
-
+        // latest_maneuver_plan may get updated, so this is to avoid race condition
+        const auto& locked_maneuver_plan = latest_maneuver_plan_;
         // Flag for the first received trajectory plan service response
         bool first_trajectory_plan = true;
 
@@ -609,10 +610,9 @@ namespace plan_delegator
         uint16_t current_maneuver_index = 0;
 
         // Loop through maneuver list to make service call to applicable Tactical Plugin
-        while(current_maneuver_index < latest_maneuver_plan_.maneuvers.size())
+        while(current_maneuver_index < locked_maneuver_plan.maneuvers.size())
         {
-            // const auto& maneuver = latest_maneuver_plan_.maneuvers[current_maneuver_index];
-            auto& maneuver = latest_maneuver_plan_.maneuvers[current_maneuver_index];
+            auto& maneuver = locked_maneuver_plan.maneuvers[current_maneuver_index];
 
             // ignore expired maneuvers
             if(isManeuverExpired(maneuver, get_clock()->now()))
@@ -654,7 +654,7 @@ namespace plan_delegator
 
             if (future_status != std::future_status::ready)
             {
-                RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),"Unsuccessful service call to trajectory planner:" << maneuver_planner << " for plan ID " << std::string(latest_maneuver_plan_.maneuver_plan_id));
+                RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),"Unsuccessful service call to trajectory planner:" << maneuver_planner << " for plan ID " << std::string(locked_maneuver_plan.maneuver_plan_id));
                 // if one service call fails, it should end plan immediately because it is there is no point to generate plan with empty space
                 full_plan_generation_failed = true;
                 break;
@@ -668,7 +668,7 @@ namespace plan_delegator
                 RCLCPP_WARN_STREAM(rclcpp::get_logger("plan_delegator"),
                     "Found invalid trajectory with less than 2 trajectory "
                     << "points for maneuver_plan_id: "
-                    << std::string(latest_maneuver_plan_.maneuver_plan_id));
+                    << std::string(locked_maneuver_plan.maneuver_plan_id));
                 full_plan_generation_failed = true;
                 break;
             }
@@ -694,7 +694,7 @@ namespace plan_delegator
 
             if(isTrajectoryLongEnough(latest_trajectory_plan))
             {
-                RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Plan Trajectory completed for " << std::string(latest_maneuver_plan_.maneuver_plan_id));
+                RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Plan Trajectory completed for " << std::string(locked_maneuver_plan.maneuver_plan_id));
                 break;
             }
 

--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -417,7 +417,7 @@ namespace plan_delegator
     std::shared_ptr<carma_planning_msgs::srv::PlanTrajectory::Request>
     PlanDelegator::composePlanTrajectoryRequest(
         const carma_planning_msgs::msg::TrajectoryPlan& latest_trajectory_plan,
-        const carma_planning_msgs::msg::Maneuver& locked_maneuver_plan,
+        const carma_planning_msgs::msg::ManeuverPlan& locked_maneuver_plan,
         const uint16_t& current_maneuver_index) const
     {
         auto plan_req = std::make_shared<carma_planning_msgs::srv::PlanTrajectory::Request>();

--- a/plan_delegator/test/test_plan_delegator.cpp
+++ b/plan_delegator/test/test_plan_delegator.cpp
@@ -116,7 +116,7 @@ namespace plan_delegator{
         point_2.target_time = rclcpp::Time(1.41421e9, pd->get_clock()->get_clock_type());
         traj_plan.trajectory_points.push_back(point_1);
         traj_plan.trajectory_points.push_back(point_2);
-        auto req = pd->composePlanTrajectoryRequest(traj_plan, current_maneuver_index);
+        auto req = pd->composePlanTrajectoryRequest(traj_plan, new_plan, current_maneuver_index);
         EXPECT_NEAR(1.0, req->vehicle_state.x_pos_global, 0.01);
         EXPECT_NEAR(1.0, req->vehicle_state.y_pos_global, 0.01);
         EXPECT_NEAR(1.0, req->vehicle_state.longitudinal_vel, 0.1);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Currently plan_delegator could ignore a whole maneuver intermittently. 

For context, ILC can plan over multiple maneuvers using the related_maneuvers field even if only 1 maneuver was sent to be planned. Due to this, plan_delegator accounts for it, and increments its index for what maneuver to plan next using related_maneuvers size.

The problem arises when plan_delegator just skips 1 whole maneuver. This probably happens because two different callback groups are using the same resource. And when one planTrajectory() is running, we may have the latest_maneuver_plan_ get updated, changing its index. So saving local copy should solve the issue. Example debug logs show this:
```
1753212966.228795642 | ERROR | plan_delegator | planTrajectory:600 | Starting new plan
1753212966.228823273 | ERROR | plan_delegator | planTrajectory:619 | current_maneuver_index: 0, size of total maneuver plan size now:6
1753212966.228863727 | ERROR | plan_delegator | planTrajectory:634 | current_downtrack56.9401
1753212966.228876351 | ERROR | plan_delegator | planTrajectory:636 | maneuver_end_dist50.9903
1753212966.229558607 | ERROR | plan_delegator | planTrajectory:641 | Dropping passed maneuver: 7e696935-7965-415a-b6c1-6a1bc76004e6
1753212966.229578266 | ERROR | plan_delegator | planTrajectory:619 | current_maneuver_index: 1, size of total maneuver plan size now:6
1753212966.229625750 | ERROR | plan_delegator | planTrajectory:634 | current_downtrack56.9401
1753212966.229643104 | ERROR | plan_delegator | planTrajectory:636 | maneuver_end_dist80.993
1753212966.229658910 | ERROR | plan_delegator | planTrajectory:653 | Current planner: inlanecruising_plugin
1753212966.229686920 | ERROR | plan_delegator | composePlanTrajectoryRequest:423 | inside ComposePlan plan size: 6
1753212966.269581568 | ERROR | plan_delegator | planTrajectory:693 | new latest_trajectory_plan size: 26
1753212966.269633054 | ERROR | plan_delegator | planTrajectory:619 | current_maneuver_index: 3, size of total maneuver plan size now:5
1753212966.269675400 | ERROR | plan_delegator | planTrajectory:634 | current_downtrack57.3164
1753212966.269691753 | ERROR | plan_delegator | planTrajectory:636 | maneuver_end_dist119.244
1753212966.269704307 | ERROR | plan_delegator | planTrajectory:653 | Current planner: inlanecruising_plugin
1753212966.269724626 | ERROR | plan_delegator | composePlanTrajectoryRequest:423 | inside ComposePlan plan size: 5
1753212966.276190175 | ERROR | plan_delegator | planTrajectory:686 | Removing duplicate point for planner: inlanecruising_plugin
1753212966.276222354 | ERROR | plan_delegator | planTrajectory:688 | plan_response->trajectory_plan size: 42
1753212966.276246354 | ERROR | plan_delegator | planTrajectory:693 | new latest_trajectory_plan size: 68
1753212966.276260738 | ERROR | plan_delegator | planTrajectory:704 | Plan Trajectory completed for 9d831194-8153-4e76-a957-063a54c4d0be
```
You can see that current_index was not reset to 0 meaning it was still in the `while` loop, but the plan size changed from `6` to `5`.

After making it use local variable, I made sure it was not changing the local variable as well as it shouldn't:

```
omponent_container_mt-26] 1753214482.554830978 | ERROR | plan_delegator | planTrajectory:696 | new latest_trajectory_plan size: 16
[carma_component_container_mt-26] 1753214482.554868285 | ERROR | plan_delegator | planTrajectory:622 | current_maneuver_index: 2, size of total plan:7
[carma_component_container_mt-26] 1753214482.554913033 | ERROR | plan_delegator | planTrajectory:637 | current_downtrack18.3346
[carma_component_container_mt-26] 1753214482.554925668 | ERROR | plan_delegator | planTrajectory:639 | maneuver_end_dist50.9903
[carma_component_container_mt-26] 1753214482.554936554 | ERROR | plan_delegator | planTrajectory:656 | Current planner: cooperative_lanechange
[carma_component_container_mt-26] 1753214482.554956578 | ERROR | plan_delegator | composePlanTrajectoryRequest:424 | inside ComposePlan plan size: 7
[carma_component_container_mt-26] 1753214482.573216731 | ERROR | plan_delegator | maneuverPlanCallback:206 | Received plan with 6 maneuvers
[carma_component_container_mt-26] 1753214482.576770099 | ERROR | plan_delegator | planTrajectory:689 | Removing duplicate point for planner: cooperative_lanechange
[carma_component_container_mt-26] 1753214482.576799777 | ERROR | plan_delegator | planTrajectory:691 | plan_response->trajectory_plan size: 17
[carma_component_container_mt-26] 1753214482.576816059 | ERROR | plan_delegator | planTrajectory:696 | new latest_trajectory_plan size: 33
[carma_component_container_mt-26] 1753214482.576834101 | ERROR | plan_delegator | planTrajectory:622 | current_maneuver_index: 3, size of total plan:7
[carma_component_container_mt-26] 1753214482.576879783 | ERROR | plan_delegator | planTrajectory:637 | current_downtrack18.3346
[carma_component_container_mt-26] 1753214482.576893997 | ERROR | plan_delegator | planTrajectory:639 | maneuver_end_dist80.993
[carma_component_container_mt-26] 1753214482.576944007 | ERROR | plan_delegator | planTrajectory:656 | Current planner: inlanecruising_plugin
[carma_component_container_mt-26] 1753214482.576965923 | ERROR | plan_delegator | composePlanTrajectoryRequest:424 | inside ComposePlan plan size: 7
[carma_component_container_mt-26] 1753214482.598069529 | ERROR | plan_delegator | planTrajectory:689 | Removing duplicate point for planner: inlanecruising_plugin
[carma_component_container_mt-26] 1753214482.598206411 | ERROR | plan_delegator | planTrajectory:691 | plan_response->trajectory_plan size: 31
[carma_component_container_mt-26] 1753214482.598233474 | ERROR | plan_delegator | planTrajectory:696 | new latest_trajectory_plan size: 64
[carma_component_container_mt-26] 1753214482.598249476 | ERROR | plan_delegator | planTrajectory:707 | Plan Trajectory completed for a5cdc15f-d1c1-41f7-bbca-409a8018a473
[carma_component_container_mt-26] 1753214482.631361534 | ERROR | plan_delegator | planTrajectory:601 | Starting new plan
[carma_component_container_mt-26] 1753214482.631449737 | ERROR | plan_delegator | planTrajectory:622 | current_maneuver_index: 0, size of total plan:6
[carma_component_container_mt-26] 1753214482.631537628 | ERROR | plan_delegator | planTrajectory:637 | current_downtrack18.7287
[carma_component_container_mt-26] 1753214482.631552441 | ERROR | plan_delegator | planTrajectory:639 | maneuver_end_dist35.9309
[carma_component_container_mt-26] 1753214482.631562744 | ERROR | plan_delegator | planTrajectory:656 | Current planner: inlanecruising_plugin
```

You see how the size stayed 7 even after receiving a new plan size with 6.

Picture of CLC being ignored:
<img width="747" height="471" alt="image" src="https://github.com/user-attachments/assets/07ad3d48-2d6a-425a-a5d2-2c1aefb08e80" />


<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-159
CDAD-152
<!-- e.g. CAR-123 -->

## Motivation and Context
Summit Point testing tempest release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO
Black Pacifica Summit point
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
