### PR TITLE
Apply leftover fix for race condition for plan_delegator

### DIFF
--- a/plan_delegator/src/plan_delegator.cpp
+++ b/plan_delegator/src/plan_delegator.cpp
@@ -605,8 +605,8 @@ namespace plan_delegator
             RCLCPP_INFO_STREAM(rclcpp::get_logger("plan_delegator"),"Guidance is not engaged. Plan delegator will not plan trajectory.");
             return latest_trajectory_plan;
         }
-        // latest_maneuver_plan may get updated, so this is to avoid race condition
-        const auto& locked_maneuver_plan = latest_maneuver_plan_;
+        // latest_maneuver_plan may get updated, so local copy to avoid race condition
+        auto locked_maneuver_plan = latest_maneuver_plan_;
 
         // Flag for the first received trajectory plan service response
         bool first_trajectory_plan = true;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Duplicate of https://github.com/usdot-fhwa-stol/carma-platform/pull/2606
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-182 CDAD-186
<!-- e.g. CAR-123 -->

## Motivation and Context
Tempest release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.