### PR TITLE
Fix checkout script to use correct branch for carma-message-filters

### DIFF
--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -51,7 +51,7 @@ git clone --depth=1 https://github.com/usdot-fhwa-stol/multiple_object_tracking 
 if [[ "$BRANCH" == "master" ]]; then
   git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch carma-master
 else
-  git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters-test.git --branch "$BRANCH"
+  git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch "$BRANCH"
 fi
 
 # TODO: Remove V2X-Hub Depedency (CAR-6029)

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -46,7 +46,6 @@ cd "${dir}"/src
 git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch "${BRANCH}"
 git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch "${BRANCH}"
 git clone --depth=1 https://github.com/usdot-fhwa-stol/v2x-ros-conversion.git --branch "${BRANCH}"
-git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch "${BRANCH}"
 git clone --depth=1 https://github.com/usdot-fhwa-stol/multiple_object_tracking --branch "${BRANCH}"
 if [[ "$BRANCH" == "master" ]]; then
   git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch carma-master

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -48,6 +48,11 @@ git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-utils.git --branch 
 git clone --depth=1 https://github.com/usdot-fhwa-stol/v2x-ros-conversion.git --branch "${BRANCH}"
 git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch "${BRANCH}"
 git clone --depth=1 https://github.com/usdot-fhwa-stol/multiple_object_tracking --branch "${BRANCH}"
+if [[ "$BRANCH" == "master" ]]; then
+  git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters.git --branch carma-master
+else
+  git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-message-filters-test.git --branch "$BRANCH"
+fi
 
 # TODO: Remove V2X-Hub Depedency (CAR-6029)
 git clone -b master --depth 1 https://github.com/etherealjoy/qhttpengine.git


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR is to update checkout script to use carma-master branch for carma-message-filters when BRANCH=master
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
