### PR TITLE
Workaround for inaccurate collision check 

### DIFF
--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -721,6 +721,18 @@ namespace yield_plugin
         double p2a_t = rclcpp::Time(p2a.header.stamp).seconds();
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
+        // Temporary workaround for the issue CDAD-187 and CDAD-141
+        // //magic collision time horizon hardcoded at the moment
+        // //we shouldn't extrapolate the trajectory more than 2 seconds this will give wrong results
+        // double collision_time_radius = std::fabs(p1b_t - p1a_t);
+        // if (collision_time_radius > 2.0)
+        // {
+        //   RCLCPP_DEBUG_STREAM(nh_->get_logger(),
+        //     "Skipping pair of points because the time horizon is too large: "
+        //     << collision_time_radius);
+        //   continue;
+        // }
+
         RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
         RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
         RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.x: " << p1a.x << ", p1a.y: " << p1a.y);
@@ -763,6 +775,11 @@ namespace yield_plugin
           // continue searching for collision
           continue;
         }
+
+        RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("yield_plugin"),
+          "Returning collision with extended interpolation of time: " <<
+          collision_time_radius << " seconds. This is WRONG!");
 
         GetCollisionResult collision_result;
         collision_result.point1 = lanelet::BasicPoint2d(x1,y1);

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -725,13 +725,13 @@ namespace yield_plugin
         // //magic collision time horizon hardcoded at the moment
         // //we shouldn't extrapolate the trajectory more than 2 seconds this will give wrong results
         double collision_time_radius = std::fabs(p2a_t - p1a_t);
-        // if (collision_time_radius > 2.0)
-        // {
-        //   RCLCPP_DEBUG_STREAM(nh_->get_logger(),
-        //     "Skipping pair of points because the time horizon is too large: "
-        //     << collision_time_radius);
-        //   continue;
-        // }
+        if (collision_time_radius > 2.0)
+        {
+          RCLCPP_DEBUG_STREAM(nh_->get_logger(),
+            "Skipping pair of points because the time horizon is too large: "
+            << collision_time_radius);
+          continue;
+        }
 
         RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p1a.target_time: " << std::to_string(p1a_t) << ", p1b.target_time: " << std::to_string(p1b_t));
         RCLCPP_DEBUG_STREAM(nh_->get_logger(), "p2a.target_time: " << std::to_string(p2a_t) << ", p2b.target_time: " << std::to_string(p2b_t));
@@ -780,14 +780,6 @@ namespace yield_plugin
           rclcpp::get_logger("yield_plugin"),
           "Returning collision with interpolation of time: " <<
           collision_time_radius << " seconds.");
-
-        if (collision_time_radius > 2.0)
-        {
-          RCLCPP_ERROR_STREAM(
-          rclcpp::get_logger("yield_plugin"),
-          "This interpolation is too extended: " <<
-          collision_time_radius << " seconds.");
-        }
 
         GetCollisionResult collision_result;
         collision_result.point1 = lanelet::BasicPoint2d(x1,y1);

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -722,9 +722,11 @@ namespace yield_plugin
         double p2b_t = rclcpp::Time(p2b.header.stamp).seconds();
 
         // Temporary workaround for the issue CDAD-187 and CDAD-141
-        // //magic collision time horizon hardcoded at the moment
-        // //we shouldn't extrapolate the trajectory more than 2 seconds this will give wrong results
         double collision_time_radius = std::fabs(p2a_t - p1a_t);
