### PR TITLE
Adjust speed advisory unit conversion

### DIFF
--- a/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
+++ b/traffic_incident_parser/src/traffic_incident_parser_worker.cpp
@@ -479,7 +479,7 @@ namespace traffic_incident_parser
             boost::uuids::uuid speed_id = boost::uuids::random_generator()();
             std::copy(speed_id.begin(), speed_id.end(), traffic_mobility_msg.id.id.begin());
             traffic_mobility_msg.params.detail.choice=carma_v2x_msgs::msg::TrafficControlDetail::MAXSPEED_CHOICE;
-            traffic_mobility_msg.params.detail.maxspeed=speed_advisory;
+            traffic_mobility_msg.params.detail.maxspeed=speed_advisory * 0.44704; // convert mph to m/s since world model expects m/s
             output_msg.push_back(traffic_mobility_msg);
 
         }


### PR DESCRIPTION
# PR Details
## Description
Convert speed advisory from mph to m/s for world model compatibility.
ERV sends the speed advisory in mobility_operation as mph, but carma-platform expected mps. Since it is correct to expect mps in TrafficControlMessage (geofence), the conversion needs to happen in the traffic_incident_parser node. 

<!--- Describe your changes in detail -->
You can see the 5mph (in the mobility_operation msg) is being interpreted as 5 m/s as the commanded speed on the other window:

<img width="1158" height="870" alt="image" src="https://github.com/user-attachments/assets/520548fe-408b-4702-8e54-10a0d797a1b8" />

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
This has been an open issue for a long time. 
Discovered again during Town10 cdasim verification
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested during cdasim verification testing.
TODO: However, need to test it with the actual ERV (Tahoe) on the field again to make sure that operation is not broken
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
