### PR TITLE
Skip negative extrapolation when checking collision - release

### DIFF
--- a/yield_plugin/src/yield_plugin.cpp
+++ b/yield_plugin/src/yield_plugin.cpp
@@ -731,6 +731,11 @@ namespace yield_plugin
 
         // Linearly interpolate positions at a common timestamp for both trajectories
         double dt = (p2a_t - p1a_t) / (p1b_t - p1a_t);
+        // if negative extrapolation, skip because car wouldn't go backwards
+        if (dt < 0)
+        {
+          continue;
+        }
         double x1 = p1a.x + dt * (p1b.x - p1a.x);
         double y1 = p1a.y + dt * (p1b.y - p1a.y);
         double x2 = p2a.predicted_position.position.x;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
NOTE: Duplicate of https://github.com/usdot-fhwa-stol/carma-platform/pull/2614
<!--- Describe your changes in detail -->
As you can see the vehicle is detecting a collision by extrapolating backwards:
<img width="654" height="481" alt="image" src="https://github.com/user-attachments/assets/c93cf290-ae62-416e-ab5a-d1b8e8f65844" />
After 2nd lanechange ILC is detecting collision due to minor heading deviation the trajectories have. This angled trajectory is not along the 2nd lane, but can point toward the collision area where it detects a collision because it is projecting backwardsin time, which it shouldn't do.
We started seeing this after we significantly reduced the lanelet sizes and perhaps the angle started lining up with the collision area. Saw it 1 time out of 3 runs. 

NOTE:
This also has a weird result of vanishing the current trajectory, but keep future trajectory in tact. To illustrate, after above instance, next few iterations were like this:
<img width="655" height="483" alt="image" src="https://github.com/user-attachments/assets/657a1836-b60c-4bc8-a867-e421f7857ed0" />
Orange circle is the collision point
This is because yield_plugin has a logic to commit to stopping if collision was detected within the near few seconds (to continue yielding as a safety even if objects sometimes vanish due to camera's poor performance). However, this time, ILC was called 2 times. So whenever it is called the next iteration, it keeps returning 2nd segment's yielding trajectory to 1st segment. Therefore, missing 2 tactical plugins' plans (1st ILC + 2nd CLC)

This issue shouldn't be fixed (such as accounting for multiple calls to yield plugin) as it will go away with this omission of negative extrapolation AND when yield_plugin is called by plan_delegator in the future, it should be called only once so cache of 1 last successful trajectory should be sufficient.

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-187
<!-- e.g. CAR-123 -->

## Motivation and Context
Reducing map after Tempest Verification testing to fit to ITSWC zone.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