+        // magic collision time horizon hardcoded at the moment
+        // extrapolating more than this will result in collision location
+        // too far out in the future. such collisions should be 
+        // calculated from trajectory points close to that collision time
         if (collision_time_radius > 2.0)
         {
           RCLCPP_DEBUG_STREAM(nh_->get_logger(),
@@ -776,9 +778,9 @@ namespace yield_plugin
           continue;
         }
 
-        RCLCPP_ERROR_STREAM(
+        RCLCPP_DEBUG_STREAM(
           rclcpp::get_logger("yield_plugin"),
-          "Returning collision with interpolation of time: " <<
+          "Returning collision with extrapolation of time: " <<
           collision_time_radius << " seconds.");
 
         GetCollisionResult collision_result;

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -724,7 +724,7 @@ namespace yield_plugin
         // Temporary workaround for the issue CDAD-187 and CDAD-141
         // //magic collision time horizon hardcoded at the moment
         // //we shouldn't extrapolate the trajectory more than 2 seconds this will give wrong results
-        // double collision_time_radius = std::fabs(p1b_t - p1a_t);
+        // double collision_time_radius = std::fabs(p2a_t - p1a_t);
         // if (collision_time_radius > 2.0)
         // {
         //   RCLCPP_DEBUG_STREAM(nh_->get_logger(),
@@ -778,8 +778,16 @@ namespace yield_plugin
 
         RCLCPP_ERROR_STREAM(
           rclcpp::get_logger("yield_plugin"),
-          "Returning collision with extended interpolation of time: " <<
-          collision_time_radius << " seconds. This is WRONG!");
+          "Returning collision with interpolation of time: " <<
+          collision_time_radius << " seconds.");
+
+        if (collision_time_radius > 2.0)
+        {
+          RCLCPP_ERROR_STREAM(
+          rclcpp::get_logger("yield_plugin"),
+          "This interpolation is too extended: " <<
+          collision_time_radius << " seconds.");
+        }
 
         GetCollisionResult collision_result;
         collision_result.point1 = lanelet::BasicPoint2d(x1,y1);

--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -724,7 +724,7 @@ namespace yield_plugin
         // Temporary workaround for the issue CDAD-187 and CDAD-141
         // //magic collision time horizon hardcoded at the moment
         // //we shouldn't extrapolate the trajectory more than 2 seconds this will give wrong results
-        // double collision_time_radius = std::fabs(p2a_t - p1a_t);
+        double collision_time_radius = std::fabs(p2a_t - p1a_t);
         // if (collision_time_radius > 2.0)
         // {
         //   RCLCPP_DEBUG_STREAM(nh_->get_logger(),


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The collision check is extrapolating 2 trajectory points too long. And with naked eye, it is unclear how these two trajectories' heading is placed. But plotting these I found that the tiniest angle would result in massively deviated extrapolation as shown below:

<img width="1098" height="1205" alt="image" src="https://github.com/user-attachments/assets/e046ce7b-daec-446f-9ea4-d4335aa02cd3" />

Triangles show detected collision locations while circle show the trajectory points. The lines show a line connecting the 2 trajectory points used to extrapolate. As you can see the angle can be misplaced when trajectory is generated from the tactical plugins for unknown reason. This could also mean that excessive extrapolation can result in collisions too early as shown below:

<img width="1001" height="683" alt="image" src="https://github.com/user-attachments/assets/e5416540-6410-4953-ac26-1880314f1b29" />
Excessive extrapolation of first ILC's trajectory is colliding with the pedestrian's future movements although vehicle will not travel through those lanelets (NOTE: Large circle is showing the collision location). It can also be wrong like this with previous code (orange circle in this one, which is the same picture as the first basically):

<img width="731" height="457" alt="image" src="https://github.com/user-attachments/assets/4da4160d-db71-409e-958b-af83590fc756" />


Either way, the algorithm shouldn't be extrapolating this much to get the collision (because going straight assumption is wrong). The statistic is on the bottom of the graph, saying average 2.9s extrapolation. This is an analysis done where this much extrapolation is allowed to get a collision, so it is natural to be high on average, so I am curious to see what stat will be shown if we don't allow more than 2s extrapolation. With current data, all collisions have this type of distribution:
```
Under 2.0 seconds: 1 collision (3.3%)
Collision 14: 1.97s time gap

2.0-3.0 seconds: 22 collisions (73.3%)
Range: 2.01s to 2.85s time gaps

Over 3.0 seconds: 7 collisions (23.3%)
Range: 3.15s to 6.26s time gaps
```
New fix up/down analysis:
UPSIDE:
- Better collision locations
- Stopping from prematurely leaving the loop due to extrapolating too much (loop is exited if collision distance starts to get big indicating the 2 trajectories are growing apart. If the extrapolation can have this much of error, this logic was most likely getting triggered prematurely and missing potential collisions)

DOWNSIDE:
- Limiting it will definitely make the algorithm slower, but it is not clear by how much at the moment.
- If the collision was missed, it means either it was premature loop ending OR iteration stride. Even if premature loop is fixed, we still have iteration stride that will make it miss collision, so we may not get the benefit of MORE collisions. It is not as clear.

EDIT: Looks like the execution time is not affect as much, so that's good.

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-187
CDAD-141
<!-- e.g. CAR-123 -->

## Motivation and Context
Have seen early stopping where there shouldn't be collision, so I figured that the points' are getting extrapolated too much
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on the vehicle and now the collision shows up in correct locations consistently:

https://github.com/user-attachments/assets/87eec062-484a-4dc4-a844-5ab3581fea6e
Orange circle shows where the collision is being detected (it doesn't go away once it stops detecting just fyi)

And this is the ExecutionTime comparison so far, which seems pretty comparable considering same median and acceptable average (although I know it is not apples to apples comparison due to fix only had 1 run).
<img width="512" height="159" alt="image" src="https://github.com/user-attachments/assets/65292445-2e0e-4bd7-b91d-c701d7883d9d" />

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.