### PR TITLE
Increase plan_delegator tolerance to overcome basic_autonomy issue

### DIFF
--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -37,4 +37,4 @@ duration_to_signal_before_lane_change: 2.5
 # Int: The maximum number of times plan_delegator attempts to generate a trajectory before giving up
 # When trajectory generations fails, it reuses the last successful trajectory until tries again
 # in the next iteration.
-max_traj_generation_reattempt: 10
+max_traj_generation_reattempt: 50

--- a/plan_delegator/config/plan_delegator_params.yaml
+++ b/plan_delegator/config/plan_delegator_params.yaml
@@ -37,4 +37,6 @@ duration_to_signal_before_lane_change: 2.5
 # Int: The maximum number of times plan_delegator attempts to generate a trajectory before giving up
 # When trajectory generations fails, it reuses the last successful trajectory until tries again
 # in the next iteration.
+# TODO: This essentially means allowing 5s outdated (but successful) trajectory.
+# Until this issue is resolved, such high tolerance is needed (https://usdot-carma.atlassian.net/browse/CDAD-191)
 max_traj_generation_reattempt: 50


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Perhaps due to smaller map, or due to some other issue that was coincidentally avoided before, plan_delegator is failing by hitting the limit of number of times not being able to generate full trajectory from all requested plugins.

It is able to generated it at least once before, but fails while running through it (most likely while transitioning through lanelet boundary, which could be caused by inconsistent downtrack usage of plugins, and that is a different discussion/investigation). Therefore, for the demo, until the root cause is fixed, increasing the parameter value to increase the tolerance.

The error I am getting is the ""Current state is at or past the planned end distance. Couldn't generate trajectory"
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAD-191
<!-- e.g. CAR-123 -->

## Motivation and Context
ITSWC Demo Prep
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
