### PR TITLE
Fix LCI not able to generate trajectory when close to the intersection

### DIFF
--- a/lci_strategic_plugin/src/lci_strategic_plugin.cpp
+++ b/lci_strategic_plugin/src/lci_strategic_plugin.cpp
@@ -707,6 +707,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
   // Pick UPPER or LOWER trajectory based on light
   bool is_return_params_found = false;
 
+  // Check UPPER
   if (calculation_success_upper)
   {
     RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Checking this time!: " << current_time + modified_remaining_time_upper);
@@ -730,6 +731,7 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
   }
 
+  // Check LOWER
   if (!is_return_params_found)
   {
     auto lower_optional = traffic_light->predictState(lanelet::time::timeFromSec(current_time + modified_remaining_time_lower));
@@ -749,21 +751,31 @@ TrajectoryParams LCIStrategicPlugin::handleFailureCaseHelper(const lanelet::Carm
     }
   }
 
-  // Handle hard failure case such as nan or invalid states
-  if (is_return_params_found && !isnan(return_params.modified_departure_speed) && return_params.modified_departure_speed > epsilon_ &&
-      return_params.modified_departure_speed < speed_limit ) //80_mph
-  {
-    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Updated the speed, and using modified_departure_speed: " << return_params.modified_departure_speed);
-    print_params(return_params);
-    return return_params;
-  }
-  else
+  // Handle hard failure case such as nan or invalid states)
+  if (!is_return_params_found || isnan(return_params.modified_departure_speed))
   {
     RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Unable to handle edge case gracefully");
     return_params = TrajectoryParams(); //reset
     return_params.is_algorithm_successful = false;
     return return_params;
   }
+
+  // if NOT hard failure case, double check the speed and return
+  if (return_params.modified_departure_speed < 0)
+  {
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected negative modified_departure_speed, setting to zero");
+    return_params.modified_departure_speed = 0.0;
+  }
+  else if (return_params.modified_departure_speed > speed_limit)
+  {
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Detected modified_departure_speed greater than speed limit, setting to speed limit");
+    return_params.modified_departure_speed = speed_limit;
+  }
+
+  RCLCPP_DEBUG_STREAM(rclcpp::get_logger("lci_strategic_plugin"), "Updated the speed, and using modified_departure_speed: " << return_params.modified_departure_speed);
+  print_params(return_params);
+  return return_params;
+
 }
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
LCI is not able to make "pass through green" trajectory because its condition and certain math logic is creating a departure speed higher than speed limit. Relevant log section:

```
1759262720.5723195 [carma_component_container_mt-35] 1759262720.515405250 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:957 | SPEED PROFILE CASE:8
1759262720.5724540 [carma_component_container_mt-35] 1759262720.515420194 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:961 | emergency_distance_to_stop at emergency_decel_norm_ (with stopping_location_buffer/2):  8.21427, emergency_decel_norm_: 4
1759262720.5725660 [carma_component_container_mt-35] 1759262720.515433395 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:964 | safe_distance_to_stop at max_comfort_decel (with stopping_location_buffer/2):  12.9285, max_comfort_decel_norm_: 2
1759262720.5727532 [carma_component_container_mt-35] 1759262720.515442822 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:967 | desired_distance_to_stop at: 28.4694, where effective deceleration rate is: 1.4
1759262720.5729401 [carma_component_container_mt-35] 1759262720.515453177 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:973 | new emergency_distance_to_stop: 8.21427
1759262720.5731449 [carma_component_container_mt-35] 1759262720.515462241 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:974 | new safe_distance_to_stop: 12.9285
1759262720.5756226 [carma_component_container_mt-35] 1759262720.515472201 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:975 | new desired_distance_to_stop: 28.4694
1759262720.5762866 [carma_component_container_mt-35] 1759262720.515482634 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:977 | distance_remaining_to_traffic_light:  8.26009, current_state.speed: 6.14119
1759262720.5765283 [carma_component_container_mt-35] 1759262720.515492668 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:1032 | Not able to make it with certainty: NEW TSCase: 8
1759262720.5783617 [carma_component_container_mt-35] 1759262720.515501893 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:1057 | No longer within safe distance to stop! Decide to continue stopping or continue into intersection
1759262720.5814512 [carma_component_container_mt-35] 1759262720.515510532 | DEBUG | lci_strategic_plugin | planWhenAPPROACHING:1062 | HANDLE_LAST_RESORT: The vehicle is not able to stop at red/yellow light nor is able to reach target speed at green. Attempting its best to pass through at green!
1759262720.5871677 [carma_component_container_mt-35] 1759262720.547675947 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:557 | HANDLE_LAST_RESORT_CASE: Starting...
1759262720.5873964 [carma_component_container_mt-35] 1759262720.547735197 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:577 | HandleFailureCase -> Upper Trajectory -> Current Speed <= Desired Departure Speed, Actual Departure Speed < Desired Departure Speed
1759262720.5875223 [carma_component_container_mt-35] 1759262720.547760309 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:712 | Checking this time!: 1.75926e+09
1759262720.5876212 [carma_component_container_mt-35] 1759262720.547778551 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:716 | Checking this time! state: CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED
1759262720.5913427 [carma_component_container_mt-35] 1759262720.547791941 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:726 | Detected Upper GREEN case
1759262720.5920217 [carma_component_container_mt-35] 1759262720.547805086 | DEBUG | lci_strategic_plugin | handleFailureCaseHelper:762 | Unable to handle edge case gracefully
1759262720.5923085 [carma_component_container_mt-35] 1759262720.547816311 | DEBUG | lci_strategic_plugin | handleFailureCase:442 | Failed to generate maneuver for edge cases...
1759262720.5925066 [carma_component_container_mt-35] 1759262720.547829941 | WARN | lci_strategic_plugin | planWhenAPPROACHING:1069 | HANDLE_SAFETY: Planning forced slow-down... last case:7
```

As you can see this section corresponds to the `handleFailureCaseHelper` function. And plugging in the values result in 8.411 m/s `modified_departure_speed` where the `speed_limit` is 6.706 m/s. I am not too familiar with the math here as Saeid is the one who wrote it several years ago. However, it seems too strict to discard the results just because it is over the speed limit. When it discards at this stage, the plugin commands to forced slowdown, which is wrong when it had plenty time to make it to through the green (the whole math breaks down near the intersection as the distance to intersection becomes small, which is why it creates this kind of edge cases).

This PR modifies the code to allow the departure speed to be passed and just be limited from 0 to speed_limit. This seems appropriate as the situation occurred when there was plenty time left in the green to make it through. 
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
VIP Demo prep to make it through the green light at east intersection. Somehow vehicle commands to stop before going again despite having plenty room to make it through.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TODO: The issue itself is intermittent in nature. However, we could test it by running repeatedly and seeing the if the new logs generate. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
